### PR TITLE
#619 [PWA] fix: bound opportunity ranges between 50-80 and 80+

### DIFF
--- a/core/tpl/frontend/reedcrm_pwa_home_graphs.tpl.php
+++ b/core/tpl/frontend/reedcrm_pwa_home_graphs.tpl.php
@@ -58,9 +58,11 @@ if (is_array($projects) && !empty($projects)) {
         $amount      = (float) $project->opp_amount;
         $probability = (float) $project->opp_percent;
 
-        $days[$dayKey]['count']++;
         $days[$dayKey]['amount']          += $amount;
         $days[$dayKey]['weighted_amount'] += $amount * ($probability / 100.0);
+        if ($probability <= 50) {
+            $days[$dayKey]['count']++;
+        }
         if ($probability > 50 && $probability <= 80) {
             $days[$dayKey]['count_50']++;
         }
@@ -125,7 +127,7 @@ foreach ($days as $dateKey => $day) {
 
     $baseOpp    = $urlBase . '?search_usage_opportunity=1' . $dateFilter;
 
-    $jsUrls[]          = $baseOpp;
+    $jsUrls[]          = $baseOpp . '&search_opp_percent=' . urlencode('<=50');
     $jsUrlsWeighted[]  = $baseOpp . '&search_opp_percent=>0&search_opp_amount=>0';
     $jsUrls50[]        = $baseOpp . '&search_opp_percent=' . urlencode('>50 <=80');
     $jsUrls80[]        = $baseOpp . '&search_opp_percent=' . urlencode('>80');

--- a/core/tpl/frontend/reedcrm_pwa_home_graphs.tpl.php
+++ b/core/tpl/frontend/reedcrm_pwa_home_graphs.tpl.php
@@ -61,7 +61,7 @@ if (is_array($projects) && !empty($projects)) {
         $days[$dayKey]['count']++;
         $days[$dayKey]['amount']          += $amount;
         $days[$dayKey]['weighted_amount'] += $amount * ($probability / 100.0);
-        if ($probability > 50) {
+        if ($probability > 50 && $probability <= 80) {
             $days[$dayKey]['count_50']++;
         }
         if ($probability > 80) {
@@ -127,8 +127,8 @@ foreach ($days as $dateKey => $day) {
 
     $jsUrls[]          = $baseOpp;
     $jsUrlsWeighted[]  = $baseOpp . '&search_opp_percent=>0&search_opp_amount=>0';
-    $jsUrls50[]        = $baseOpp . '&search_opp_percent=>50';
-    $jsUrls80[]        = $baseOpp . '&search_opp_percent=>80';
+    $jsUrls50[]        = $baseOpp . '&search_opp_percent=' . urlencode('>50 <=80');
+    $jsUrls80[]        = $baseOpp . '&search_opp_percent=' . urlencode('>80');
 }
 
 $prevOffset = $weekOffset - 1;


### PR DESCRIPTION
## Changements
- `count_50` ne compte plus que les opportunités avec probabilité **>50 et <=80** (incluait auparavant les >80)
- `count_80` reste **>80** uniquement
- URLs mises à jour avec la syntaxe de filtre numérique Dolibarr : `>50 <=80` et `>80`

## Fichiers modifiés
- `core/tpl/frontend/reedcrm_pwa_home_graphs.tpl.php`

## Issue
#619
