### PR TITLE
#614 [Menu] fix: search_status filter not working for opened propals

### DIFF
--- a/core/modules/modReedCRM.class.php
+++ b/core/modules/modReedCRM.class.php
@@ -552,7 +552,7 @@ class modReedCRM extends DolibarrModules
             'prefix'   => '<i class="fas fa-file-signature pictofixedwidth"></i>',
             'mainmenu' => 'reedcrm',
             'leftmenu' => 'openedpropals',
-            'url'      => '/saturne/view/saturne_list.php?object_type=propal&search_status=1',
+            'url'      => '/saturne/view/saturne_list.php?object_type=propal&search_fk_statut[]=0&search_fk_statut[]=1',
             'langs'    => 'reedcrm@reedcrm',
             'position' => 1000 + $r,
             'enabled'  => 'isModEnabled(\'reedcrm\')',


### PR DESCRIPTION
## Summary

- Corrige le filtre du menu "Propals ouvertes" qui ne filtrait rien car `search_status` ne correspond pas au nom de champ `fk_statut` de la classe Propal
- Utilise `search_fk_statut[]=0&search_fk_statut[]=1` (syntaxe tableau) compatible avec le `searchmulti => 1` défini dans le hook `saturneListAddCustomFields`

## Test plan

- [x] Désactiver/réactiver le module ReedCRM
- [x] Cliquer sur le menu "Propals ouvertes"
- [x] Vérifier que seules les propals brouillon (0) et validées (1) sont affichées
- [x] Vérifier que le multiselect statut est bien pré-rempli avec ces valeurs