### PR TITLE
fix(#676): exclure le PROJECTLEADER interne des chips contact dans le PWA

### DIFF
--- a/core/tpl/frontend/reedcrm_opportunities_list_frontend.tpl.php
+++ b/core/tpl/frontend/reedcrm_opportunities_list_frontend.tpl.php
@@ -197,7 +197,7 @@ require_once DOL_DOCUMENT_ROOT . '/custom/saturne/lib/medias.lib.php';
         }
         $socNomUrl = $socNomUrl ?? '';
 
-        // --- Linked contacts (all PROJECTCONTRIBUTOR/LEADER/SALESREP) ---
+        // --- Linked contacts (external only — internal PROJECTLEADER excluded from chips) ---
         $linkedContacts = [];
         $resLC = $db->query(
             "SELECT ec.rowid as link_id, ec.fk_socpeople,
@@ -208,7 +208,8 @@ require_once DOL_DOCUMENT_ROOT . '/custom/saturne/lib/medias.lib.php';
                JOIN " . MAIN_DB_PREFIX . "c_type_contact ctc ON ctc.rowid = ec.fk_c_type_contact
               WHERE ec.element_id = " . (int)$project->id . "
                 AND ctc.element = 'project'
-                AND ctc.code IN ('PROJECTLEADER','PROJECTCONTRIBUTOR','SALESREPINTERNAL')
+                AND ec.source = 'external'
+                AND ctc.code IN ('PROJECTCONTRIBUTOR','SALESREPINTERNAL')
               ORDER BY ec.rowid ASC"
         );
         if ($resLC) {


### PR DESCRIPTION
## Issue liée
Closes #676 — BUG - Affectation automatique d'un contact par défaut lors de la création d'un projet dans le PWA

## Description

Lors de la création d'un projet via le formulaire PWA, l'utilisateur connecté était automatiquement affiché comme chip contact **"Chef de Projet"** sur la carte projet, sans que l'utilisateur ait effectué cette action.

## Cause racine

Lors de la création d'un projet, Dolibarr appelle :
```php
$project->add_contact($user->id, 'PROJECTLEADER', 'internal');
```

Cette ligne ajoute l'utilisateur connecté dans `llx_element_contact` avec `source = 'internal'`.

La requête SQL de rendu des chips dans `reedcrm_opportunities_list_frontend.tpl.php` faisait une JOIN sur `llx_socpeople` **sans filtrer sur `source`**, ce qui résolvait le nom de l'utilisateur (via son enregistrement `socpeople`) et l'affichait comme un chip externe.

## Fix

Ajout du filtre `AND ec.source = 'external'` dans la requête SQL des chips, et suppression du code `PROJECTLEADER` de la clause `IN()` puisque ce rôle est strictement interne.

```sql
-- Avant
AND ctc.code IN ('PROJECTLEADER','PROJECTCONTRIBUTOR','SALESREPINTERNAL')

-- Après
AND ec.source = 'external'
AND ctc.code IN ('PROJECTCONTRIBUTOR','SALESREPINTERNAL')
```

> L'assignation automatique du `PROJECTLEADER` est conservée (suivi interne Dolibarr). Seul son affichage dans les chips PWA est supprimé : les chips sont réservés aux **contacts externes** associés via le bouton `[+]`.

## Fichier modifié
- `core/tpl/frontend/reedcrm_opportunities_list_frontend.tpl.php`
