### PR TITLE
#679 [JS] fix: geoloc header positioning and infinite spinner on quickcreation PWA

### DIFF
--- a/js/modules/quickcreation.js
+++ b/js/modules/quickcreation.js
@@ -111,13 +111,14 @@ window.reedcrm.quickcreation.getCurrentPosition = function() {
     },
     function (error) {
       var messages = {
-        1: 'User denied the request for geolocation.',
-        2: 'Location information is unavailable.',
-        3: 'The request to get user location timed out.'
+        1: 'Accès à la position refusé.',
+        2: 'Position indisponible.',
+        3: 'Délai de géolocalisation dépassé.'
       };
-      $('#id-container #geolocation-error').val(messages[error.code] || 'An unknown error occurred.');
-      window.reedcrm.quickcreation.setAddressBlockState('error', 'Accès à la position refusé.');
-    }
+      $('#id-container #geolocation-error').val(error.message || '');
+      window.reedcrm.quickcreation.setAddressBlockState('error', messages[error.code] || 'Erreur de géolocalisation.');
+    },
+    { timeout: 10000, maximumAge: 300000 }
   );
 };
 
@@ -184,13 +185,16 @@ window.reedcrm.quickcreation.setAddressBlockState = function(state, message) {
   if (state === 'success') {
     $icon.addClass('fa-map-marker-alt').css('color', '#2ecc71');
     $text.css('color', '#34495e');
+    $block.addClass('is-visible');
   } else if (state === 'error') {
     $icon.addClass('fa-map-marker-alt').css('color', '#e74c3c');
     $ko.show();
     $text.css('color', '#e74c3c');
+    $block.addClass('is-visible');
   } else {
     $icon.addClass('fa-circle-notch fa-spin').css('color', '#3498db');
     $text.css('color', '#94a3b8');
+    $block.removeClass('is-visible');
   }
 
   $text.text(message);

--- a/js/reedcrm.js
+++ b/js/reedcrm.js
@@ -1250,6 +1250,16 @@ window.saturne.quickcreation_form.init = function() {
 
 window.saturne.quickcreation_form.moveGeolocIcon = function() {
     setTimeout(function() {
+        var $pwaHeader = $('#id-top');
+        if ($pwaHeader.length) {
+            var $userWidget = $pwaHeader.find('.user-profile-widget');
+            if ($userWidget.length) {
+                $('#geoloc-header-wrapper').css('display', 'flex').insertBefore($userWidget);
+            } else {
+                $pwaHeader.append($('#geoloc-header-wrapper').css('display', 'flex'));
+            }
+            return;
+        }
         var $headerRight = $('.login_block, .header-pwa-right, .saturne-header-right').first();
         if ($headerRight.length) {
             $('#geoloc-header-wrapper').css('display', 'flex').prependTo($headerRight);


### PR DESCRIPTION
## Changements

- **Positionnement header** : moveGeolocIcon() cherchait .login_block / .header-pwa-right qui n'existent pas dans le header PWA. Le widget tombait sur le fallback position:fixed mal positionne. Fix : cibler #id-top et inserer avant .user-profile-widget via insertBefore.
- **Spinner infini** : getCurrentPosition n'avait pas de timeout, donc attendait indefiniment si la permission n'etait pas accordee. Fix : { timeout: 10000, maximumAge: 300000 }.
- **Bloc adresse jamais affiche** : setAddressBlockState ne rajoutait jamais .is-visible au #current-address-block. L'adresse restait cachee meme apres resolution. Fix : block.addClass('is-visible') sur success/error.

## Fichiers modifies

- js/reedcrm.js - correction moveGeolocIcon()
- js/modules/quickcreation.js - correction getCurrentPosition() + setAddressBlockState()

## Issue

#679