### PR TITLE
#629 [PWA] feat: add categories selector and remove gravityform field in quickcreation

### DIFF
--- a/core/tpl/frontend/reedcrm_project_quickcreation_frontend.tpl.php
+++ b/core/tpl/frontend/reedcrm_project_quickcreation_frontend.tpl.php
@@ -111,7 +111,7 @@ require_once __DIR__ . '/../../../../saturne/core/tpl/medias/media_editor_modal.
             $extraFields->attributes['projet']['type'] = $sortedType; 
 
             foreach ($extraFields->attributes['projet']['type'] as $key => $value) {
-                if (strpos($key, 'reedcrm') === false && $key != 'projectphone') {
+                if ((strpos($key, 'reedcrm') === false && $key != 'projectphone') || $key == 'reedcrm_gravityform') {
                     continue;
                 }
 
@@ -180,6 +180,13 @@ require_once __DIR__ . '/../../../../saturne/core/tpl/medias/media_editor_modal.
         <?php endif; ?>
 
         <!-- Visual Section Divider Removed & Relocated Below -->
+
+        <!-- Tags / Categories -->
+        <?php if (isModEnabled('categorie')) : ?>
+            <div class="form-group" style="margin-top: 8px;">
+                <?php print $form->selectCategories(Categorie::TYPE_PROJECT, 'categories'); ?>
+            </div>
+        <?php endif; ?>
 
         <!-- Media & Submit Block -->
         <div class="action-buttons-row" style="margin-top: 15px; margin-bottom: 15px;">

--- a/core/tpl/frontend/reedcrm_quickcreation_actions_frontend.tpl.php
+++ b/core/tpl/frontend/reedcrm_quickcreation_actions_frontend.tpl.php
@@ -490,15 +490,15 @@ if ($action == 'add') {
     }
     
     if ($projectID > 0) {
-//        // Category association
-//        $categories = GETPOST('categories_project', 'array');
-//        if (count($categories) > 0) {
-//            $result = $project->setCategories($categories);
-//            if ($result < 0) {
-//                setEventMessages($project->error, $project->errors, 'errors');
-//                $error++;
-//            }
-//        }
+        // Category association
+        $categories = GETPOST('categories', 'array:int');
+        if (!empty($categories)) {
+            $result = $project->setCategories($categories);
+            if ($result < 0) {
+                setEventMessages($project->error, $project->errors, 'errors');
+                $error++;
+            }
+        }
 
         $pathToProjectDir = $conf->project->multidir_output[$conf->entity] . '/' . $project->ref;
         if (!dol_is_dir($pathToProjectDir)) {


### PR DESCRIPTION
## Changements
- Ajout du selecteur de categories dans le formulaire PWA via selectCategories() (multi-select natif Dolibarr avec select2)
- Suppression du champ reedcrm_gravityform du formulaire quickcreation (non pertinent PWA)
- Activation de setCategories() lors de la creation opportunite

## Fichiers modifies
- core/tpl/frontend/reedcrm_project_quickcreation_frontend.tpl.php
- core/tpl/frontend/reedcrm_quickcreation_actions_frontend.tpl.php

## Issue
#629