### PR TITLE
#481 [menu] fix: redirect recurring invoice menu to correct page

### DIFF
--- a/core/modules/modReedCRM.class.php
+++ b/core/modules/modReedCRM.class.php
@@ -568,7 +568,7 @@ class modReedCRM extends DolibarrModules
             'prefix'   => '<i class="fas fa-file-invoice-dollar pictofixedwidth"></i>',
             'mainmenu' => 'reedcrm',
             'leftmenu' => 'recurringinvoices',
-            'url'      => '/compta/facture/list.php?search_status=4',
+            'url'      => '/compta/facture/invoicetemplate_list.php',
             'langs'    => 'reedcrm@reedcrm',
             'position' => 1000 + $r,
             'enabled'  => 'isModEnabled(\'reedcrm\')',


### PR DESCRIPTION
## Summary

- Correction de l'entrée menu **Factures récurrentes** dans le module ReedCRM
- L'URL pointait vers `/compta/facture/list.php?search_status=4` (liste des factures normales filtrées), elle pointe désormais vers `/compta/facture/invoicetemplate_list.php` (page dédiée aux factures récurrentes/templates)

## Type of change

- [x] Bug fix

## Related issues

Closes #481