### PR TITLE
fix(#679): sync reedcrm.min.js + include missing quickcreation.js in page

### DIFF
--- a/js/modules/quickcreation.js
+++ b/js/modules/quickcreation.js
@@ -60,6 +60,10 @@ window.reedcrm.quickcreation.longitude = null;
  */
 window.reedcrm.quickcreation.init = function() {
   window.reedcrm.quickcreation.setAddressBlockState('searching', 'Détection de la position en cours...');
+  // Also boot the saturne quickcreation_form module (geoloc icon positioning, phone/email/slider)
+  if (window.saturne && window.saturne.quickcreation_form && window.saturne.quickcreation_form.init) {
+    window.saturne.quickcreation_form.init();
+  }
   window.reedcrm.quickcreation.event();
 };
 

--- a/js/modules/quickcreation.js
+++ b/js/modules/quickcreation.js
@@ -272,3 +272,11 @@ window.reedcrm.quickcreation.showOppPercentValue = function() {
   $('.opp_percent-value').text(val + '%');
   $('#opp_percent').parent().get(0).style.setProperty('--val', val);
 };
+
+// Self-boot: this module loads after $(document).ready has fired (placed after reedcrm.min.js).
+// jQuery fires the callback immediately if DOM is already ready.
+$(document).ready(function() {
+  if (document.querySelector('.quickcreation-form') || document.getElementById('geoloc-header-wrapper')) {
+    window.reedcrm.quickcreation.init();
+  }
+});

--- a/js/modules/quickcreation.js
+++ b/js/modules/quickcreation.js
@@ -59,6 +59,7 @@ window.reedcrm.quickcreation.longitude = null;
  * @returns {void}
  */
 window.reedcrm.quickcreation.init = function() {
+  window.reedcrm.quickcreation.setAddressBlockState('searching', 'Détection de la position en cours...');
   window.reedcrm.quickcreation.event();
 };
 
@@ -98,8 +99,21 @@ window.reedcrm.quickcreation.getCurrentPosition = function() {
     return;
   }
 
+  // Safety fallback: if browser silently ignores permission (no popup shown),
+  // the native timeout may never fire. Force error state after 12s.
+  var _geolocResolved = false;
+  var _safetyTimer = setTimeout(function() {
+    if (!_geolocResolved) {
+      _geolocResolved = true;
+      $('#id-container #geolocation-error').val('Timeout');
+      window.reedcrm.quickcreation.setAddressBlockState('error', 'Délai dépassé. Autorisez la localisation dans votre navigateur.');
+    }
+  }, 12000);
+
   navigator.geolocation.getCurrentPosition(
     function (position) {
+      _geolocResolved = true;
+      clearTimeout(_safetyTimer);
       window.reedcrm.quickcreation.latitude  = position.coords.latitude;
       window.reedcrm.quickcreation.longitude = position.coords.longitude;
       $('#id-container #latitude').val(window.reedcrm.quickcreation.latitude);
@@ -110,6 +124,9 @@ window.reedcrm.quickcreation.getCurrentPosition = function() {
       );
     },
     function (error) {
+      if (_geolocResolved) return; // safety timer already fired
+      _geolocResolved = true;
+      clearTimeout(_safetyTimer);
       var messages = {
         1: 'Accès à la position refusé.',
         2: 'Position indisponible.',

--- a/js/reedcrm.min.js
+++ b/js/reedcrm.min.js
@@ -1250,6 +1250,16 @@ window.saturne.quickcreation_form.init = function() {
 
 window.saturne.quickcreation_form.moveGeolocIcon = function() {
     setTimeout(function() {
+        var $pwaHeader = $('#id-top');
+        if ($pwaHeader.length) {
+            var $userWidget = $pwaHeader.find('.user-profile-widget');
+            if ($userWidget.length) {
+                $('#geoloc-header-wrapper').css('display', 'flex').insertBefore($userWidget);
+            } else {
+                $pwaHeader.append($('#geoloc-header-wrapper').css('display', 'flex'));
+            }
+            return;
+        }
         var $headerRight = $('.login_block, .header-pwa-right, .saturne-header-right').first();
         if ($headerRight.length) {
             $('#geoloc-header-wrapper').css('display', 'flex').prependTo($headerRight);

--- a/view/frontend/quickcreation.php
+++ b/view/frontend/quickcreation.php
@@ -107,8 +107,8 @@ $moreJS   = [
     '/custom/saturne/js/includes/signature-pad.min.js',
     '/custom/saturne/js/includes/hammer.min.js',
     '/custom/reedcrm/js/intl-tel-input/js/intlTelInput.min.js',
-    '/custom/reedcrm/js/modules/quickcreation.js',
-    '/custom/reedcrm/js/reedcrm.min.js'
+    '/custom/reedcrm/js/reedcrm.min.js',
+    '/custom/reedcrm/js/modules/quickcreation.js'
 ];
 $moreCSS  = ['/custom/saturne/css/saturne.min.css', '/custom/reedcrm/css/reedcrm.min.css'];
 

--- a/view/frontend/quickcreation.php
+++ b/view/frontend/quickcreation.php
@@ -107,6 +107,7 @@ $moreJS   = [
     '/custom/saturne/js/includes/signature-pad.min.js',
     '/custom/saturne/js/includes/hammer.min.js',
     '/custom/reedcrm/js/intl-tel-input/js/intlTelInput.min.js',
+    '/custom/reedcrm/js/modules/quickcreation.js',
     '/custom/reedcrm/js/reedcrm.min.js'
 ];
 $moreCSS  = ['/custom/saturne/css/saturne.min.css', '/custom/reedcrm/css/reedcrm.min.css'];


### PR DESCRIPTION
## Contexte

Suite au merge de la PR #680 (fix #679 — géoloc PWA quickcreation), plusieurs régressions ont été introduites.

## Problèmes identifiés et corrigés

### 1. `reedcrm.min.js` non synchronisé

Le fichier `js/reedcrm.js` avait été modifié (`moveGeolocIcon` pour `#id-top`) mais `reedcrm.min.js` — le fichier réellement chargé — n'avait pas été mis à jour.

**Symptôme** : l'icône géoloc disparaît du header en production.

---

### 2. `js/modules/quickcreation.js` jamais inclus dans la page

Le fix #679 modifiait `quickcreation.js` mais ce fichier n'était pas dans `moreJS` de `view/frontend/quickcreation.php`.

**Symptôme** : formulaire de création quasi-vide (pas de JS).

---

### 3. Ordre de chargement incorrect → TypeError

`quickcreation.js` avait été inséré **avant** `reedcrm.min.js`, alors qu'il dépend de `window.reedcrm` défini dans `reedcrm.min.js`.

**Symptôme** : `TypeError: Cannot set properties of undefined (setting 'quickcreation')`.

**Fix** : `quickcreation.js` placé **après** `reedcrm.min.js`.

---

### 4. `init()` jamais appelé → spinner infini

`quickcreation.js` charge **après** que `$(document).ready` ait déjà tiré (via `saturne.init`). Le module n'est donc jamais initialisé automatiquement.

**Symptôme** : spinner géoloc infini, `moveGeolocIcon()` jamais appelé, icône absente.

**Fix** : auto-démarrage en bas de `quickcreation.js` :
```javascript
$(document).ready(function() {
  if (document.querySelector('.quickcreation-form') || document.getElementById('geoloc-header-wrapper')) {
    window.reedcrm.quickcreation.init();
  }
});
```
jQuery déclenche le callback immédiatement si le DOM est déjà prêt.

---

### 5. Spinner infini si le navigateur ignore silencieusement la permission GPS

Ajout d'un timer de sécurité de 12s dans `getCurrentPosition()` : si aucun callback (success/error) ne s'est déclenché, on force l'état erreur pour éviter le spinner permanent.

## Fichiers modifiés
- `js/reedcrm.min.js` — synchronisation avec `reedcrm.js`
- `js/modules/quickcreation.js` — self-boot + safety timeout géoloc
- `view/frontend/quickcreation.php` — ajout et repositionnement de `quickcreation.js` dans `moreJS`
