### PR TITLE
#663 [PWA] style: homogénéisation de l'interface du formulaire (slider, montant, catégories)

### DIFF
--- a/core/tpl/frontend/reedcrm_project_quickcreation_frontend.tpl.php
+++ b/core/tpl/frontend/reedcrm_project_quickcreation_frontend.tpl.php
@@ -129,6 +129,43 @@ require_once __DIR__ . '/../../../../saturne/core/tpl/medias/media_editor_modal.
     .geoloc-address-link:hover {
         background: #e2e8f0 !important;
     }
+    /* Style custom pour Categories */
+    .category-wrapper .select2-container {
+        width: 100% !important;
+    }
+    .category-wrapper .select2-container--default .select2-selection--multiple,
+    .category-wrapper .select2-container--default .select2-selection--single {
+        border: none !important;
+        background: transparent !important;
+        padding: 0 !important;
+        box-shadow: none !important;
+    }
+    .category-wrapper .select2-container--default.select2-container--focus .select2-selection--multiple {
+        border: none !important;
+    }
+    .category-wrapper table, 
+    .category-wrapper tr, 
+    .category-wrapper td {
+        border: none !important;
+        background: transparent !important;
+        padding: 0 !important;
+        display: block;
+        width: 100%;
+    }
+    .category-wrapper tbody {
+        display: flex;
+        align-items: center;
+        width: 100%;
+    }
+    .category-wrapper td:last-child {
+        width: auto !important;
+        margin-left: auto;
+        display: flex;
+        align-items: center;
+    }
+    .category-wrapper .buttonAction {
+        margin-left: auto;
+    }
 </style>
 
 <div id="id-container" class="page-content">
@@ -245,9 +282,9 @@ require_once __DIR__ . '/../../../../saturne/core/tpl/medias/media_editor_modal.
 
                 <!-- Opportunity option -->
         <?php if (!empty($conf->global->PROJECT_USE_OPPORTUNITIES)) : ?>
-            <div class="opp-row" style="display: flex; gap: 15px; align-items: center; margin-top: 0; margin-bottom: 0;">
-                <!-- 70% -->
-                <div class="form-group" style="flex: 7; margin-bottom: 0;">
+            <div class="opp-row" style="display: flex; flex-direction: column; gap: 15px; margin-top: 0; margin-bottom: 0;">
+                <!-- 100% Slider -->
+                <div class="form-group" style="width: 100%; margin-bottom: 0;">
                     <div class="opp-percent" style="display: flex; align-items: center;">
                         <span style="font-size: 22px; margin-right: 8px;">🥵</span>
                         <div style="position: relative; flex: 1; display: flex; align-items: center; --val: <?php echo empty($project->opp_percent) ? '0' : $project->opp_percent; ?>;">
@@ -258,15 +295,15 @@ require_once __DIR__ . '/../../../../saturne/core/tpl/medias/media_editor_modal.
                     </div>
                 </div>
 
-                <!-- 30% -->
-                <div class="form-group" style="flex: 3; margin-bottom: 0;">
-                    <?php if ($conf->global->REEDCRM_PROJECT_OPPORTUNITY_AMOUNT_VISIBLE > 0) : ?>
-                        <div class="input-with-icon" style="margin-top: 0; line-height: 1;">
-                            <span class="input-icon">€</span>
-                            <input type="text" inputmode="decimal" name="opp_amount" id="opp_amount" placeholder="Montant" value="<?php echo dol_escape_htmltag((GETPOSTISSET('opp_amount') ? GETPOST('opp_amount', 'int') : '')); ?>" style="width: 100%;">
-                        </div>
-                    <?php endif; ?>
+                <!-- 100% Amount -->
+                <?php if ($conf->global->REEDCRM_PROJECT_OPPORTUNITY_AMOUNT_VISIBLE > 0) : ?>
+                <div class="form-group" style="width: 100%; margin-bottom: 0;">
+                    <div class="input-with-icon" style="margin-top: 0; line-height: 1;">
+                        <span class="input-icon">€</span>
+                        <input type="text" inputmode="decimal" name="opp_amount" id="opp_amount" placeholder="Montant" value="<?php echo dol_escape_htmltag((GETPOSTISSET('opp_amount') ? GETPOST('opp_amount', 'int') : '')); ?>" style="width: 100%;">
+                    </div>
                 </div>
+                <?php endif; ?>
             </div>
         <?php endif; ?>
 
@@ -274,8 +311,13 @@ require_once __DIR__ . '/../../../../saturne/core/tpl/medias/media_editor_modal.
 
         <!-- Tags / Categories -->
         <?php if (isModEnabled('categorie')) : ?>
-            <div class="form-group" style="margin-top: 8px;">
-                <?php print $form->selectCategories(Categorie::TYPE_PROJECT, 'categories'); ?>
+            <div class="form-group" style="margin-top: 15px;">
+                <div class="category-wrapper" style="border: 1px solid #cbd5e1; border-radius: 4px; background: #fff; padding: 4px 8px; display: flex; align-items: center; min-height: 38px; box-sizing: border-box;">
+                    <i class="fas fa-tags" style="color: #0f172a; margin-right: 8px;"></i>
+                    <div style="flex: 1; min-width: 0;" class="category-select-container">
+                        <?php print $form->selectCategories(Categorie::TYPE_PROJECT, 'categories'); ?>
+                    </div>
+                </div>
             </div>
         <?php endif; ?>
 

--- a/core/tpl/frontend/reedcrm_project_quickcreation_frontend.tpl.php
+++ b/core/tpl/frontend/reedcrm_project_quickcreation_frontend.tpl.php
@@ -143,28 +143,47 @@ require_once __DIR__ . '/../../../../saturne/core/tpl/medias/media_editor_modal.
     .category-wrapper .select2-container--default.select2-container--focus .select2-selection--multiple {
         border: none !important;
     }
-    .category-wrapper table, 
-    .category-wrapper tr, 
-    .category-wrapper td {
+    .category-select-container table {
+        width: 100%;
+        margin: 0;
+        padding: 0;
+        border: none !important;
+        background: transparent !important;
+    }
+    .category-select-container table tr,
+    .category-select-container table td {
         border: none !important;
         background: transparent !important;
         padding: 0 !important;
-        display: block;
+    }
+    .category-select-container table td:first-child {
         width: 100%;
     }
-    .category-wrapper tbody {
-        display: flex;
-        align-items: center;
-        width: 100%;
+    .category-select-container table td:last-child {
+        width: auto;
+        padding-left: 8px !important;
     }
-    .category-wrapper td:last-child {
-        width: auto !important;
+    .category-select-container > .select2-container,
+    .category-select-container > select {
+        flex: 1;
+        min-width: 0;
+    }
+    .category-select-container .buttonAction,
+    .category-select-container a.button-add {
         margin-left: auto;
         display: flex;
         align-items: center;
+        justify-content: center;
     }
-    .category-wrapper .buttonAction {
-        margin-left: auto;
+    .category-wrapper i.fa-tags {
+        color: #0f172a;
+        margin-right: 8px;
+    }
+    /* S'assurer que le flex marche si pas de tableau */
+    .category-select-container {
+        display: flex;
+        align-items: center;
+        width: 100%;
     }
 </style>
 
@@ -313,7 +332,6 @@ require_once __DIR__ . '/../../../../saturne/core/tpl/medias/media_editor_modal.
         <?php if (isModEnabled('categorie')) : ?>
             <div class="form-group" style="margin-top: 15px;">
                 <div class="category-wrapper" style="border: 1px solid #cbd5e1; border-radius: 4px; background: #fff; padding: 4px 8px; display: flex; align-items: center; min-height: 38px; box-sizing: border-box;">
-                    <i class="fas fa-tags" style="color: #0f172a; margin-right: 8px;"></i>
                     <div style="flex: 1; min-width: 0;" class="category-select-container">
                         <?php print $form->selectCategories(Categorie::TYPE_PROJECT, 'categories'); ?>
                     </div>

--- a/core/tpl/frontend/reedcrm_project_quickcreation_frontend.tpl.php
+++ b/core/tpl/frontend/reedcrm_project_quickcreation_frontend.tpl.php
@@ -130,60 +130,55 @@ require_once __DIR__ . '/../../../../saturne/core/tpl/medias/media_editor_modal.
         background: #e2e8f0 !important;
     }
     /* Style custom pour Categories */
-    .category-wrapper .select2-container {
+    .category-wrapper {
+        border: 1px solid #cbd5e1;
+        border-radius: 4px;
+        background: #fff;
+        padding: 4px 8px;
+        display: flex;
+        align-items: center;
+        min-height: 38px;
+        box-sizing: border-box;
+    }
+    .category-select-container {
+        display: flex;
+        align-items: center;
+        width: 100%;
+        gap: 8px;
+    }
+    .category-select-container > span.fa-tag {
+        color: #0f172a;
+        font-size: 16px;
+    }
+    .category-select-container > span.multiselectarraycategories {
+        flex: 1;
+        min-width: 0;
+        display: block;
+    }
+    .category-select-container .select2-container {
         width: 100% !important;
     }
-    .category-wrapper .select2-container--default .select2-selection--multiple,
-    .category-wrapper .select2-container--default .select2-selection--single {
+    .category-select-container .select2-container--default .select2-selection--multiple,
+    .category-select-container .select2-container--default .select2-selection--single {
         border: none !important;
         background: transparent !important;
         padding: 0 !important;
         box-shadow: none !important;
     }
-    .category-wrapper .select2-container--default.select2-container--focus .select2-selection--multiple {
+    .category-select-container .select2-container--default.select2-container--focus .select2-selection--multiple {
         border: none !important;
     }
-    .category-select-container table {
-        width: 100%;
-        margin: 0;
-        padding: 0;
-        border: none !important;
-        background: transparent !important;
-    }
-    .category-select-container table tr,
-    .category-select-container table td {
-        border: none !important;
-        background: transparent !important;
-        padding: 0 !important;
-    }
-    .category-select-container table td:first-child {
-        width: 100%;
-    }
-    .category-select-container table td:last-child {
-        width: auto;
-        padding-left: 8px !important;
-    }
-    .category-select-container > .select2-container,
-    .category-select-container > select {
-        flex: 1;
-        min-width: 0;
-    }
-    .category-select-container .buttonAction,
-    .category-select-container a.button-add {
+    .category-select-container > a {
         margin-left: auto;
+        flex-shrink: 0;
         display: flex;
         align-items: center;
         justify-content: center;
+        text-decoration: none;
     }
-    .category-wrapper i.fa-tags {
+    .category-select-container > a span.fa-plus-circle {
+        font-size: 18px;
         color: #0f172a;
-        margin-right: 8px;
-    }
-    /* S'assurer que le flex marche si pas de tableau */
-    .category-select-container {
-        display: flex;
-        align-items: center;
-        width: 100%;
     }
 </style>
 
@@ -331,7 +326,7 @@ require_once __DIR__ . '/../../../../saturne/core/tpl/medias/media_editor_modal.
         <!-- Tags / Categories -->
         <?php if (isModEnabled('categorie')) : ?>
             <div class="form-group" style="margin-top: 15px;">
-                <div class="category-wrapper" style="border: 1px solid #cbd5e1; border-radius: 4px; background: #fff; padding: 4px 8px; display: flex; align-items: center; min-height: 38px; box-sizing: border-box;">
+                <div class="category-wrapper">
                     <div style="flex: 1; min-width: 0;" class="category-select-container">
                         <?php print $form->selectCategories(Categorie::TYPE_PROJECT, 'categories'); ?>
                     </div>


### PR DESCRIPTION
Harmonisation de l'interface de création rapide PWA selon le design souhaité : le slider d'opportunité et le champ montant sont désormais en pleine largeur sur des lignes séparées. Le champ Catégories a été intégré dans un bloc stylisé (bordures, fond blanc) cohérent avec le reste du formulaire.

<img width="987" height="479" alt="image" src="https://github.com/user-attachments/assets/272d78ef-d376-4185-bc94-6fba150e8e70" />
