### PR TITLE
feat(#682): PWA Tickets Kanban board

### DIFF
--- a/core/tpl/frontend/reedcrm_tickets_kanban.tpl.php
+++ b/core/tpl/frontend/reedcrm_tickets_kanban.tpl.php
@@ -2,18 +2,258 @@
 /**
  * \file    core/tpl/frontend/reedcrm_tickets_kanban.tpl.php
  * \ingroup reedcrm
- * \brief   Kanban board template for PWA tickets page
+ * \brief   Kanban board + Notion-like table template for PWA tickets
  *
  * Expects from parent:
- *   $ticketsByStatus  array  Tickets grouped by status code
- *   $statusMap        array  Status definitions [code => [label, color]]
- *   $severityMap      array  Severity translations
- *   $usersData        array  User objects indexed by rowid
- *   $totalTickets     int    Total ticket count
+ *   $tickets          array   All ticket objects
+ *   $ticketsByStatus  array   Tickets grouped by status code
+ *   $ticketTags       array   Tags per ticket [ticketId => [{id,label,color}]]
+ *   $statusMap        array   Status definitions [code => [label, color]]
+ *   $severityMap      array   Severity translations
+ *   $allInternalUsers array   All active internal users
+ *   $usersData        array   Users with assigned tickets
+ *   $totalTickets     int     Total ticket count
+ *   $sortfield        string  Current sort field
+ *   $sortorder        string  Current sort direction
+ *   $s_ref, $s_subject, $s_severity, $s_author, $s_assignee, $s_status, $s_tags  search params
+ *   $viewmode         string  'kanban' or 'table'
  */
+
+// --- Helper: build sort URL ---
+$baseParams = [];
+if (!empty($s_ref))      $baseParams['s_ref'] = $s_ref;
+if (!empty($s_subject))  $baseParams['s_subject'] = $s_subject;
+if (!empty($s_severity)) $baseParams['s_severity'] = $s_severity;
+if (!empty($s_author))   $baseParams['s_author'] = $s_author;
+if ($s_assignee !== '' && $s_assignee !== null) $baseParams['s_assignee'] = $s_assignee;
+if ($s_status !== '' && $s_status !== null)     $baseParams['s_status'] = $s_status;
+if (!empty($s_tags))     $baseParams['s_tags'] = $s_tags;
+$baseParams['viewmode'] = 'table';
+$baseParams['source'] = 'pwa';
+
+/**
+ * Build sort link for a column header
+ * @param string $field   SQL field name
+ * @param string $label   Display label
+ * @param string $icon    FontAwesome icon class
+ * @param string $currentSort  Current sort field
+ * @param string $currentOrder Current sort direction
+ * @param array  $baseParams   Base query params
+ * @return string HTML
+ */
+function buildSortHeader($field, $label, $icon, $currentSort, $currentOrder, $baseParams) {
+    $isActive = ($currentSort === $field);
+    $nextOrder = ($isActive && $currentOrder === 'ASC') ? 'DESC' : 'ASC';
+    $params = $baseParams;
+    $params['sortfield'] = $field;
+    $params['sortorder'] = $nextOrder;
+    $url = '?' . http_build_query($params);
+
+    $arrow = '';
+    if ($isActive) {
+        $arrow = ($currentOrder === 'ASC')
+            ? ' <i class="fas fa-sort-up nt-sort-active"></i>'
+            : ' <i class="fas fa-sort-down nt-sort-active"></i>';
+    } else {
+        $arrow = ' <i class="fas fa-sort nt-sort-inactive"></i>';
+    }
+
+    return '<a href="' . dol_escape_htmltag($url) . '" class="nt-header-link' . ($isActive ? ' nt-header-sorted' : '') . '" title="Trier par ' . dol_escape_htmltag($label) . '">'
+         . '<i class="' . dol_escape_htmltag($icon) . ' nt-header-icon"></i> '
+         . dol_escape_htmltag($label)
+         . $arrow
+         . '</a>';
+}
 ?>
 
-<!-- ===== ASSIGNEE FILTER BAR ===== -->
+<!-- ============================================================== -->
+<!-- NOTION TABLE VIEW                                               -->
+<!-- ============================================================== -->
+<div class="notion-table-wrapper" id="notion-table-wrapper" style="<?php echo $viewmode !== 'table' ? 'display:none;' : ''; ?>">
+
+<!-- Search form -->
+<form method="GET" action="" id="notion-search-form" class="notion-search-form">
+    <input type="hidden" name="source" value="pwa">
+    <input type="hidden" name="viewmode" value="table">
+    <input type="hidden" name="sortfield" value="<?php echo dol_escape_htmltag($sortfield); ?>">
+    <input type="hidden" name="sortorder" value="<?php echo dol_escape_htmltag($sortorder); ?>">
+
+    <div class="nt-grid nt-header-row">
+        <div class="nt-cell nt-cell-ref"><?php echo buildSortHeader('ref', 'Réf', 'fas fa-hashtag', $sortfield, $sortorder, $baseParams); ?></div>
+        <div class="nt-cell nt-cell-author">
+            <span class="nt-header-label"><i class="fas fa-user nt-header-icon"></i> Auteur</span>
+        </div>
+        <div class="nt-cell nt-cell-subject"><?php echo buildSortHeader('subject', 'Sujet', 'fas fa-font', $sortfield, $sortorder, $baseParams); ?></div>
+        <div class="nt-cell nt-cell-severity"><?php echo buildSortHeader('severity_code', 'Sévérité', 'fas fa-exclamation-triangle', $sortfield, $sortorder, $baseParams); ?></div>
+        <div class="nt-cell nt-cell-date"><?php echo buildSortHeader('datec', 'Création', 'fas fa-calendar', $sortfield, $sortorder, $baseParams); ?></div>
+        <div class="nt-cell nt-cell-assignee"><?php echo buildSortHeader('fk_user_assign', 'Assigné à', 'fas fa-user-check', $sortfield, $sortorder, $baseParams); ?></div>
+        <div class="nt-cell nt-cell-status"><?php echo buildSortHeader('fk_statut', 'État', 'fas fa-circle', $sortfield, $sortorder, $baseParams); ?></div>
+        <div class="nt-cell nt-cell-tags">
+            <span class="nt-header-label"><i class="fas fa-tags nt-header-icon"></i> Tags</span>
+        </div>
+    </div>
+
+    <!-- SEARCH ROW -->
+    <div class="nt-grid nt-search-row">
+        <div class="nt-cell nt-cell-ref">
+            <input type="text" name="s_ref" value="<?php echo dol_escape_htmltag($s_ref); ?>" placeholder="Filtrer..." class="nt-search-input" autocomplete="off">
+        </div>
+        <div class="nt-cell nt-cell-author">
+            <input type="text" name="s_author" value="<?php echo dol_escape_htmltag($s_author); ?>" placeholder="Filtrer..." class="nt-search-input" autocomplete="off">
+        </div>
+        <div class="nt-cell nt-cell-subject">
+            <input type="text" name="s_subject" value="<?php echo dol_escape_htmltag($s_subject); ?>" placeholder="Filtrer..." class="nt-search-input" autocomplete="off">
+        </div>
+        <div class="nt-cell nt-cell-severity">
+            <select name="s_severity" class="nt-search-select">
+                <option value="">Tous</option>
+                <?php foreach ($severityMap as $code => $label) { ?>
+                <option value="<?php echo dol_escape_htmltag($code); ?>"<?php echo ($s_severity === $code) ? ' selected' : ''; ?>><?php echo dol_escape_htmltag($label); ?></option>
+                <?php } ?>
+            </select>
+        </div>
+        <div class="nt-cell nt-cell-date"></div>
+        <div class="nt-cell nt-cell-assignee">
+            <select name="s_assignee" class="nt-search-select">
+                <option value="">Tous</option>
+                <option value="0"<?php echo ($s_assignee === '0') ? ' selected' : ''; ?>>Non assigné</option>
+                <?php foreach ($allInternalUsers as $uid => $uObj) {
+                    $uName = trim(($uObj->firstname ?? '') . ' ' . ($uObj->lastname ?? ''));
+                    if (empty($uName)) $uName = $uObj->login;
+                ?>
+                <option value="<?php echo (int)$uid; ?>"<?php echo ($s_assignee == $uid && $s_assignee !== '') ? ' selected' : ''; ?>><?php echo dol_escape_htmltag($uName); ?></option>
+                <?php } ?>
+            </select>
+        </div>
+        <div class="nt-cell nt-cell-status">
+            <select name="s_status" class="nt-search-select">
+                <option value="">Tous</option>
+                <?php foreach ($statusMap as $stCode => $stInfo) { ?>
+                <option value="<?php echo (int)$stCode; ?>"<?php echo ($s_status !== '' && (int)$s_status === (int)$stCode) ? ' selected' : ''; ?>><?php echo dol_escape_htmltag($stInfo['label']); ?></option>
+                <?php } ?>
+            </select>
+        </div>
+        <div class="nt-cell nt-cell-tags">
+            <input type="text" name="s_tags" value="<?php echo dol_escape_htmltag($s_tags); ?>" placeholder="Filtrer..." class="nt-search-input" autocomplete="off">
+        </div>
+    </div>
+</form>
+
+<!-- DATA ROWS -->
+<div class="nt-body" id="notion-table-body">
+<?php
+if (empty($tickets)) {
+    echo '<div class="nt-empty"><i class="fas fa-inbox"></i> Aucun ticket trouvé</div>';
+}
+foreach ($tickets as $ticket) {
+    $ref = $ticket->ref ?: $ticket->track_id ?: '#' . $ticket->rowid;
+    $ticketUrl = DOL_URL_ROOT . '/ticket/card.php?id=' . $ticket->rowid;
+    $status = (int)$ticket->status;
+    $stInfo = $statusMap[$status] ?? ['label' => '?', 'color' => '#ccc'];
+    $sevLabel = $severityMap[strtoupper($ticket->severity_code ?? '')] ?? ($ticket->severity_code ?: '-');
+    $assigneeId = (int)($ticket->fk_user_assign ?: 0);
+
+    // Author name
+    $authorName = trim(($ticket->author_firstname ?? '') . ' ' . ($ticket->author_lastname ?? ''));
+    if (empty($authorName)) $authorName = $ticket->author_login ?? '-';
+
+    // Assignee name
+    $assigneeName = '-';
+    $assigneeInitials = '?';
+    $assigneePhoto = '';
+    if ($assigneeId > 0) {
+        $assigneeName = trim(($ticket->assign_firstname ?? '') . ' ' . ($ticket->assign_lastname ?? ''));
+        if (empty($assigneeName)) $assigneeName = $ticket->assign_login ?? '?';
+        $assigneeInitials = mb_strtoupper(mb_substr($ticket->assign_firstname ?? '', 0, 1) . mb_substr($ticket->assign_lastname ?? '', 0, 1));
+        if (!empty($ticket->assign_photo) && trim($ticket->assign_photo) !== '') {
+            $assigneePhoto = DOL_URL_ROOT . '/viewimage.php?modulepart=user&file=' . urlencode($assigneeId . '/' . $ticket->assign_photo);
+        }
+    }
+
+    // Date
+    $dateFormatted = '';
+    if (!empty($ticket->datec)) {
+        $dateTs = $db->jdate($ticket->datec);
+        $dateFormatted = dol_print_date($dateTs, 'day');
+    }
+
+    // Tags for this ticket
+    $tTags = $ticketTags[(int)$ticket->rowid] ?? [];
+    $tagIds = array_map(function($t) { return $t['id']; }, $tTags);
+?>
+<div class="nt-grid nt-data-row" data-ticket-id="<?php echo (int)$ticket->rowid; ?>" data-status="<?php echo $status; ?>" data-assignee="<?php echo $assigneeId; ?>" data-severity="<?php echo dol_escape_htmltag($ticket->severity_code ?? ''); ?>" data-tag-ids="<?php echo dol_escape_htmltag(implode(',', $tagIds)); ?>">
+
+    <!-- Réf (link) -->
+    <div class="nt-cell nt-cell-ref">
+        <a href="<?php echo $ticketUrl; ?>" class="nt-ref-link"><?php echo dol_escape_htmltag($ref); ?></a>
+    </div>
+
+    <!-- Auteur (read-only) -->
+    <div class="nt-cell nt-cell-author" title="<?php echo dol_escape_htmltag($authorName); ?>">
+        <span class="nt-author-text"><?php echo dol_escape_htmltag($authorName); ?></span>
+    </div>
+
+    <!-- Sujet (editable text) -->
+    <div class="nt-cell nt-cell-subject nt-editable" data-field="subject" data-edit-type="text" data-value="<?php echo dol_escape_htmltag($ticket->subject ?? ''); ?>">
+        <span class="nt-cell-text"><?php echo dol_escape_htmltag($ticket->subject ?? 'Sans titre'); ?></span>
+    </div>
+
+    <!-- Sévérité (editable select) -->
+    <div class="nt-cell nt-cell-severity nt-editable" data-field="severity" data-edit-type="select" data-value="<?php echo dol_escape_htmltag($ticket->severity_code ?? 'NORMAL'); ?>">
+        <span class="nt-severity-badge nt-severity-<?php echo strtolower($ticket->severity_code ?? 'normal'); ?>"><?php echo dol_escape_htmltag($sevLabel); ?></span>
+    </div>
+
+    <!-- Date création (read-only) -->
+    <div class="nt-cell nt-cell-date">
+        <span><?php echo dol_escape_htmltag($dateFormatted); ?></span>
+    </div>
+
+    <!-- Assigné à (editable user) -->
+    <div class="nt-cell nt-cell-assignee nt-editable" data-field="assignee" data-edit-type="user" data-value="<?php echo $assigneeId; ?>">
+        <?php if ($assigneeId > 0) { ?>
+        <div class="nt-user-chip">
+            <?php if ($assigneePhoto) { ?>
+            <img src="<?php echo dol_escape_htmltag($assigneePhoto); ?>" class="nt-user-avatar" alt="">
+            <?php } else { ?>
+            <span class="nt-user-avatar nt-user-initials"><?php echo dol_escape_htmltag($assigneeInitials); ?></span>
+            <?php } ?>
+            <span class="nt-user-name"><?php echo dol_escape_htmltag($assigneeName); ?></span>
+        </div>
+        <?php } else { ?>
+        <span class="nt-empty-value">-</span>
+        <?php } ?>
+    </div>
+
+    <!-- État (editable select) -->
+    <div class="nt-cell nt-cell-status nt-editable" data-field="status" data-edit-type="select" data-value="<?php echo $status; ?>">
+        <span class="nt-status-badge" style="--st-color: <?php echo $stInfo['color']; ?>">
+            <span class="nt-status-dot" style="background: <?php echo $stInfo['color']; ?>"></span>
+            <?php echo dol_escape_htmltag($stInfo['label']); ?>
+        </span>
+    </div>
+
+    <!-- Tags (editable multi-select) -->
+    <div class="nt-cell nt-cell-tags nt-editable" data-field="tags" data-edit-type="tags" data-value="<?php echo dol_escape_htmltag(implode(',', $tagIds)); ?>">
+        <?php if (!empty($tTags)) {
+            foreach ($tTags as $tag) { ?>
+            <span class="nt-tag-chip" style="--tag-color: #<?php echo dol_escape_htmltag($tag['color']); ?>" data-tag-id="<?php echo (int)$tag['id']; ?>"><?php echo dol_escape_htmltag($tag['label']); ?></span>
+            <?php }
+        } else { ?>
+        <span class="nt-empty-value">-</span>
+        <?php } ?>
+    </div>
+
+</div>
+<?php } ?>
+</div>
+</div>
+
+<!-- ============================================================== -->
+<!-- KANBAN VIEW (existing)                                          -->
+<!-- ============================================================== -->
+<div id="kanban-view-section" style="<?php echo $viewmode !== 'kanban' ? 'display:none;' : ''; ?>">
+
+<!-- Assignee filter bar -->
 <div class="kanban-filters" id="kanban-filters">
     <div class="kanban-filter-chips">
         <button class="kanban-chip active" data-filter-user="all" title="Tous les tickets">
@@ -22,7 +262,6 @@
             <span class="chip-count" id="chip-count-all"><?php echo $totalTickets; ?></span>
         </button>
         <?php
-        // Unassigned chip
         $unassignedCount = 0;
         foreach ($ticketsByStatus as $stTickets) {
             foreach ($stTickets as $t) {
@@ -35,8 +274,7 @@
             <span>Non assigné</span>
             <span class="chip-count" id="chip-count-0"><?php echo $unassignedCount; ?></span>
         </button>
-        <?php
-        foreach ($usersData as $uid => $uObj) {
+        <?php foreach ($usersData as $uid => $uObj) {
             $initials = '?';
             if (!empty($uObj->firstname) && !empty($uObj->lastname)) {
                 $initials = mb_strtoupper(mb_substr($uObj->firstname, 0, 1) . mb_substr($uObj->lastname, 0, 1));
@@ -45,163 +283,120 @@
             }
             $fullName = trim(($uObj->firstname ?? '') . ' ' . ($uObj->lastname ?? ''));
             if (empty($fullName)) $fullName = $uObj->login ?? 'User #' . $uid;
-
-            // Count tickets for this user
             $userCount = 0;
             foreach ($ticketsByStatus as $stTickets) {
                 foreach ($stTickets as $t) {
                     if ((int)$t->fk_user_assign === (int)$uid) $userCount++;
                 }
             }
-
-            $avatarHtml = '';
-            if (!empty($uObj->photo) && trim($uObj->photo) !== '') {
-                $photoUrl = DOL_URL_ROOT . '/viewimage.php?modulepart=user&file=' . urlencode($uObj->rowid . '/' . $uObj->photo);
-                $avatarHtml = '<img src="' . dol_escape_htmltag($photoUrl) . '" alt="' . dol_escape_htmltag($initials) . '" class="kanban-avatar-img">';
-            } else {
-                $avatarHtml = '<span class="kanban-avatar">' . dol_escape_htmltag($initials) . '</span>';
-            }
-            ?>
-            <button class="kanban-chip" data-filter-user="<?php echo (int)$uid; ?>" title="<?php echo dol_escape_htmltag($fullName); ?>">
-                <?php echo $avatarHtml; ?>
-                <span><?php echo dol_escape_htmltag($fullName); ?></span>
-                <span class="chip-count" id="chip-count-<?php echo (int)$uid; ?>"><?php echo $userCount; ?></span>
-            </button>
-            <?php
-        }
         ?>
+        <button class="kanban-chip" data-filter-user="<?php echo (int)$uid; ?>" title="<?php echo dol_escape_htmltag($fullName); ?>">
+            <span class="kanban-avatar"><?php echo dol_escape_htmltag($initials); ?></span>
+            <span><?php echo dol_escape_htmltag($fullName); ?></span>
+            <span class="chip-count"><?php echo $userCount; ?></span>
+        </button>
+        <?php } ?>
     </div>
 </div>
 
-<!-- ===== KANBAN BOARD ===== -->
+<!-- Kanban Board -->
 <div class="kanban-board" id="kanban-board">
-    <?php
-    foreach ($statusMap as $statusCode => $statusInfo) {
-        $columnTickets = $ticketsByStatus[$statusCode] ?? [];
-        $colCount = count($columnTickets);
-        // Annulé (9) and Fermé (8) collapsed by default
-        $isCollapsed = in_array($statusCode, [Ticket::STATUS_CANCELED]);
-    ?>
-    <div class="kanban-column<?php echo $isCollapsed ? ' collapsed' : ''; ?>" data-status="<?php echo $statusCode; ?>" id="kanban-col-<?php echo $statusCode; ?>">
-        <div class="kanban-column-header" style="--col-color: <?php echo $statusInfo['color']; ?>">
-            <div class="kanban-column-dot" style="background-color: <?php echo $statusInfo['color']; ?>"></div>
-            <span class="kanban-column-title"><?php echo dol_escape_htmltag($statusInfo['label']); ?></span>
-            <span class="kanban-column-count" id="col-count-<?php echo $statusCode; ?>"><?php echo $colCount; ?></span>
-            <button class="kanban-column-toggle" title="Afficher/masquer"><i class="fas fa-chevron-down"></i></button>
-        </div>
-        <div class="kanban-column-body" id="kanban-body-<?php echo $statusCode; ?>">
-            <?php
-            if (empty($columnTickets)) {
-                echo '<div class="kanban-empty-col"><i class="fas fa-inbox"></i><span>Aucun ticket</span></div>';
+<?php foreach ($statusMap as $statusCode => $statusInfo) {
+    $columnTickets = $ticketsByStatus[$statusCode] ?? [];
+    $colCount = count($columnTickets);
+    $isCollapsed = ($statusCode == Ticket::STATUS_CANCELED);
+?>
+<div class="kanban-column<?php echo $isCollapsed ? ' collapsed' : ''; ?>" data-status="<?php echo $statusCode; ?>">
+    <div class="kanban-column-header" style="--col-color: <?php echo $statusInfo['color']; ?>">
+        <div class="kanban-column-dot" style="background-color: <?php echo $statusInfo['color']; ?>"></div>
+        <span class="kanban-column-title"><?php echo dol_escape_htmltag($statusInfo['label']); ?></span>
+        <span class="kanban-column-count" id="col-count-<?php echo $statusCode; ?>"><?php echo $colCount; ?></span>
+        <button class="kanban-column-toggle" title="Afficher/masquer"><i class="fas fa-chevron-down"></i></button>
+    </div>
+    <div class="kanban-column-body" id="kanban-body-<?php echo $statusCode; ?>">
+    <?php if (empty($columnTickets)) {
+        echo '<div class="kanban-empty-col"><i class="fas fa-inbox"></i><span>Aucun ticket</span></div>';
+    }
+    foreach ($columnTickets as $t) {
+        $ref = $t->ref ?: $t->track_id ?: '#' . $t->rowid;
+        $companyName = $t->company_name ?: '';
+        $severity = $severityMap[strtoupper($t->severity_code ?? '')] ?? ($t->severity_code ?: 'Normal');
+        $progressPct = (int)($t->progress ?: 0);
+        $dateFormatted = '';
+        $elapsedTimeStr = '';
+        if (!empty($t->datec)) {
+            $dateTs = $db->jdate($t->datec);
+            $dateFormatted = dol_print_date($dateTs, 'day');
+            $diffSec = dol_now() - $dateTs;
+            if ($diffSec > 0) {
+                $diffDays = floor($diffSec / 86400);
+                $diffHrs = floor(($diffSec % 86400) / 3600);
+                $diffMins = floor(($diffSec % 3600) / 60);
+                $tps = [];
+                if ($diffDays > 0) $tps[] = $diffDays . 'j';
+                $tps[] = str_pad($diffHrs, 2, '0', STR_PAD_LEFT) . ':' . str_pad($diffMins, 2, '0', STR_PAD_LEFT);
+                $elapsedTimeStr = 'Tps: ' . implode(' ', $tps);
             }
-            foreach ($columnTickets as $ticket) {
-                // --- Build card data ---
-                $ref = $ticket->ref ?: $ticket->track_id ?: 'Ticket #' . $ticket->rowid;
-                $companyName = $ticket->company_name ?: '';
-                $severity = $severityMap[strtoupper($ticket->severity_code ?? '')] ?? ($ticket->severity_code ?: 'Normal');
-                $progressPct = (int)($ticket->progress ?: 0);
-
-                // Date & Elapsed
-                $dateFormatted = '';
-                $elapsedTimeStr = '';
-                if (!empty($ticket->datec)) {
-                    $dateTs = $db->jdate($ticket->datec);
-                    $dateFormatted = dol_print_date($dateTs, 'day');
-                    $diffSec = dol_now() - $dateTs;
-                    if ($diffSec > 0) {
-                        $diffDays = floor($diffSec / 86400);
-                        $diffHrs  = floor(($diffSec % 86400) / 3600);
-                        $diffMins = floor(($diffSec % 3600) / 60);
-                        $tps = [];
-                        if ($diffDays > 0) $tps[] = $diffDays . 'j';
-                        $tps[] = str_pad($diffHrs, 2, '0', STR_PAD_LEFT) . ':' . str_pad($diffMins, 2, '0', STR_PAD_LEFT);
-                        $elapsedTimeStr = 'Tps: ' . implode(' ', $tps);
-                    }
-                }
-
-                // Assignee
-                $initials = '?';
-                $photoHtml = '';
-                $assigneeId = (int)($ticket->fk_user_assign ?: 0);
-                if ($assigneeId > 0 && isset($usersData[$assigneeId])) {
-                    $u = $usersData[$assigneeId];
-                    if (!empty($u->firstname) && !empty($u->lastname)) {
-                        $initials = mb_strtoupper(mb_substr($u->firstname, 0, 1) . mb_substr($u->lastname, 0, 1));
-                    } elseif (!empty($u->login)) {
-                        $initials = mb_strtoupper(mb_substr($u->login, 0, 2));
-                    }
-                    if (!empty($u->photo) && trim($u->photo) !== '') {
-                        $pUrl = DOL_URL_ROOT . '/viewimage.php?modulepart=user&file=' . urlencode($u->rowid . '/' . $u->photo);
-                        $photoHtml = '<img src="' . dol_escape_htmltag($pUrl) . '" alt="' . dol_escape_htmltag($initials) . '" class="tc-assignee-img">';
-                    }
-                }
-
-                // Clean message
-                $rawMsg = strip_tags(str_replace(['<br>', '<br/>', '<br />'], "\n", $ticket->message ?? ''));
-                $rawMsg = trim(preg_replace('/\n{3,}/', "\n\n", $rawMsg));
-                $safeSubject = dol_escape_htmltag($ticket->subject ?: 'Sans titre');
-                $safeMessage = dol_escape_htmltag(mb_substr($rawMsg, 0, 200));
-
-                // Search string for JS filter
-                $searchStr = mb_strtolower($ref . ' ' . ($ticket->subject ?: '') . ' ' . $companyName);
-
-                // URLs
-                $ticketUrl = DOL_URL_ROOT . '/ticket/card.php?id=' . $ticket->rowid;
-                $chatUrl   = DOL_URL_ROOT . '/ticket/messaging.php?id=' . $ticket->rowid;
-
-                // Status
-                $stColor = $statusInfo['color'];
-                $stLabel = $statusInfo['label'];
-            ?>
-            <div class="ticket-card-kanban" draggable="true"
-                 data-ticket-id="<?php echo (int)$ticket->rowid; ?>"
-                 data-status="<?php echo (int)$ticket->status; ?>"
-                 data-assignee="<?php echo $assigneeId; ?>"
-                 data-search="<?php echo dol_escape_htmltag($searchStr); ?>">
-                <div class="tc-header">
-                    <div class="tc-meta" style="flex:1;min-width:0;">
-                        <a href="<?php echo $ticketUrl; ?>" class="tc-ref"><?php echo dol_escape_htmltag($ref); ?></a>
-                        <span class="tc-sep">&bull;</span>
-                        <?php if (!empty($companyName)) { ?>
-                        <span class="tc-company" title="Tiers"><i class="fas fa-building" style="color: #6a7491;"></i> <?php echo dol_escape_htmltag($companyName); ?></span>
-                        <span class="tc-sep">&bull;</span>
-                        <?php } ?>
-                        <span class="tc-date" title="Créé le"><?php echo $dateFormatted; ?></span>
-                        <span class="tc-sep">&bull;</span>
-                        <span class="tc-time" title="Temps écoulé"><?php echo dol_escape_htmltag($elapsedTimeStr); ?></span>
-                    </div>
-                    <div class="tc-assignee tc-assignee-picker" title="Changer l'assigné" data-ticket-id="<?php echo (int)$ticket->rowid; ?>" data-current-assignee="<?php echo $assigneeId; ?>">
-                        <?php echo $photoHtml ?: dol_escape_htmltag($initials); ?>
-                        <i class="fas fa-caret-down tc-assignee-caret"></i>
-                    </div>
-                </div>
-                <div class="tc-row-middle">
-                    <span class="tc-severity"><?php echo dol_escape_htmltag($severity); ?></span>
-                    <span class="tc-sep">&bull;</span>
-                    <span class="tc-progress"><?php echo $progressPct; ?>%</span>
-                </div>
-                <div class="tc-title-row">
-                    <div class="tc-title" title="<?php echo $safeSubject; ?>"><?php echo $safeSubject; ?></div>
-                    <div class="tc-actions">
-                        <div class="tc-status-btn" title="Statut">
-                            <div class="tc-status-dot" style="background-color: <?php echo $stColor; ?>"></div>
-                            <span class="tc-status-label"><?php echo dol_escape_htmltag($stLabel); ?></span>
-                        </div>
-                        <a href="<?php echo $chatUrl; ?>" class="tc-chat-link" title="Messages & Évènements">
-                            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 11.5a8.38 8.38 0 0 1-.9 3.8 8.5 8.5 0 0 1-7.6 4.7 8.38 8.38 0 0 1-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 0 1-.9-3.8 8.5 8.5 0 0 1 4.7-7.6 8.38 8.38 0 0 1 3.8-.9h.5a8.48 8.48 0 0 1 8 8v.5z"></path></svg>
-                        </a>
-                    </div>
-                </div>
-                <?php if (!empty($safeMessage)) { ?>
-                <div class="tc-body">
-                    <div class="tc-message-preview"><?php echo $safeMessage; ?></div>
-                </div>
+        }
+        $initials = '?';
+        $photoHtml = '';
+        $aId = (int)($t->fk_user_assign ?: 0);
+        if ($aId > 0 && isset($allInternalUsers[$aId])) {
+            $u = $allInternalUsers[$aId];
+            if (!empty($u->firstname) && !empty($u->lastname)) $initials = mb_strtoupper(mb_substr($u->firstname, 0, 1) . mb_substr($u->lastname, 0, 1));
+            if (!empty($u->photo) && trim($u->photo) !== '') {
+                $pUrl = DOL_URL_ROOT . '/viewimage.php?modulepart=user&file=' . urlencode($u->rowid . '/' . $u->photo);
+                $photoHtml = '<img src="' . dol_escape_htmltag($pUrl) . '" class="tc-assignee-img">';
+            }
+        }
+        $rawMsg = strip_tags(str_replace(['<br>', '<br/>', '<br />'], "\n", $t->message ?? ''));
+        $rawMsg = trim(preg_replace('/\n{3,}/', "\n\n", $rawMsg));
+        $safeSubject = dol_escape_htmltag($t->subject ?: 'Sans titre');
+        $safeMessage = dol_escape_htmltag(mb_substr($rawMsg, 0, 200));
+        $searchStr = mb_strtolower($ref . ' ' . ($t->subject ?: '') . ' ' . $companyName);
+        $ticketUrl = DOL_URL_ROOT . '/ticket/card.php?id=' . $t->rowid;
+        $stColor = $statusInfo['color'];
+        $stLabel = $statusInfo['label'];
+    ?>
+    <div class="ticket-card-kanban" draggable="true" data-ticket-id="<?php echo (int)$t->rowid; ?>" data-status="<?php echo (int)$t->status; ?>" data-assignee="<?php echo $aId; ?>" data-search="<?php echo dol_escape_htmltag($searchStr); ?>">
+        <div class="tc-header">
+            <div class="tc-meta" style="flex:1;min-width:0;">
+                <a href="<?php echo $ticketUrl; ?>" class="tc-ref"><?php echo dol_escape_htmltag($ref); ?></a>
+                <span class="tc-sep">&bull;</span>
+                <?php if (!empty($companyName)) { ?>
+                <span class="tc-company"><i class="fas fa-building" style="color:#6a7491;"></i> <?php echo dol_escape_htmltag($companyName); ?></span>
+                <span class="tc-sep">&bull;</span>
                 <?php } ?>
+                <span class="tc-date"><?php echo $dateFormatted; ?></span>
+                <span class="tc-sep">&bull;</span>
+                <span class="tc-time"><?php echo dol_escape_htmltag($elapsedTimeStr); ?></span>
             </div>
-            <?php } ?>
+            <div class="tc-assignee tc-assignee-picker" data-ticket-id="<?php echo (int)$t->rowid; ?>" data-current-assignee="<?php echo $aId; ?>">
+                <?php echo $photoHtml ?: dol_escape_htmltag($initials); ?>
+                <i class="fas fa-caret-down tc-assignee-caret"></i>
+            </div>
         </div>
+        <div class="tc-row-middle">
+            <span class="tc-severity"><?php echo dol_escape_htmltag($severity); ?></span>
+            <span class="tc-sep">&bull;</span>
+            <span class="tc-progress"><?php echo $progressPct; ?>%</span>
+        </div>
+        <div class="tc-title-row">
+            <div class="tc-title"><?php echo $safeSubject; ?></div>
+            <div class="tc-actions">
+                <div class="tc-status-btn">
+                    <div class="tc-status-dot" style="background-color:<?php echo $stColor; ?>"></div>
+                    <span class="tc-status-label"><?php echo dol_escape_htmltag($stLabel); ?></span>
+                </div>
+            </div>
+        </div>
+        <?php if (!empty($safeMessage)) { ?>
+        <div class="tc-body"><div class="tc-message-preview"><?php echo $safeMessage; ?></div></div>
+        <?php } ?>
     </div>
     <?php } ?>
+    </div>
 </div>
-
-
+<?php } ?>
+</div>
+</div>

--- a/core/tpl/frontend/reedcrm_tickets_kanban.tpl.php
+++ b/core/tpl/frontend/reedcrm_tickets_kanban.tpl.php
@@ -159,7 +159,7 @@
                  data-assignee="<?php echo $assigneeId; ?>"
                  data-search="<?php echo dol_escape_htmltag($searchStr); ?>">
                 <div class="tc-header">
-                    <div class="tc-meta">
+                    <div class="tc-meta" style="flex:1;min-width:0;">
                         <a href="<?php echo $ticketUrl; ?>" class="tc-ref"><?php echo dol_escape_htmltag($ref); ?></a>
                         <span class="tc-sep">&bull;</span>
                         <?php if (!empty($companyName)) { ?>
@@ -170,8 +170,9 @@
                         <span class="tc-sep">&bull;</span>
                         <span class="tc-time" title="Temps écoulé"><?php echo dol_escape_htmltag($elapsedTimeStr); ?></span>
                     </div>
-                    <div class="tc-assignee" title="Assigné à">
+                    <div class="tc-assignee tc-assignee-picker" title="Changer l'assigné" data-ticket-id="<?php echo (int)$ticket->rowid; ?>" data-current-assignee="<?php echo $assigneeId; ?>">
                         <?php echo $photoHtml ?: dol_escape_htmltag($initials); ?>
+                        <i class="fas fa-caret-down tc-assignee-caret"></i>
                     </div>
                 </div>
                 <div class="tc-row-middle">
@@ -202,4 +203,5 @@
     </div>
     <?php } ?>
 </div>
+
 

--- a/core/tpl/frontend/reedcrm_tickets_kanban.tpl.php
+++ b/core/tpl/frontend/reedcrm_tickets_kanban.tpl.php
@@ -1,0 +1,205 @@
+﻿<?php
+/**
+ * \file    core/tpl/frontend/reedcrm_tickets_kanban.tpl.php
+ * \ingroup reedcrm
+ * \brief   Kanban board template for PWA tickets page
+ *
+ * Expects from parent:
+ *   $ticketsByStatus  array  Tickets grouped by status code
+ *   $statusMap        array  Status definitions [code => [label, color]]
+ *   $severityMap      array  Severity translations
+ *   $usersData        array  User objects indexed by rowid
+ *   $totalTickets     int    Total ticket count
+ */
+?>
+
+<!-- ===== ASSIGNEE FILTER BAR ===== -->
+<div class="kanban-filters" id="kanban-filters">
+    <div class="kanban-filter-chips">
+        <button class="kanban-chip active" data-filter-user="all" title="Tous les tickets">
+            <i class="fas fa-users"></i>
+            <span>Tous</span>
+            <span class="chip-count" id="chip-count-all"><?php echo $totalTickets; ?></span>
+        </button>
+        <?php
+        // Unassigned chip
+        $unassignedCount = 0;
+        foreach ($ticketsByStatus as $stTickets) {
+            foreach ($stTickets as $t) {
+                if (empty($t->fk_user_assign) || $t->fk_user_assign <= 0) $unassignedCount++;
+            }
+        }
+        ?>
+        <button class="kanban-chip" data-filter-user="0" title="Non assigné">
+            <span class="kanban-avatar kanban-avatar-placeholder"><i class="fas fa-question"></i></span>
+            <span>Non assigné</span>
+            <span class="chip-count" id="chip-count-0"><?php echo $unassignedCount; ?></span>
+        </button>
+        <?php
+        foreach ($usersData as $uid => $uObj) {
+            $initials = '?';
+            if (!empty($uObj->firstname) && !empty($uObj->lastname)) {
+                $initials = mb_strtoupper(mb_substr($uObj->firstname, 0, 1) . mb_substr($uObj->lastname, 0, 1));
+            } elseif (!empty($uObj->login)) {
+                $initials = mb_strtoupper(mb_substr($uObj->login, 0, 2));
+            }
+            $fullName = trim(($uObj->firstname ?? '') . ' ' . ($uObj->lastname ?? ''));
+            if (empty($fullName)) $fullName = $uObj->login ?? 'User #' . $uid;
+
+            // Count tickets for this user
+            $userCount = 0;
+            foreach ($ticketsByStatus as $stTickets) {
+                foreach ($stTickets as $t) {
+                    if ((int)$t->fk_user_assign === (int)$uid) $userCount++;
+                }
+            }
+
+            $avatarHtml = '';
+            if (!empty($uObj->photo) && trim($uObj->photo) !== '') {
+                $photoUrl = DOL_URL_ROOT . '/viewimage.php?modulepart=user&file=' . urlencode($uObj->rowid . '/' . $uObj->photo);
+                $avatarHtml = '<img src="' . dol_escape_htmltag($photoUrl) . '" alt="' . dol_escape_htmltag($initials) . '" class="kanban-avatar-img">';
+            } else {
+                $avatarHtml = '<span class="kanban-avatar">' . dol_escape_htmltag($initials) . '</span>';
+            }
+            ?>
+            <button class="kanban-chip" data-filter-user="<?php echo (int)$uid; ?>" title="<?php echo dol_escape_htmltag($fullName); ?>">
+                <?php echo $avatarHtml; ?>
+                <span><?php echo dol_escape_htmltag($fullName); ?></span>
+                <span class="chip-count" id="chip-count-<?php echo (int)$uid; ?>"><?php echo $userCount; ?></span>
+            </button>
+            <?php
+        }
+        ?>
+    </div>
+</div>
+
+<!-- ===== KANBAN BOARD ===== -->
+<div class="kanban-board" id="kanban-board">
+    <?php
+    foreach ($statusMap as $statusCode => $statusInfo) {
+        $columnTickets = $ticketsByStatus[$statusCode] ?? [];
+        $colCount = count($columnTickets);
+        // Annulé (9) and Fermé (8) collapsed by default
+        $isCollapsed = in_array($statusCode, [Ticket::STATUS_CANCELED]);
+    ?>
+    <div class="kanban-column<?php echo $isCollapsed ? ' collapsed' : ''; ?>" data-status="<?php echo $statusCode; ?>" id="kanban-col-<?php echo $statusCode; ?>">
+        <div class="kanban-column-header" style="--col-color: <?php echo $statusInfo['color']; ?>">
+            <div class="kanban-column-dot" style="background-color: <?php echo $statusInfo['color']; ?>"></div>
+            <span class="kanban-column-title"><?php echo dol_escape_htmltag($statusInfo['label']); ?></span>
+            <span class="kanban-column-count" id="col-count-<?php echo $statusCode; ?>"><?php echo $colCount; ?></span>
+            <button class="kanban-column-toggle" title="Afficher/masquer"><i class="fas fa-chevron-down"></i></button>
+        </div>
+        <div class="kanban-column-body" id="kanban-body-<?php echo $statusCode; ?>">
+            <?php
+            if (empty($columnTickets)) {
+                echo '<div class="kanban-empty-col"><i class="fas fa-inbox"></i><span>Aucun ticket</span></div>';
+            }
+            foreach ($columnTickets as $ticket) {
+                // --- Build card data ---
+                $ref = $ticket->ref ?: $ticket->track_id ?: 'Ticket #' . $ticket->rowid;
+                $companyName = $ticket->company_name ?: '';
+                $severity = $severityMap[strtoupper($ticket->severity_code ?? '')] ?? ($ticket->severity_code ?: 'Normal');
+                $progressPct = (int)($ticket->progress ?: 0);
+
+                // Date & Elapsed
+                $dateFormatted = '';
+                $elapsedTimeStr = '';
+                if (!empty($ticket->datec)) {
+                    $dateTs = $db->jdate($ticket->datec);
+                    $dateFormatted = dol_print_date($dateTs, 'day');
+                    $diffSec = dol_now() - $dateTs;
+                    if ($diffSec > 0) {
+                        $diffDays = floor($diffSec / 86400);
+                        $diffHrs  = floor(($diffSec % 86400) / 3600);
+                        $diffMins = floor(($diffSec % 3600) / 60);
+                        $tps = [];
+                        if ($diffDays > 0) $tps[] = $diffDays . 'j';
+                        $tps[] = str_pad($diffHrs, 2, '0', STR_PAD_LEFT) . ':' . str_pad($diffMins, 2, '0', STR_PAD_LEFT);
+                        $elapsedTimeStr = 'Tps: ' . implode(' ', $tps);
+                    }
+                }
+
+                // Assignee
+                $initials = '?';
+                $photoHtml = '';
+                $assigneeId = (int)($ticket->fk_user_assign ?: 0);
+                if ($assigneeId > 0 && isset($usersData[$assigneeId])) {
+                    $u = $usersData[$assigneeId];
+                    if (!empty($u->firstname) && !empty($u->lastname)) {
+                        $initials = mb_strtoupper(mb_substr($u->firstname, 0, 1) . mb_substr($u->lastname, 0, 1));
+                    } elseif (!empty($u->login)) {
+                        $initials = mb_strtoupper(mb_substr($u->login, 0, 2));
+                    }
+                    if (!empty($u->photo) && trim($u->photo) !== '') {
+                        $pUrl = DOL_URL_ROOT . '/viewimage.php?modulepart=user&file=' . urlencode($u->rowid . '/' . $u->photo);
+                        $photoHtml = '<img src="' . dol_escape_htmltag($pUrl) . '" alt="' . dol_escape_htmltag($initials) . '" class="tc-assignee-img">';
+                    }
+                }
+
+                // Clean message
+                $rawMsg = strip_tags(str_replace(['<br>', '<br/>', '<br />'], "\n", $ticket->message ?? ''));
+                $rawMsg = trim(preg_replace('/\n{3,}/', "\n\n", $rawMsg));
+                $safeSubject = dol_escape_htmltag($ticket->subject ?: 'Sans titre');
+                $safeMessage = dol_escape_htmltag(mb_substr($rawMsg, 0, 200));
+
+                // Search string for JS filter
+                $searchStr = mb_strtolower($ref . ' ' . ($ticket->subject ?: '') . ' ' . $companyName);
+
+                // URLs
+                $ticketUrl = DOL_URL_ROOT . '/ticket/card.php?id=' . $ticket->rowid;
+                $chatUrl   = DOL_URL_ROOT . '/ticket/messaging.php?id=' . $ticket->rowid;
+
+                // Status
+                $stColor = $statusInfo['color'];
+                $stLabel = $statusInfo['label'];
+            ?>
+            <div class="ticket-card-kanban" draggable="true"
+                 data-ticket-id="<?php echo (int)$ticket->rowid; ?>"
+                 data-status="<?php echo (int)$ticket->status; ?>"
+                 data-assignee="<?php echo $assigneeId; ?>"
+                 data-search="<?php echo dol_escape_htmltag($searchStr); ?>">
+                <div class="tc-header">
+                    <div class="tc-meta">
+                        <a href="<?php echo $ticketUrl; ?>" class="tc-ref"><?php echo dol_escape_htmltag($ref); ?></a>
+                        <span class="tc-sep">&bull;</span>
+                        <?php if (!empty($companyName)) { ?>
+                        <span class="tc-company" title="Tiers"><i class="fas fa-building" style="color: #6a7491;"></i> <?php echo dol_escape_htmltag($companyName); ?></span>
+                        <span class="tc-sep">&bull;</span>
+                        <?php } ?>
+                        <span class="tc-date" title="Créé le"><?php echo $dateFormatted; ?></span>
+                        <span class="tc-sep">&bull;</span>
+                        <span class="tc-time" title="Temps écoulé"><?php echo dol_escape_htmltag($elapsedTimeStr); ?></span>
+                    </div>
+                    <div class="tc-assignee" title="Assigné à">
+                        <?php echo $photoHtml ?: dol_escape_htmltag($initials); ?>
+                    </div>
+                </div>
+                <div class="tc-row-middle">
+                    <span class="tc-severity"><?php echo dol_escape_htmltag($severity); ?></span>
+                    <span class="tc-sep">&bull;</span>
+                    <span class="tc-progress"><?php echo $progressPct; ?>%</span>
+                </div>
+                <div class="tc-title-row">
+                    <div class="tc-title" title="<?php echo $safeSubject; ?>"><?php echo $safeSubject; ?></div>
+                    <div class="tc-actions">
+                        <div class="tc-status-btn" title="Statut">
+                            <div class="tc-status-dot" style="background-color: <?php echo $stColor; ?>"></div>
+                            <span class="tc-status-label"><?php echo dol_escape_htmltag($stLabel); ?></span>
+                        </div>
+                        <a href="<?php echo $chatUrl; ?>" class="tc-chat-link" title="Messages & Évènements">
+                            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 11.5a8.38 8.38 0 0 1-.9 3.8 8.5 8.5 0 0 1-7.6 4.7 8.38 8.38 0 0 1-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 0 1-.9-3.8 8.5 8.5 0 0 1 4.7-7.6 8.38 8.38 0 0 1 3.8-.9h.5a8.48 8.48 0 0 1 8 8v.5z"></path></svg>
+                        </a>
+                    </div>
+                </div>
+                <?php if (!empty($safeMessage)) { ?>
+                <div class="tc-body">
+                    <div class="tc-message-preview"><?php echo $safeMessage; ?></div>
+                </div>
+                <?php } ?>
+            </div>
+            <?php } ?>
+        </div>
+    </div>
+    <?php } ?>
+</div>
+

--- a/css/reedcrm_tickets_kanban.css
+++ b/css/reedcrm_tickets_kanban.css
@@ -615,3 +615,107 @@
 .kanban-board::-webkit-scrollbar { height: 6px; }
 .kanban-board::-webkit-scrollbar-track { background: #f1f5f9; border-radius: 3px; }
 .kanban-board::-webkit-scrollbar-thumb { background: #cbd5e1; border-radius: 3px; }
+
+/* ── ASSIGNEE PICKER DROPDOWN ──────────────────────────────────────── */
+.tc-assignee-picker {
+    cursor: pointer;
+    position: relative;
+    transition: box-shadow 0.2s;
+}
+.tc-assignee-picker:hover {
+    box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.3);
+}
+.tc-assignee-caret {
+    position: absolute;
+    bottom: -2px;
+    right: -2px;
+    font-size: 8px;
+    color: #94a3b8;
+    background: #fff;
+    border-radius: 50%;
+    width: 12px;
+    height: 12px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.15);
+}
+.tc-assignee-picker:hover .tc-assignee-caret {
+    color: #3b82f6;
+}
+
+/* Dropdown overlay */
+.assignee-dropdown {
+    position: absolute;
+    top: 100%;
+    right: 0;
+    z-index: 100;
+    background: #fff;
+    border: 1px solid #e2e8f0;
+    border-radius: 10px;
+    box-shadow: 0 10px 25px rgba(0,0,0,0.12), 0 4px 10px rgba(0,0,0,0.06);
+    min-width: 200px;
+    max-height: 280px;
+    overflow-y: auto;
+    padding: 4px;
+    animation: assignee-dd-in 0.15s ease;
+}
+@keyframes assignee-dd-in {
+    from { opacity: 0; transform: translateY(-4px) scale(0.97); }
+    to   { opacity: 1; transform: translateY(0) scale(1); }
+}
+.assignee-dropdown-item {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 7px 10px;
+    border: none;
+    background: transparent;
+    width: 100%;
+    text-align: left;
+    font-size: 12px;
+    font-weight: 500;
+    color: #1e293b;
+    cursor: pointer;
+    border-radius: 6px;
+    transition: background 0.15s;
+    white-space: nowrap;
+}
+.assignee-dropdown-item:hover {
+    background: #f1f5f9;
+}
+.assignee-dropdown-item.selected {
+    background: #eff6ff;
+    color: #2563eb;
+    font-weight: 700;
+}
+.assignee-dropdown-item .dd-avatar {
+    width: 22px;
+    height: 22px;
+    border-radius: 50%;
+    background: #e2e8f0;
+    color: #475569;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 9px;
+    font-weight: bold;
+    flex-shrink: 0;
+    overflow: hidden;
+}
+.assignee-dropdown-item .dd-avatar img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    border-radius: 50%;
+}
+.assignee-dropdown-item .dd-check {
+    margin-left: auto;
+    color: #2563eb;
+    font-size: 11px;
+}
+.assignee-dropdown-separator {
+    height: 1px;
+    background: #e2e8f0;
+    margin: 4px 6px;
+}

--- a/css/reedcrm_tickets_kanban.css
+++ b/css/reedcrm_tickets_kanban.css
@@ -1,5 +1,5 @@
 ﻿/* =====================================================================
- *  ReedCRM — Kanban Tickets PWA Stylesheet v3
+ *  ReedCRM — Kanban + Notion Table Tickets PWA Stylesheet v4
  *  File: css/reedcrm_tickets_kanban.css
  * ===================================================================== */
 
@@ -27,669 +27,382 @@
     cursor: pointer;
     transition: all 0.2s ease;
 }
-.view-toggle-btn:hover {
-    background: rgba(255,255,255,0.5);
-    color: #1e293b;
-}
-.view-toggle-btn.active {
-    background: #fff;
-    color: #1e293b;
-    box-shadow: 0 1px 3px rgba(0,0,0,0.1);
-}
+.view-toggle-btn:hover { background: rgba(255,255,255,0.5); color: #1e293b; }
+.view-toggle-btn.active { background: #fff; color: #1e293b; box-shadow: 0 1px 3px rgba(0,0,0,0.1); }
 
-/* ── KANBAN FILTER BAR ─────────────────────────────────────────────── */
-.kanban-filters {
-    padding: 10px 15px 0 15px;
+/* ══════════════════════════════════════════════════════════════════════
+   NOTION TABLE
+   ══════════════════════════════════════════════════════════════════════ */
+
+.notion-table-wrapper {
+    padding: 0 12px 90px 12px;
     overflow-x: auto;
     -webkit-overflow-scrolling: touch;
 }
-.kanban-filter-chips {
-    display: flex;
-    gap: 8px;
-    align-items: center;
-    min-width: max-content;
-}
-.kanban-chip {
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    padding: 6px 12px;
-    border: 1.5px solid #e2e8f0;
-    border-radius: 20px;
-    background: #fff;
-    color: #475569;
-    font-size: 12px;
-    font-weight: 600;
-    cursor: pointer;
-    transition: all 0.2s ease;
-    white-space: nowrap;
-    flex-shrink: 0;
-}
-.kanban-chip:hover {
-    border-color: #94a3b8;
-    background: #f8fafc;
-}
-.kanban-chip.active {
-    background: #1e293b;
-    border-color: #1e293b;
-    color: #fff;
-    box-shadow: 0 2px 8px rgba(30, 41, 59, 0.25);
-}
-.kanban-chip .chip-count {
-    background: rgba(0, 0, 0, 0.08);
-    padding: 1px 7px;
-    border-radius: 10px;
-    font-size: 11px;
-    font-weight: 700;
-    min-width: 18px;
-    text-align: center;
-}
-.kanban-chip.active .chip-count {
-    background: rgba(255, 255, 255, 0.2);
+
+/* Grid layout */
+.nt-grid {
+    display: grid;
+    grid-template-columns:
+        minmax(110px, 0.8fr)  /* Réf */
+        minmax(100px, 0.8fr)  /* Auteur */
+        minmax(180px, 2fr)    /* Sujet */
+        minmax(80px, 0.7fr)   /* Sévérité */
+        minmax(90px, 0.7fr)   /* Date */
+        minmax(120px, 1fr)    /* Assigné */
+        minmax(100px, 0.8fr)  /* État */
+        minmax(140px, 1.2fr); /* Tags */
+    min-width: 900px;
 }
 
-/* Avatar in chip */
-.kanban-avatar {
-    width: 22px;
-    height: 22px;
-    border-radius: 50%;
-    background: #e2e8f0;
-    color: #475569;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    font-size: 9px;
-    font-weight: bold;
-    flex-shrink: 0;
-    overflow: hidden;
-}
-.kanban-avatar-placeholder {
-    background: #cbd5e1;
-    color: #64748b;
-    font-size: 10px;
-}
-.kanban-avatar-img {
-    width: 22px;
-    height: 22px;
-    border-radius: 50%;
-    object-fit: cover;
-}
-.kanban-chip.active .kanban-avatar {
-    background: rgba(255, 255, 255, 0.2);
-    color: #fff;
-}
-
-/* ── STATUS FILTER BAR (Notion-like) ───────────────────────────────── */
-.kanban-status-filters {
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    padding: 8px 0 10px 0;
-    overflow-x: auto;
-    -webkit-overflow-scrolling: touch;
-    min-width: max-content;
-}
-.status-filter-label {
-    font-size: 11px;
-    font-weight: 700;
-    color: #94a3b8;
-    white-space: nowrap;
-    margin-right: 4px;
-    display: flex;
-    align-items: center;
-    gap: 4px;
-}
-.status-filter-label i {
-    font-size: 10px;
-}
-.status-filter-chip {
-    display: flex;
-    align-items: center;
-    gap: 5px;
-    padding: 4px 10px;
-    border: 1px solid #e2e8f0;
-    border-radius: 6px;
-    background: #fff;
-    color: #475569;
-    font-size: 11px;
-    font-weight: 600;
-    cursor: pointer;
-    transition: all 0.2s ease;
-    white-space: nowrap;
-    flex-shrink: 0;
-}
-.status-filter-chip:hover {
-    border-color: #94a3b8;
-    background: #f8fafc;
-}
-.status-filter-chip.active {
-    background: #f8fafc;
-    border-color: #cbd5e1;
-}
-.status-filter-chip:not(.active) {
-    opacity: 0.45;
-    background: #f1f5f9;
-    text-decoration: line-through;
-}
-.sf-dot {
-    width: 8px;
-    height: 8px;
-    border-radius: 50%;
-    flex-shrink: 0;
-}
-.sf-label {
-    font-size: 11px;
-}
-.sf-count {
-    background: rgba(0, 0, 0, 0.06);
-    padding: 0 5px;
-    border-radius: 6px;
-    font-size: 10px;
-    font-weight: 700;
-    min-width: 14px;
-    text-align: center;
-}
-
-/* ── KANBAN BOARD ──────────────────────────────────────────────────── */
-.kanban-board {
-    display: flex;
-    gap: 12px;
-    padding: 0 15px 90px 15px;
-    overflow-x: auto;
-    -webkit-overflow-scrolling: touch;
-    min-height: calc(100vh - 220px);
-    align-items: flex-start;
-}
-
-/* ── LIST MODE ─────────────────────────────────────────────────────── */
-.kanban-board.kanban-list-mode {
-    flex-direction: column;
-    overflow-x: visible;
-    gap: 16px;
-}
-.kanban-board.kanban-list-mode .kanban-column {
-    flex: 1 1 auto;
-    min-width: 100% !important;
-    max-width: 100% !important;
-    max-height: none;
-}
-.kanban-board.kanban-list-mode .kanban-column-body {
-    flex-direction: row;
-    flex-wrap: wrap;
-    gap: 10px;
-    overflow-y: visible;
-}
-.kanban-board.kanban-list-mode .ticket-card-kanban {
-    flex: 0 0 calc(50% - 5px);
-    max-width: calc(50% - 5px);
-}
-.kanban-board.kanban-list-mode .kanban-resize-handle {
-    display: none;
-}
-@media (max-width: 768px) {
-    .kanban-board.kanban-list-mode .ticket-card-kanban {
-        flex: 0 0 100%;
-        max-width: 100%;
-    }
-}
-@media (min-width: 1200px) {
-    .kanban-board.kanban-list-mode .ticket-card-kanban {
-        flex: 0 0 calc(33.33% - 7px);
-        max-width: calc(33.33% - 7px);
-    }
-}
-
-/* ── KANBAN COLUMN ─────────────────────────────────────────────────── */
-.kanban-column {
-    flex: 0 0 280px;
-    min-width: 280px;
-    max-width: 320px;
-    background: #f8fafc;
-    border: 1px solid #e2e8f0;
-    border-radius: 12px;
-    display: flex;
-    flex-direction: column;
-    max-height: calc(100vh - 220px);
-    transition: opacity 0.3s;
-    position: relative;
-}
-.kanban-column.collapsed .kanban-column-body {
-    display: none;
-}
-.kanban-column.collapsed .kanban-column-toggle i {
-    transform: rotate(-90deg);
-}
-
-/* Column header — clickable */
-.kanban-column-header {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    padding: 10px 12px;
-    border-bottom: 2px solid var(--col-color, #e2e8f0);
-    background: linear-gradient(135deg, rgba(255,255,255,0.9), rgba(248,250,252,0.95));
-    border-radius: 12px 12px 0 0;
+/* ── HEADER ROW ────────────────────────────────────────────────────── */
+.nt-header-row {
     position: sticky;
     top: 0;
-    z-index: 2;
-    cursor: pointer;
-    user-select: none;
-    transition: background 0.2s;
-}
-.kanban-column-header:hover {
-    background: linear-gradient(135deg, rgba(241,245,249,1), rgba(248,250,252,0.95));
-}
-.kanban-column-dot {
-    width: 10px;
-    height: 10px;
-    border-radius: 50%;
-    flex-shrink: 0;
-}
-.kanban-column-title {
-    font-size: 13px;
-    font-weight: 700;
-    color: #1e293b;
-    flex: 1;
-}
-.kanban-column-count {
-    background: #e2e8f0;
-    color: #475569;
-    padding: 2px 8px;
-    border-radius: 10px;
-    font-size: 11px;
-    font-weight: 700;
-    min-width: 20px;
-    text-align: center;
-}
-.kanban-column-toggle {
-    background: none;
-    border: none;
-    cursor: pointer;
-    color: #94a3b8;
-    font-size: 12px;
-    padding: 2px 4px;
-    transition: transform 0.2s;
-}
-
-/* ── COLUMN RESIZE HANDLE ──────────────────────────────────────────── */
-.kanban-resize-handle {
-    position: absolute;
-    top: 0;
-    right: -4px;
-    width: 8px;
-    height: 100%;
-    cursor: col-resize;
     z-index: 10;
-    background: transparent;
-    transition: background 0.2s;
+    background: #f8fafc;
+    border-bottom: 2px solid #e2e8f0;
 }
-.kanban-resize-handle:hover,
-.kanban-column.resizing .kanban-resize-handle {
-    background: rgba(59, 130, 246, 0.3);
-    border-radius: 4px;
-}
-.kanban-column.resizing {
-    border-color: #3b82f6;
-    box-shadow: 0 0 0 1px rgba(59, 130, 246, 0.2);
-}
-
-/* Column body */
-.kanban-column-body {
-    padding: 8px;
-    display: flex;
-    flex-direction: column;
-    gap: 8px;
-    overflow-y: auto;
-    flex: 1;
-}
-
-/* Empty state */
-.kanban-empty-col {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    padding: 30px 10px;
-    color: #cbd5e1;
-    font-size: 12px;
-    gap: 8px;
-}
-.kanban-empty-col i {
-    font-size: 24px;
-}
-
-/* ── TICKET CARD ───────────────────────────────────────────────────── */
-.ticket-card-kanban {
-    background: #fff;
-    border: 1px solid #e2e8f0;
-    border-radius: 8px;
-    padding: 10px 12px;
-    display: flex;
-    flex-direction: column;
-    gap: 6px;
-    transition: box-shadow 0.2s, border-color 0.2s, opacity 0.3s, transform 0.2s;
-    cursor: grab;
-}
-.ticket-card-kanban:hover {
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
-    border-color: #cbd5e1;
-}
-.ticket-card-kanban.dragging {
-    opacity: 0.5;
-    transform: rotate(2deg);
-    box-shadow: 0 8px 25px rgba(0, 0, 0, 0.15);
-}
-.ticket-card-kanban.hidden-by-filter {
-    display: none;
-}
-
-/* Card header */
-.ticket-card-kanban .tc-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: flex-start;
-    width: 100%;
-}
-.ticket-card-kanban .tc-meta {
-    display: flex;
-    align-items: center;
-    flex-wrap: wrap;
-    gap: 4px;
+.nt-header-row .nt-cell {
+    padding: 10px 8px;
     font-size: 11px;
+    font-weight: 700;
     color: #64748b;
-}
-.ticket-card-kanban .tc-ref {
-    font-weight: 600;
-    color: #0f172a;
-    text-decoration: none;
-    font-size: 11px;
-}
-.ticket-card-kanban .tc-ref:hover {
-    color: #3b82f6;
-    text-decoration: underline;
-}
-.ticket-card-kanban .tc-sep {
-    color: #cbd5e1;
-    font-size: 10px;
-}
-.ticket-card-kanban .tc-company {
-    color: #475569;
-    font-weight: 500;
-    font-size: 11px;
-}
-.ticket-card-kanban .tc-date,
-.ticket-card-kanban .tc-time {
-    font-size: 11px;
-}
-
-/* Assignee avatar */
-.ticket-card-kanban .tc-assignee {
-    width: 24px;
-    height: 24px;
-    border-radius: 50%;
-    background: #e2e8f0;
-    color: #475569;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    font-size: 9px;
-    font-weight: bold;
-    flex-shrink: 0;
-    overflow: hidden;
-}
-.ticket-card-kanban .tc-assignee-img {
-    width: 100%;
-    height: 100%;
-    border-radius: 50%;
-    object-fit: cover;
-}
-
-/* Severity & progress row */
-.ticket-card-kanban .tc-row-middle {
-    display: flex;
-    align-items: center;
-    gap: 4px;
-    font-size: 11px;
-}
-.ticket-card-kanban .tc-severity {
-    font-weight: 600;
-    color: #0f172a;
-}
-.ticket-card-kanban .tc-progress {
-    font-weight: 700;
-    color: #0f172a;
-}
-
-/* Title & Actions row */
-.ticket-card-kanban .tc-title-row {
-    display: flex;
-    justify-content: space-between;
-    align-items: flex-start;
-    gap: 8px;
-}
-.ticket-card-kanban .tc-title {
-    font-size: 13px;
-    font-weight: 600;
-    color: #0f172a;
-    line-height: 1.3;
-    flex: 1;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    display: -webkit-box;
-    -webkit-line-clamp: 2;
-    -webkit-box-orient: vertical;
-}
-.ticket-card-kanban .tc-actions {
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    flex-shrink: 0;
-}
-.ticket-card-kanban .tc-status-btn {
-    display: flex;
-    align-items: center;
-    gap: 4px;
-    padding: 3px 6px;
-    border: 1px solid #cbd5e1;
-    border-radius: 4px;
-    background: #fff;
-    font-size: 10px;
-    font-weight: 700;
-    color: #0f172a;
     text-transform: uppercase;
+    letter-spacing: 0.3px;
+    display: flex;
+    align-items: center;
+}
+.nt-header-link {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    color: #64748b;
+    text-decoration: none;
+    transition: color 0.15s;
     white-space: nowrap;
 }
-.ticket-card-kanban .tc-status-dot {
-    width: 8px;
-    height: 8px;
+.nt-header-link:hover { color: #1e293b; }
+.nt-header-sorted { color: #1e293b !important; font-weight: 800; }
+.nt-header-icon { font-size: 10px; opacity: 0.7; }
+.nt-header-label { display: flex; align-items: center; gap: 4px; white-space: nowrap; }
+.nt-sort-active { color: #3b82f6; font-size: 10px; }
+.nt-sort-inactive { color: #cbd5e1; font-size: 9px; }
+
+/* ── SEARCH ROW ────────────────────────────────────────────────────── */
+.nt-search-row {
+    background: #f1f5f9;
+    border-bottom: 1px solid #e2e8f0;
+}
+.nt-search-row .nt-cell {
+    padding: 4px 6px;
+}
+.nt-search-input {
+    width: 100%;
+    padding: 4px 8px;
+    border: 1px solid #e2e8f0;
+    border-radius: 4px;
+    font-size: 11px;
+    color: #1e293b;
+    background: #fff;
+    outline: none;
+    transition: border-color 0.2s;
+    box-sizing: border-box;
+}
+.nt-search-input:focus { border-color: #3b82f6; box-shadow: 0 0 0 2px rgba(59,130,246,0.1); }
+.nt-search-input::placeholder { color: #94a3b8; }
+.nt-search-select {
+    width: 100%;
+    padding: 4px 4px;
+    border: 1px solid #e2e8f0;
+    border-radius: 4px;
+    font-size: 11px;
+    color: #1e293b;
+    background: #fff;
+    outline: none;
+    cursor: pointer;
+    box-sizing: border-box;
+}
+.nt-search-select:focus { border-color: #3b82f6; }
+
+/* ── DATA ROWS ─────────────────────────────────────────────────────── */
+.nt-data-row {
+    border-bottom: 1px solid #f1f5f9;
+    transition: background 0.1s;
+}
+.nt-data-row:hover {
+    background: #fafbfd;
+}
+.nt-cell {
+    padding: 8px 8px;
+    font-size: 13px;
+    color: #1e293b;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    overflow: hidden;
+    min-height: 38px;
+}
+
+/* Ref link */
+.nt-ref-link {
+    font-weight: 600;
+    color: #1e40af;
+    text-decoration: none;
+    font-size: 12px;
+    white-space: nowrap;
+}
+.nt-ref-link:hover { text-decoration: underline; }
+
+/* Author */
+.nt-author-text {
+    font-size: 12px;
+    color: #475569;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+/* Subject */
+.nt-cell-subject .nt-cell-text {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    flex: 1;
+    font-size: 13px;
+}
+
+/* Empty value */
+.nt-empty-value { color: #cbd5e1; font-size: 12px; }
+.nt-empty { text-align: center; padding: 40px 20px; color: #94a3b8; font-size: 14px; }
+.nt-empty i { margin-right: 6px; }
+
+/* ── EDITABLE CELLS ────────────────────────────────────────────────── */
+.nt-editable {
+    cursor: pointer;
+    border-radius: 4px;
+    transition: background 0.15s;
+    position: relative;
+}
+.nt-editable:hover {
+    background: rgba(59, 130, 246, 0.05);
+}
+.nt-editable.nt-editing {
+    background: rgba(59, 130, 246, 0.08);
+    z-index: 20;
+}
+/* Inline input */
+.nt-inline-input {
+    width: 100%;
+    padding: 4px 6px;
+    border: none;
+    border-bottom: 2px solid #3b82f6;
+    background: transparent;
+    font-size: 13px;
+    color: #1e293b;
+    outline: none;
+    font-family: inherit;
+    box-sizing: border-box;
+}
+/* Inline select */
+.nt-inline-select {
+    width: 100%;
+    padding: 4px 4px;
+    border: 1px solid #3b82f6;
+    border-radius: 4px;
+    background: #fff;
+    font-size: 12px;
+    color: #1e293b;
+    outline: none;
+    cursor: pointer;
+    box-sizing: border-box;
+}
+/* Save feedback */
+.nt-cell-saving {
+    opacity: 0.5;
+    pointer-events: none;
+}
+.nt-cell-success {
+    animation: nt-flash-green 0.8s ease;
+}
+.nt-cell-error {
+    animation: nt-flash-red 1s ease;
+}
+@keyframes nt-flash-green {
+    0% { background: rgba(34,197,94,0.2); }
+    100% { background: transparent; }
+}
+@keyframes nt-flash-red {
+    0% { background: rgba(239,68,68,0.2); }
+    100% { background: transparent; }
+}
+
+/* ── SEVERITY BADGE ────────────────────────────────────────────────── */
+.nt-severity-badge {
+    padding: 2px 8px;
+    border-radius: 4px;
+    font-size: 11px;
+    font-weight: 600;
+    white-space: nowrap;
+}
+.nt-severity-low      { background: #f0fdf4; color: #15803d; }
+.nt-severity-normal   { background: #eff6ff; color: #1d4ed8; }
+.nt-severity-high     { background: #fef3c7; color: #b45309; }
+.nt-severity-blocking { background: #fef2f2; color: #dc2626; }
+
+/* ── STATUS BADGE ──────────────────────────────────────────────────── */
+.nt-status-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    padding: 3px 8px;
+    border-radius: 4px;
+    font-size: 11px;
+    font-weight: 700;
+    white-space: nowrap;
+    background: color-mix(in srgb, var(--st-color) 10%, white);
+    color: var(--st-color);
+    border: 1px solid color-mix(in srgb, var(--st-color) 25%, white);
+}
+.nt-status-dot {
+    width: 7px;
+    height: 7px;
     border-radius: 50%;
     flex-shrink: 0;
 }
-.ticket-card-kanban .tc-chat-link {
-    color: #94a3b8;
-    transition: color 0.2s;
+
+/* ── USER CHIP ─────────────────────────────────────────────────────── */
+.nt-user-chip {
     display: flex;
     align-items: center;
-    text-decoration: none;
-}
-.ticket-card-kanban .tc-chat-link:hover {
-    color: #3b82f6;
-}
-
-/* Message preview */
-.ticket-card-kanban .tc-body {
-    margin-top: 2px;
-}
-.ticket-card-kanban .tc-message-preview {
-    font-size: 12px;
-    color: #334155;
-    line-height: 1.4;
-    display: -webkit-box;
-    -webkit-line-clamp: 2;
-    -webkit-box-orient: vertical;
+    gap: 6px;
     overflow: hidden;
-    word-break: break-word;
 }
-
-/* ── DRAG & DROP FEEDBACK ──────────────────────────────────────────── */
-.kanban-column.drag-over .kanban-column-body {
-    background: rgba(59, 130, 246, 0.04);
-    border: 2px dashed #3b82f6;
-    border-radius: 8px;
-    min-height: 80px;
-}
-.kanban-column.drag-over .kanban-column-header {
-    background: linear-gradient(135deg, rgba(59, 130, 246, 0.08), rgba(248, 250, 252, 0.95));
-}
-
-.kanban-drop-placeholder {
-    border: 2px dashed #93c5fd;
-    border-radius: 8px;
-    background: rgba(59, 130, 246, 0.05);
-    min-height: 60px;
-    transition: all 0.2s;
-}
-
-/* ── RESPONSIVE ────────────────────────────────────────────────────── */
-@media (max-width: 768px) {
-    .kanban-board {
-        padding: 0 10px 90px 10px;
-        gap: 10px;
-    }
-    .kanban-column {
-        flex: 0 0 260px;
-        min-width: 260px;
-    }
-    .ticket-card-kanban {
-        padding: 8px 10px;
-        cursor: default;
-    }
-    .ticket-card-kanban[draggable="true"] {
-        -webkit-user-drag: none;
-    }
-    .kanban-resize-handle {
-        display: none;
-    }
-}
-
-@media (min-width: 1200px) {
-    .kanban-board:not(.kanban-list-mode) {
-        max-width: 1600px;
-        margin: 0 auto;
-    }
-    .kanban-board:not(.kanban-list-mode) .kanban-column {
-        flex: 1 1 0;
-        max-width: 320px;
-    }
-}
-
-/* ── LOADING SPINNER ───────────────────────────────────────────────── */
-.kanban-card-loading {
-    pointer-events: none;
-    opacity: 0.6;
-}
-.kanban-card-loading::after {
-    content: '';
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    width: 20px;
-    height: 20px;
-    margin: -10px 0 0 -10px;
-    border: 3px solid rgba(59, 130, 246, 0.3);
+.nt-user-avatar {
+    width: 22px;
+    height: 22px;
     border-radius: 50%;
-    border-top-color: #3b82f6;
-    animation: kanban-spin 0.6s linear infinite;
+    object-fit: cover;
+    flex-shrink: 0;
 }
-@keyframes kanban-spin {
-    to { transform: rotate(360deg); }
-}
-
-/* Custom scrollbar for columns */
-.kanban-column-body::-webkit-scrollbar { width: 4px; }
-.kanban-column-body::-webkit-scrollbar-track { background: transparent; }
-.kanban-column-body::-webkit-scrollbar-thumb { background: #cbd5e1; border-radius: 4px; }
-.kanban-column-body::-webkit-scrollbar-thumb:hover { background: #94a3b8; }
-
-/* Custom scrollbar for board */
-.kanban-board::-webkit-scrollbar { height: 6px; }
-.kanban-board::-webkit-scrollbar-track { background: #f1f5f9; border-radius: 3px; }
-.kanban-board::-webkit-scrollbar-thumb { background: #cbd5e1; border-radius: 3px; }
-
-/* ── ASSIGNEE PICKER DROPDOWN ──────────────────────────────────────── */
-.tc-assignee-picker {
-    cursor: pointer;
-    position: relative;
-    transition: box-shadow 0.2s;
-}
-.tc-assignee-picker:hover {
-    box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.3);
-}
-.tc-assignee-caret {
-    position: absolute;
-    bottom: -2px;
-    right: -2px;
-    font-size: 8px;
-    color: #94a3b8;
-    background: #fff;
-    border-radius: 50%;
-    width: 12px;
-    height: 12px;
+.nt-user-initials {
     display: flex;
     align-items: center;
     justify-content: center;
-    box-shadow: 0 1px 3px rgba(0,0,0,0.15);
+    background: #e2e8f0;
+    color: #475569;
+    font-size: 9px;
+    font-weight: bold;
 }
-.tc-assignee-picker:hover .tc-assignee-caret {
-    color: #3b82f6;
+.nt-user-name {
+    font-size: 12px;
+    color: #1e293b;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
-/* Dropdown overlay */
-.assignee-dropdown {
+/* ── TAG CHIPS ─────────────────────────────────────────────────────── */
+.nt-cell-tags {
+    flex-wrap: wrap;
+    gap: 4px;
+}
+.nt-tag-chip {
+    display: inline-flex;
+    align-items: center;
+    padding: 2px 8px;
+    border-radius: 4px;
+    font-size: 10px;
+    font-weight: 600;
+    white-space: nowrap;
+    background: color-mix(in srgb, var(--tag-color) 15%, white);
+    color: color-mix(in srgb, var(--tag-color) 80%, black);
+    border: 1px solid color-mix(in srgb, var(--tag-color) 30%, white);
+}
+
+/* ── TAG PICKER DROPDOWN ───────────────────────────────────────────── */
+.nt-tag-picker {
     position: absolute;
     top: 100%;
-    right: 0;
+    left: 0;
     z-index: 100;
     background: #fff;
     border: 1px solid #e2e8f0;
-    border-radius: 10px;
-    box-shadow: 0 10px 25px rgba(0,0,0,0.12), 0 4px 10px rgba(0,0,0,0.06);
+    border-radius: 8px;
+    box-shadow: 0 8px 20px rgba(0,0,0,0.12);
+    min-width: 200px;
+    max-height: 250px;
+    overflow-y: auto;
+    padding: 4px;
+    animation: nt-dd-in 0.12s ease;
+}
+@keyframes nt-dd-in {
+    from { opacity: 0; transform: translateY(-4px); }
+    to   { opacity: 1; transform: translateY(0); }
+}
+.nt-tag-picker-item {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 10px;
+    border: none;
+    background: transparent;
+    width: 100%;
+    text-align: left;
+    font-size: 12px;
+    cursor: pointer;
+    border-radius: 4px;
+    transition: background 0.1s;
+}
+.nt-tag-picker-item:hover { background: #f1f5f9; }
+.nt-tag-picker-item.selected { background: #eff6ff; }
+.nt-tag-picker-dot {
+    width: 10px;
+    height: 10px;
+    border-radius: 3px;
+    flex-shrink: 0;
+}
+.nt-tag-picker-check {
+    margin-left: auto;
+    color: #2563eb;
+    font-size: 11px;
+}
+
+/* ── USER PICKER (inline table) ────────────────────────────────────── */
+.nt-user-picker {
+    position: absolute;
+    top: 100%;
+    left: 0;
+    z-index: 100;
+    background: #fff;
+    border: 1px solid #e2e8f0;
+    border-radius: 8px;
+    box-shadow: 0 8px 20px rgba(0,0,0,0.12);
     min-width: 200px;
     max-height: 280px;
     overflow-y: auto;
     padding: 4px;
-    animation: assignee-dd-in 0.15s ease;
+    animation: nt-dd-in 0.12s ease;
 }
-@keyframes assignee-dd-in {
-    from { opacity: 0; transform: translateY(-4px) scale(0.97); }
-    to   { opacity: 1; transform: translateY(0) scale(1); }
-}
-.assignee-dropdown-item {
+.nt-user-picker-item {
     display: flex;
     align-items: center;
     gap: 8px;
-    padding: 7px 10px;
+    padding: 6px 10px;
     border: none;
     background: transparent;
     width: 100%;
     text-align: left;
     font-size: 12px;
     font-weight: 500;
-    color: #1e293b;
     cursor: pointer;
-    border-radius: 6px;
-    transition: background 0.15s;
-    white-space: nowrap;
+    border-radius: 4px;
+    color: #1e293b;
+    transition: background 0.1s;
 }
-.assignee-dropdown-item:hover {
-    background: #f1f5f9;
-}
-.assignee-dropdown-item.selected {
-    background: #eff6ff;
-    color: #2563eb;
-    font-weight: 700;
-}
-.assignee-dropdown-item .dd-avatar {
+.nt-user-picker-item:hover { background: #f1f5f9; }
+.nt-user-picker-item.selected { background: #eff6ff; color: #2563eb; font-weight: 700; }
+.nt-user-picker-avatar {
     width: 22px;
     height: 22px;
     border-radius: 50%;
@@ -703,19 +416,112 @@
     flex-shrink: 0;
     overflow: hidden;
 }
-.assignee-dropdown-item .dd-avatar img {
+.nt-user-picker-avatar img {
     width: 100%;
     height: 100%;
     object-fit: cover;
     border-radius: 50%;
 }
-.assignee-dropdown-item .dd-check {
-    margin-left: auto;
-    color: #2563eb;
-    font-size: 11px;
+.nt-user-picker-check { margin-left: auto; color: #2563eb; font-size: 11px; }
+.nt-user-picker-sep { height: 1px; background: #e2e8f0; margin: 4px 6px; }
+
+/* ══════════════════════════════════════════════════════════════════════
+   KANBAN VIEW (existing styles preserved)
+   ══════════════════════════════════════════════════════════════════════ */
+
+/* Filter bar */
+.kanban-filters { padding: 10px 15px 0 15px; overflow-x: auto; }
+.kanban-filter-chips { display: flex; gap: 8px; align-items: center; min-width: max-content; }
+.kanban-chip {
+    display: flex; align-items: center; gap: 6px; padding: 6px 12px;
+    border: 1.5px solid #e2e8f0; border-radius: 20px; background: #fff;
+    color: #475569; font-size: 12px; font-weight: 600; cursor: pointer;
+    transition: all 0.2s; white-space: nowrap; flex-shrink: 0;
 }
-.assignee-dropdown-separator {
-    height: 1px;
-    background: #e2e8f0;
-    margin: 4px 6px;
+.kanban-chip:hover { border-color: #94a3b8; background: #f8fafc; }
+.kanban-chip.active { background: #1e293b; border-color: #1e293b; color: #fff; box-shadow: 0 2px 8px rgba(30,41,59,0.25); }
+.kanban-chip .chip-count { background: rgba(0,0,0,0.08); padding: 1px 7px; border-radius: 10px; font-size: 11px; font-weight: 700; }
+.kanban-chip.active .chip-count { background: rgba(255,255,255,0.2); }
+.kanban-avatar { width: 22px; height: 22px; border-radius: 50%; background: #e2e8f0; color: #475569; display: flex; align-items: center; justify-content: center; font-size: 9px; font-weight: bold; flex-shrink: 0; }
+
+/* Board */
+.kanban-board { display: flex; gap: 12px; padding: 10px 15px 90px 15px; overflow-x: auto; min-height: calc(100vh - 180px); align-items: flex-start; }
+.kanban-column {
+    flex: 0 0 280px; min-width: 280px; max-width: 320px; background: #f8fafc;
+    border: 1px solid #e2e8f0; border-radius: 12px; display: flex; flex-direction: column;
+    max-height: calc(100vh - 180px); position: relative;
 }
+.kanban-column.collapsed .kanban-column-body { display: none; }
+.kanban-column.collapsed .kanban-column-toggle i { transform: rotate(-90deg); }
+.kanban-column-header {
+    display: flex; align-items: center; gap: 8px; padding: 10px 12px;
+    border-bottom: 2px solid var(--col-color, #e2e8f0); border-radius: 12px 12px 0 0;
+    cursor: pointer; user-select: none;
+    background: linear-gradient(135deg, rgba(255,255,255,0.9), rgba(248,250,252,0.95));
+}
+.kanban-column-header:hover { background: linear-gradient(135deg, rgba(241,245,249,1), rgba(248,250,252,0.95)); }
+.kanban-column-dot { width: 10px; height: 10px; border-radius: 50%; flex-shrink: 0; }
+.kanban-column-title { font-size: 13px; font-weight: 700; color: #1e293b; flex: 1; }
+.kanban-column-count { background: #e2e8f0; color: #475569; padding: 2px 8px; border-radius: 10px; font-size: 11px; font-weight: 700; }
+.kanban-column-toggle { background: none; border: none; cursor: pointer; color: #94a3b8; font-size: 12px; padding: 2px 4px; }
+.kanban-column-body { padding: 8px; display: flex; flex-direction: column; gap: 8px; overflow-y: auto; flex: 1; }
+.kanban-empty-col { display: flex; flex-direction: column; align-items: center; padding: 30px 10px; color: #cbd5e1; font-size: 12px; gap: 8px; }
+.kanban-empty-col i { font-size: 24px; }
+
+/* Cards */
+.ticket-card-kanban { background: #fff; border: 1px solid #e2e8f0; border-radius: 8px; padding: 10px 12px; display: flex; flex-direction: column; gap: 6px; transition: box-shadow 0.2s, border-color 0.2s; cursor: grab; }
+.ticket-card-kanban:hover { box-shadow: 0 4px 12px rgba(0,0,0,0.08); border-color: #cbd5e1; }
+.ticket-card-kanban.dragging { opacity: 0.5; transform: rotate(2deg); }
+.ticket-card-kanban.hidden-by-filter { display: none; }
+.tc-header { display: flex; justify-content: space-between; align-items: flex-start; }
+.tc-meta { display: flex; align-items: center; flex-wrap: wrap; gap: 4px; font-size: 11px; color: #64748b; }
+.tc-ref { font-weight: 600; color: #0f172a; text-decoration: none; font-size: 11px; }
+.tc-ref:hover { color: #3b82f6; text-decoration: underline; }
+.tc-sep { color: #cbd5e1; font-size: 10px; }
+.tc-company { color: #475569; font-weight: 500; font-size: 11px; }
+.tc-assignee { width: 24px; height: 24px; border-radius: 50%; background: #e2e8f0; color: #475569; display: flex; align-items: center; justify-content: center; font-size: 9px; font-weight: bold; flex-shrink: 0; overflow: hidden; cursor: pointer; position: relative; }
+.tc-assignee:hover { box-shadow: 0 0 0 2px rgba(59,130,246,0.3); }
+.tc-assignee-img { width: 100%; height: 100%; border-radius: 50%; object-fit: cover; }
+.tc-assignee-caret { position: absolute; bottom: -2px; right: -2px; font-size: 8px; color: #94a3b8; background: #fff; border-radius: 50%; width: 12px; height: 12px; display: flex; align-items: center; justify-content: center; box-shadow: 0 1px 3px rgba(0,0,0,0.15); }
+.tc-row-middle { display: flex; align-items: center; gap: 4px; font-size: 11px; }
+.tc-severity { font-weight: 600; color: #0f172a; }
+.tc-progress { font-weight: 700; color: #0f172a; }
+.tc-title-row { display: flex; justify-content: space-between; align-items: flex-start; gap: 8px; }
+.tc-title { font-size: 13px; font-weight: 600; color: #0f172a; line-height: 1.3; flex: 1; overflow: hidden; text-overflow: ellipsis; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; }
+.tc-status-btn { display: flex; align-items: center; gap: 4px; padding: 3px 6px; border: 1px solid #cbd5e1; border-radius: 4px; background: #fff; font-size: 10px; font-weight: 700; white-space: nowrap; }
+.tc-status-dot { width: 8px; height: 8px; border-radius: 50%; flex-shrink: 0; }
+.tc-body { margin-top: 2px; }
+.tc-message-preview { font-size: 12px; color: #334155; line-height: 1.4; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden; }
+
+/* Drag & Drop */
+.kanban-column.drag-over .kanban-column-body { background: rgba(59,130,246,0.04); border: 2px dashed #3b82f6; border-radius: 8px; min-height: 80px; }
+.kanban-drop-placeholder { border: 2px dashed #93c5fd; border-radius: 8px; background: rgba(59,130,246,0.05); min-height: 60px; }
+
+/* Assignee dropdown (Kanban) */
+.assignee-dropdown { position: absolute; top: 100%; right: 0; z-index: 100; background: #fff; border: 1px solid #e2e8f0; border-radius: 10px; box-shadow: 0 10px 25px rgba(0,0,0,0.12); min-width: 200px; max-height: 280px; overflow-y: auto; padding: 4px; animation: nt-dd-in 0.12s ease; }
+.assignee-dropdown-item { display: flex; align-items: center; gap: 8px; padding: 7px 10px; border: none; background: transparent; width: 100%; text-align: left; font-size: 12px; font-weight: 500; color: #1e293b; cursor: pointer; border-radius: 6px; transition: background 0.15s; }
+.assignee-dropdown-item:hover { background: #f1f5f9; }
+.assignee-dropdown-item.selected { background: #eff6ff; color: #2563eb; font-weight: 700; }
+.dd-avatar { width: 22px; height: 22px; border-radius: 50%; background: #e2e8f0; color: #475569; display: flex; align-items: center; justify-content: center; font-size: 9px; font-weight: bold; overflow: hidden; }
+.dd-avatar img { width: 100%; height: 100%; object-fit: cover; border-radius: 50%; }
+.dd-check { margin-left: auto; color: #2563eb; font-size: 11px; }
+.assignee-dropdown-separator { height: 1px; background: #e2e8f0; margin: 4px 6px; }
+
+/* Loading spinner */
+.kanban-card-loading { pointer-events: none; opacity: 0.6; }
+
+/* ── RESPONSIVE ────────────────────────────────────────────────────── */
+@media (max-width: 768px) {
+    .kanban-board { padding: 0 10px 90px 10px; gap: 10px; }
+    .kanban-column { flex: 0 0 260px; min-width: 260px; }
+    .ticket-card-kanban { padding: 8px 10px; cursor: default; }
+    .notion-table-wrapper { padding: 0 6px 90px 6px; }
+}
+
+/* Scrollbars */
+.kanban-column-body::-webkit-scrollbar { width: 4px; }
+.kanban-column-body::-webkit-scrollbar-thumb { background: #cbd5e1; border-radius: 4px; }
+.kanban-board::-webkit-scrollbar { height: 6px; }
+.kanban-board::-webkit-scrollbar-thumb { background: #cbd5e1; border-radius: 3px; }
+.notion-table-wrapper::-webkit-scrollbar { height: 6px; }
+.notion-table-wrapper::-webkit-scrollbar-thumb { background: #cbd5e1; border-radius: 3px; }

--- a/css/reedcrm_tickets_kanban.css
+++ b/css/reedcrm_tickets_kanban.css
@@ -1,0 +1,617 @@
+﻿/* =====================================================================
+ *  ReedCRM — Kanban Tickets PWA Stylesheet v3
+ *  File: css/reedcrm_tickets_kanban.css
+ * ===================================================================== */
+
+/* ── VIEW TOGGLE ───────────────────────────────────────────────────── */
+.kanban-view-toggle {
+    display: flex;
+    align-items: center;
+    gap: 2px;
+    background: #e2e8f0;
+    border-radius: 8px;
+    padding: 2px;
+    flex-shrink: 0;
+}
+.view-toggle-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 30px;
+    height: 26px;
+    border: none;
+    border-radius: 6px;
+    background: transparent;
+    color: #64748b;
+    font-size: 12px;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+.view-toggle-btn:hover {
+    background: rgba(255,255,255,0.5);
+    color: #1e293b;
+}
+.view-toggle-btn.active {
+    background: #fff;
+    color: #1e293b;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+}
+
+/* ── KANBAN FILTER BAR ─────────────────────────────────────────────── */
+.kanban-filters {
+    padding: 10px 15px 0 15px;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+}
+.kanban-filter-chips {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+    min-width: max-content;
+}
+.kanban-chip {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 12px;
+    border: 1.5px solid #e2e8f0;
+    border-radius: 20px;
+    background: #fff;
+    color: #475569;
+    font-size: 12px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    white-space: nowrap;
+    flex-shrink: 0;
+}
+.kanban-chip:hover {
+    border-color: #94a3b8;
+    background: #f8fafc;
+}
+.kanban-chip.active {
+    background: #1e293b;
+    border-color: #1e293b;
+    color: #fff;
+    box-shadow: 0 2px 8px rgba(30, 41, 59, 0.25);
+}
+.kanban-chip .chip-count {
+    background: rgba(0, 0, 0, 0.08);
+    padding: 1px 7px;
+    border-radius: 10px;
+    font-size: 11px;
+    font-weight: 700;
+    min-width: 18px;
+    text-align: center;
+}
+.kanban-chip.active .chip-count {
+    background: rgba(255, 255, 255, 0.2);
+}
+
+/* Avatar in chip */
+.kanban-avatar {
+    width: 22px;
+    height: 22px;
+    border-radius: 50%;
+    background: #e2e8f0;
+    color: #475569;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 9px;
+    font-weight: bold;
+    flex-shrink: 0;
+    overflow: hidden;
+}
+.kanban-avatar-placeholder {
+    background: #cbd5e1;
+    color: #64748b;
+    font-size: 10px;
+}
+.kanban-avatar-img {
+    width: 22px;
+    height: 22px;
+    border-radius: 50%;
+    object-fit: cover;
+}
+.kanban-chip.active .kanban-avatar {
+    background: rgba(255, 255, 255, 0.2);
+    color: #fff;
+}
+
+/* ── STATUS FILTER BAR (Notion-like) ───────────────────────────────── */
+.kanban-status-filters {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 8px 0 10px 0;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    min-width: max-content;
+}
+.status-filter-label {
+    font-size: 11px;
+    font-weight: 700;
+    color: #94a3b8;
+    white-space: nowrap;
+    margin-right: 4px;
+    display: flex;
+    align-items: center;
+    gap: 4px;
+}
+.status-filter-label i {
+    font-size: 10px;
+}
+.status-filter-chip {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+    padding: 4px 10px;
+    border: 1px solid #e2e8f0;
+    border-radius: 6px;
+    background: #fff;
+    color: #475569;
+    font-size: 11px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    white-space: nowrap;
+    flex-shrink: 0;
+}
+.status-filter-chip:hover {
+    border-color: #94a3b8;
+    background: #f8fafc;
+}
+.status-filter-chip.active {
+    background: #f8fafc;
+    border-color: #cbd5e1;
+}
+.status-filter-chip:not(.active) {
+    opacity: 0.45;
+    background: #f1f5f9;
+    text-decoration: line-through;
+}
+.sf-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    flex-shrink: 0;
+}
+.sf-label {
+    font-size: 11px;
+}
+.sf-count {
+    background: rgba(0, 0, 0, 0.06);
+    padding: 0 5px;
+    border-radius: 6px;
+    font-size: 10px;
+    font-weight: 700;
+    min-width: 14px;
+    text-align: center;
+}
+
+/* ── KANBAN BOARD ──────────────────────────────────────────────────── */
+.kanban-board {
+    display: flex;
+    gap: 12px;
+    padding: 0 15px 90px 15px;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    min-height: calc(100vh - 220px);
+    align-items: flex-start;
+}
+
+/* ── LIST MODE ─────────────────────────────────────────────────────── */
+.kanban-board.kanban-list-mode {
+    flex-direction: column;
+    overflow-x: visible;
+    gap: 16px;
+}
+.kanban-board.kanban-list-mode .kanban-column {
+    flex: 1 1 auto;
+    min-width: 100% !important;
+    max-width: 100% !important;
+    max-height: none;
+}
+.kanban-board.kanban-list-mode .kanban-column-body {
+    flex-direction: row;
+    flex-wrap: wrap;
+    gap: 10px;
+    overflow-y: visible;
+}
+.kanban-board.kanban-list-mode .ticket-card-kanban {
+    flex: 0 0 calc(50% - 5px);
+    max-width: calc(50% - 5px);
+}
+.kanban-board.kanban-list-mode .kanban-resize-handle {
+    display: none;
+}
+@media (max-width: 768px) {
+    .kanban-board.kanban-list-mode .ticket-card-kanban {
+        flex: 0 0 100%;
+        max-width: 100%;
+    }
+}
+@media (min-width: 1200px) {
+    .kanban-board.kanban-list-mode .ticket-card-kanban {
+        flex: 0 0 calc(33.33% - 7px);
+        max-width: calc(33.33% - 7px);
+    }
+}
+
+/* ── KANBAN COLUMN ─────────────────────────────────────────────────── */
+.kanban-column {
+    flex: 0 0 280px;
+    min-width: 280px;
+    max-width: 320px;
+    background: #f8fafc;
+    border: 1px solid #e2e8f0;
+    border-radius: 12px;
+    display: flex;
+    flex-direction: column;
+    max-height: calc(100vh - 220px);
+    transition: opacity 0.3s;
+    position: relative;
+}
+.kanban-column.collapsed .kanban-column-body {
+    display: none;
+}
+.kanban-column.collapsed .kanban-column-toggle i {
+    transform: rotate(-90deg);
+}
+
+/* Column header — clickable */
+.kanban-column-header {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 10px 12px;
+    border-bottom: 2px solid var(--col-color, #e2e8f0);
+    background: linear-gradient(135deg, rgba(255,255,255,0.9), rgba(248,250,252,0.95));
+    border-radius: 12px 12px 0 0;
+    position: sticky;
+    top: 0;
+    z-index: 2;
+    cursor: pointer;
+    user-select: none;
+    transition: background 0.2s;
+}
+.kanban-column-header:hover {
+    background: linear-gradient(135deg, rgba(241,245,249,1), rgba(248,250,252,0.95));
+}
+.kanban-column-dot {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    flex-shrink: 0;
+}
+.kanban-column-title {
+    font-size: 13px;
+    font-weight: 700;
+    color: #1e293b;
+    flex: 1;
+}
+.kanban-column-count {
+    background: #e2e8f0;
+    color: #475569;
+    padding: 2px 8px;
+    border-radius: 10px;
+    font-size: 11px;
+    font-weight: 700;
+    min-width: 20px;
+    text-align: center;
+}
+.kanban-column-toggle {
+    background: none;
+    border: none;
+    cursor: pointer;
+    color: #94a3b8;
+    font-size: 12px;
+    padding: 2px 4px;
+    transition: transform 0.2s;
+}
+
+/* ── COLUMN RESIZE HANDLE ──────────────────────────────────────────── */
+.kanban-resize-handle {
+    position: absolute;
+    top: 0;
+    right: -4px;
+    width: 8px;
+    height: 100%;
+    cursor: col-resize;
+    z-index: 10;
+    background: transparent;
+    transition: background 0.2s;
+}
+.kanban-resize-handle:hover,
+.kanban-column.resizing .kanban-resize-handle {
+    background: rgba(59, 130, 246, 0.3);
+    border-radius: 4px;
+}
+.kanban-column.resizing {
+    border-color: #3b82f6;
+    box-shadow: 0 0 0 1px rgba(59, 130, 246, 0.2);
+}
+
+/* Column body */
+.kanban-column-body {
+    padding: 8px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    overflow-y: auto;
+    flex: 1;
+}
+
+/* Empty state */
+.kanban-empty-col {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 30px 10px;
+    color: #cbd5e1;
+    font-size: 12px;
+    gap: 8px;
+}
+.kanban-empty-col i {
+    font-size: 24px;
+}
+
+/* ── TICKET CARD ───────────────────────────────────────────────────── */
+.ticket-card-kanban {
+    background: #fff;
+    border: 1px solid #e2e8f0;
+    border-radius: 8px;
+    padding: 10px 12px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    transition: box-shadow 0.2s, border-color 0.2s, opacity 0.3s, transform 0.2s;
+    cursor: grab;
+}
+.ticket-card-kanban:hover {
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+    border-color: #cbd5e1;
+}
+.ticket-card-kanban.dragging {
+    opacity: 0.5;
+    transform: rotate(2deg);
+    box-shadow: 0 8px 25px rgba(0, 0, 0, 0.15);
+}
+.ticket-card-kanban.hidden-by-filter {
+    display: none;
+}
+
+/* Card header */
+.ticket-card-kanban .tc-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    width: 100%;
+}
+.ticket-card-kanban .tc-meta {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 4px;
+    font-size: 11px;
+    color: #64748b;
+}
+.ticket-card-kanban .tc-ref {
+    font-weight: 600;
+    color: #0f172a;
+    text-decoration: none;
+    font-size: 11px;
+}
+.ticket-card-kanban .tc-ref:hover {
+    color: #3b82f6;
+    text-decoration: underline;
+}
+.ticket-card-kanban .tc-sep {
+    color: #cbd5e1;
+    font-size: 10px;
+}
+.ticket-card-kanban .tc-company {
+    color: #475569;
+    font-weight: 500;
+    font-size: 11px;
+}
+.ticket-card-kanban .tc-date,
+.ticket-card-kanban .tc-time {
+    font-size: 11px;
+}
+
+/* Assignee avatar */
+.ticket-card-kanban .tc-assignee {
+    width: 24px;
+    height: 24px;
+    border-radius: 50%;
+    background: #e2e8f0;
+    color: #475569;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 9px;
+    font-weight: bold;
+    flex-shrink: 0;
+    overflow: hidden;
+}
+.ticket-card-kanban .tc-assignee-img {
+    width: 100%;
+    height: 100%;
+    border-radius: 50%;
+    object-fit: cover;
+}
+
+/* Severity & progress row */
+.ticket-card-kanban .tc-row-middle {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 11px;
+}
+.ticket-card-kanban .tc-severity {
+    font-weight: 600;
+    color: #0f172a;
+}
+.ticket-card-kanban .tc-progress {
+    font-weight: 700;
+    color: #0f172a;
+}
+
+/* Title & Actions row */
+.ticket-card-kanban .tc-title-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 8px;
+}
+.ticket-card-kanban .tc-title {
+    font-size: 13px;
+    font-weight: 600;
+    color: #0f172a;
+    line-height: 1.3;
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+}
+.ticket-card-kanban .tc-actions {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    flex-shrink: 0;
+}
+.ticket-card-kanban .tc-status-btn {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    padding: 3px 6px;
+    border: 1px solid #cbd5e1;
+    border-radius: 4px;
+    background: #fff;
+    font-size: 10px;
+    font-weight: 700;
+    color: #0f172a;
+    text-transform: uppercase;
+    white-space: nowrap;
+}
+.ticket-card-kanban .tc-status-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    flex-shrink: 0;
+}
+.ticket-card-kanban .tc-chat-link {
+    color: #94a3b8;
+    transition: color 0.2s;
+    display: flex;
+    align-items: center;
+    text-decoration: none;
+}
+.ticket-card-kanban .tc-chat-link:hover {
+    color: #3b82f6;
+}
+
+/* Message preview */
+.ticket-card-kanban .tc-body {
+    margin-top: 2px;
+}
+.ticket-card-kanban .tc-message-preview {
+    font-size: 12px;
+    color: #334155;
+    line-height: 1.4;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+    word-break: break-word;
+}
+
+/* ── DRAG & DROP FEEDBACK ──────────────────────────────────────────── */
+.kanban-column.drag-over .kanban-column-body {
+    background: rgba(59, 130, 246, 0.04);
+    border: 2px dashed #3b82f6;
+    border-radius: 8px;
+    min-height: 80px;
+}
+.kanban-column.drag-over .kanban-column-header {
+    background: linear-gradient(135deg, rgba(59, 130, 246, 0.08), rgba(248, 250, 252, 0.95));
+}
+
+.kanban-drop-placeholder {
+    border: 2px dashed #93c5fd;
+    border-radius: 8px;
+    background: rgba(59, 130, 246, 0.05);
+    min-height: 60px;
+    transition: all 0.2s;
+}
+
+/* ── RESPONSIVE ────────────────────────────────────────────────────── */
+@media (max-width: 768px) {
+    .kanban-board {
+        padding: 0 10px 90px 10px;
+        gap: 10px;
+    }
+    .kanban-column {
+        flex: 0 0 260px;
+        min-width: 260px;
+    }
+    .ticket-card-kanban {
+        padding: 8px 10px;
+        cursor: default;
+    }
+    .ticket-card-kanban[draggable="true"] {
+        -webkit-user-drag: none;
+    }
+    .kanban-resize-handle {
+        display: none;
+    }
+}
+
+@media (min-width: 1200px) {
+    .kanban-board:not(.kanban-list-mode) {
+        max-width: 1600px;
+        margin: 0 auto;
+    }
+    .kanban-board:not(.kanban-list-mode) .kanban-column {
+        flex: 1 1 0;
+        max-width: 320px;
+    }
+}
+
+/* ── LOADING SPINNER ───────────────────────────────────────────────── */
+.kanban-card-loading {
+    pointer-events: none;
+    opacity: 0.6;
+}
+.kanban-card-loading::after {
+    content: '';
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 20px;
+    height: 20px;
+    margin: -10px 0 0 -10px;
+    border: 3px solid rgba(59, 130, 246, 0.3);
+    border-radius: 50%;
+    border-top-color: #3b82f6;
+    animation: kanban-spin 0.6s linear infinite;
+}
+@keyframes kanban-spin {
+    to { transform: rotate(360deg); }
+}
+
+/* Custom scrollbar for columns */
+.kanban-column-body::-webkit-scrollbar { width: 4px; }
+.kanban-column-body::-webkit-scrollbar-track { background: transparent; }
+.kanban-column-body::-webkit-scrollbar-thumb { background: #cbd5e1; border-radius: 4px; }
+.kanban-column-body::-webkit-scrollbar-thumb:hover { background: #94a3b8; }
+
+/* Custom scrollbar for board */
+.kanban-board::-webkit-scrollbar { height: 6px; }
+.kanban-board::-webkit-scrollbar-track { background: #f1f5f9; border-radius: 3px; }
+.kanban-board::-webkit-scrollbar-thumb { background: #cbd5e1; border-radius: 3px; }

--- a/js/reedcrm_tickets_kanban.js
+++ b/js/reedcrm_tickets_kanban.js
@@ -1,0 +1,505 @@
+﻿/**
+ * @file    js/reedcrm_tickets_kanban.js
+ * @ingroup reedcrm
+ * @brief   Kanban board interactions: filter, search, drag & drop, view toggle, column resize
+ */
+(function () {
+    'use strict';
+
+    var isMobile = /Mobi|Android|iPhone|iPad/i.test(navigator.userAgent) || window.innerWidth < 768;
+
+    /** @type {Object<string, {label: string, color: string}>} Dolibarr 23 Ticket status map */
+    var STATUS_MAP = {
+        '0': { label: 'Non lu',         color: '#e74c3c' },
+        '1': { label: 'Lu',             color: '#f39c12' },
+        '2': { label: 'Assign\u00e9',   color: '#f1c40f' },
+        '3': { label: 'En cours',       color: '#3498db' },
+        '5': { label: "Besoin d'info",  color: '#e67e22' },
+        '7': { label: 'En attente',     color: '#9b59b6' },
+        '8': { label: 'Ferm\u00e9',     color: '#2ecc71' },
+        '9': { label: 'Annul\u00e9',    color: '#7f8c8d' }
+    };
+
+    document.addEventListener('DOMContentLoaded', function () {
+        initAssigneeFilter();
+        initSearchFilter();
+        initColumnToggle();
+        initViewToggle();
+        initStatusFilter();
+        if (!isMobile) {
+            initDragAndDrop();
+            initColumnResize();
+        } else {
+            document.querySelectorAll('.ticket-card-kanban').forEach(function (card) {
+                card.setAttribute('draggable', 'false');
+                card.style.cursor = 'default';
+            });
+        }
+    });
+
+    // ── VIEW TOGGLE (Kanban / List) ───────────────────────────────────
+    /**
+     * @description Toggle between Kanban board and list view
+     */
+    function initViewToggle() {
+        var toggleBtns = document.querySelectorAll('.view-toggle-btn');
+        var board = document.getElementById('kanban-board');
+        if (!board || !toggleBtns.length) return;
+
+        toggleBtns.forEach(function (btn) {
+            btn.addEventListener('click', function () {
+                toggleBtns.forEach(function (b) { b.classList.remove('active'); });
+                btn.classList.add('active');
+                var viewMode = btn.getAttribute('data-view');
+                if (viewMode === 'list') {
+                    board.classList.add('kanban-list-mode');
+                } else {
+                    board.classList.remove('kanban-list-mode');
+                }
+            });
+        });
+    }
+
+    // ── STATUS FILTER (Notion-like column visibility toggles) ─────────
+    /**
+     * @description Creates status filter chips below the assignee filter to show/hide columns
+     */
+    function initStatusFilter() {
+        var filtersContainer = document.getElementById('kanban-filters');
+        if (!filtersContainer) return;
+
+        var statusRow = document.createElement('div');
+        statusRow.className = 'kanban-status-filters';
+        statusRow.id = 'kanban-status-filters';
+
+        // Label
+        var label = document.createElement('span');
+        label.className = 'status-filter-label';
+        label.innerHTML = '<i class="fas fa-filter"></i> Statuts';
+        statusRow.appendChild(label);
+
+        // One toggle per status column
+        document.querySelectorAll('.kanban-column').forEach(function (col) {
+            var st = col.getAttribute('data-status');
+            var info = STATUS_MAP[st];
+            if (!info) return;
+
+            var btn = document.createElement('button');
+            btn.className = 'status-filter-chip active';
+            btn.setAttribute('data-status-filter', st);
+            btn.title = 'Afficher/masquer ' + info.label;
+            btn.innerHTML = '<span class="sf-dot" style="background:' + info.color + '"></span>'
+                + '<span class="sf-label">' + info.label + '</span>'
+                + '<span class="sf-count" id="sf-count-' + st + '">' + (col.querySelectorAll('.ticket-card-kanban').length) + '</span>';
+
+            btn.addEventListener('click', function () {
+                btn.classList.toggle('active');
+                var isVisible = btn.classList.contains('active');
+                col.style.display = isVisible ? '' : 'none';
+            });
+
+            statusRow.appendChild(btn);
+        });
+
+        filtersContainer.appendChild(statusRow);
+    }
+
+    // ── COLUMN TOGGLE (click header to collapse) ──────────────────────
+    /**
+     * @description All column headers are clickable to toggle collapse
+     */
+    function initColumnToggle() {
+        document.querySelectorAll('.kanban-column-header').forEach(function (header) {
+            // The toggle button itself
+            var toggleBtn = header.querySelector('.kanban-column-toggle');
+
+            // Make the entire header clickable (except toggle btn which has its own handler)
+            header.style.cursor = 'pointer';
+            header.addEventListener('click', function (e) {
+                // Don't double-trigger if clicking the toggle button
+                if (toggleBtn && (e.target === toggleBtn || toggleBtn.contains(e.target))) return;
+                var col = header.closest('.kanban-column');
+                if (col) {
+                    col.classList.toggle('collapsed');
+                    // Update chevron
+                    var icon = header.querySelector('.kanban-column-toggle i');
+                    if (icon) {
+                        // Icon rotation is handled by CSS
+                    }
+                }
+            });
+
+            if (toggleBtn) {
+                toggleBtn.addEventListener('click', function (e) {
+                    e.stopPropagation();
+                    var col = toggleBtn.closest('.kanban-column');
+                    if (col) col.classList.toggle('collapsed');
+                });
+            }
+        });
+    }
+
+    // ── COLUMN RESIZE (Notion-like drag to resize) ────────────────────
+    /**
+     * @description Adds resize handles to Kanban columns for width adjustment
+     */
+    function initColumnResize() {
+        var columns = document.querySelectorAll('.kanban-column');
+        columns.forEach(function (col) {
+            var handle = document.createElement('div');
+            handle.className = 'kanban-resize-handle';
+            handle.title = 'Ajuster la largeur';
+            col.appendChild(handle);
+
+            var startX, startWidth;
+
+            handle.addEventListener('mousedown', function (e) {
+                e.preventDefault();
+                e.stopPropagation();
+                startX = e.clientX;
+                startWidth = col.offsetWidth;
+                col.classList.add('resizing');
+                document.body.style.cursor = 'col-resize';
+                document.body.style.userSelect = 'none';
+
+                function onMouseMove(ev) {
+                    var diff = ev.clientX - startX;
+                    var newWidth = Math.max(200, Math.min(600, startWidth + diff));
+                    col.style.flex = '0 0 ' + newWidth + 'px';
+                    col.style.minWidth = newWidth + 'px';
+                    col.style.maxWidth = newWidth + 'px';
+                }
+
+                function onMouseUp() {
+                    col.classList.remove('resizing');
+                    document.body.style.cursor = '';
+                    document.body.style.userSelect = '';
+                    document.removeEventListener('mousemove', onMouseMove);
+                    document.removeEventListener('mouseup', onMouseUp);
+                }
+
+                document.addEventListener('mousemove', onMouseMove);
+                document.addEventListener('mouseup', onMouseUp);
+            });
+        });
+    }
+
+    // ── ASSIGNEE FILTER ───────────────────────────────────────────────
+    /**
+     * @description Filter tickets by assigned user via chip buttons
+     */
+    function initAssigneeFilter() {
+        var chips = document.querySelectorAll('.kanban-chip[data-filter-user]');
+        chips.forEach(function (chip) {
+            chip.addEventListener('click', function () {
+                chips.forEach(function (c) { c.classList.remove('active'); });
+                chip.classList.add('active');
+                applyFilters();
+            });
+        });
+    }
+
+    // ── SEARCH FILTER ─────────────────────────────────────────────────
+    /**
+     * @description Real-time text search across ticket cards
+     */
+    function initSearchFilter() {
+        var input = document.getElementById('kanban-search-input');
+        if (!input) return;
+
+        var debounceTimer = null;
+        input.addEventListener('input', function () {
+            clearTimeout(debounceTimer);
+            debounceTimer = setTimeout(function () {
+                applyFilters();
+            }, 200);
+        });
+    }
+
+    // ── APPLY ALL FILTERS ─────────────────────────────────────────────
+    /**
+     * @description Combined filter: assignee + text search. Updates counts.
+     */
+    function applyFilters() {
+        var activeChip = document.querySelector('.kanban-chip.active');
+        var filterUser = activeChip ? activeChip.getAttribute('data-filter-user') : 'all';
+        var searchInput = document.getElementById('kanban-search-input');
+        var searchTerm = (searchInput ? searchInput.value : '').toLowerCase().trim();
+
+        var allCards = document.querySelectorAll('.ticket-card-kanban');
+        var visibleByCol = {};
+        var totalVisible = 0;
+
+        allCards.forEach(function (card) {
+            var cardAssignee = card.getAttribute('data-assignee') || '0';
+            var cardSearch = card.getAttribute('data-search') || '';
+            var cardStatus = card.getAttribute('data-status') || '0';
+
+            var matchUser = (filterUser === 'all') || (cardAssignee === filterUser);
+            var matchText = !searchTerm || cardSearch.indexOf(searchTerm) >= 0;
+
+            if (matchUser && matchText) {
+                card.classList.remove('hidden-by-filter');
+                totalVisible++;
+                visibleByCol[cardStatus] = (visibleByCol[cardStatus] || 0) + 1;
+            } else {
+                card.classList.add('hidden-by-filter');
+            }
+        });
+
+        // Update column counters + status filter counters
+        document.querySelectorAll('.kanban-column').forEach(function (col) {
+            var st = col.getAttribute('data-status');
+            var count = visibleByCol[st] || 0;
+            var countEl = document.getElementById('col-count-' + st);
+            if (countEl) countEl.textContent = count;
+            // Update status filter chip count
+            var sfCount = document.getElementById('sf-count-' + st);
+            if (sfCount) sfCount.textContent = count;
+
+            // Show/hide empty state
+            var body = col.querySelector('.kanban-column-body');
+            var cards = body.querySelectorAll('.ticket-card-kanban:not(.hidden-by-filter)');
+            var emptyDiv = body.querySelector('.kanban-empty-col');
+            if (cards.length === 0 && !emptyDiv) {
+                var empty = document.createElement('div');
+                empty.className = 'kanban-empty-col';
+                empty.innerHTML = '<i class="fas fa-inbox"></i><span>Aucun ticket</span>';
+                body.appendChild(empty);
+            } else if (cards.length > 0 && emptyDiv) {
+                emptyDiv.remove();
+            }
+        });
+
+        // Update assignee chip counts based on text filter only
+        if (searchTerm) {
+            var countsByUser = { 'all': 0, '0': 0 };
+            allCards.forEach(function (card) {
+                var cs = card.getAttribute('data-search') || '';
+                if (cs.indexOf(searchTerm) >= 0) {
+                    countsByUser['all']++;
+                    var uid = card.getAttribute('data-assignee') || '0';
+                    countsByUser[uid] = (countsByUser[uid] || 0) + 1;
+                }
+            });
+            document.querySelectorAll('.kanban-chip').forEach(function (chip) {
+                var uid = chip.getAttribute('data-filter-user');
+                var cntEl = chip.querySelector('.chip-count');
+                if (cntEl) cntEl.textContent = countsByUser[uid] || 0;
+            });
+        }
+    }
+
+    // ── DRAG & DROP (Desktop only) ────────────────────────────────────
+    /**
+     * @description Drag tickets between columns to change status
+     */
+    function initDragAndDrop() {
+        var draggedCard = null;
+        var placeholder = null;
+
+        document.querySelectorAll('.ticket-card-kanban').forEach(function (card) {
+            card.addEventListener('dragstart', function (e) {
+                draggedCard = card;
+                card.classList.add('dragging');
+                e.dataTransfer.effectAllowed = 'move';
+                e.dataTransfer.setData('text/plain', card.getAttribute('data-ticket-id'));
+
+                placeholder = document.createElement('div');
+                placeholder.className = 'kanban-drop-placeholder';
+                placeholder.style.height = card.offsetHeight + 'px';
+
+                setTimeout(function () {
+                    card.style.display = 'none';
+                }, 0);
+            });
+
+            card.addEventListener('dragend', function () {
+                card.classList.remove('dragging');
+                card.style.display = '';
+                draggedCard = null;
+                document.querySelectorAll('.kanban-column').forEach(function (col) {
+                    col.classList.remove('drag-over');
+                });
+                if (placeholder && placeholder.parentNode) {
+                    placeholder.remove();
+                }
+                placeholder = null;
+            });
+        });
+
+        document.querySelectorAll('.kanban-column-body').forEach(function (body) {
+            body.addEventListener('dragover', function (e) {
+                e.preventDefault();
+                e.dataTransfer.dropEffect = 'move';
+                var col = body.closest('.kanban-column');
+                if (col) col.classList.add('drag-over');
+
+                if (placeholder) {
+                    var afterElement = getDragAfterElement(body, e.clientY);
+                    if (afterElement) {
+                        body.insertBefore(placeholder, afterElement);
+                    } else {
+                        body.appendChild(placeholder);
+                    }
+                }
+            });
+
+            body.addEventListener('dragleave', function (e) {
+                if (!body.contains(e.relatedTarget)) {
+                    var col = body.closest('.kanban-column');
+                    if (col) col.classList.remove('drag-over');
+                }
+            });
+
+            body.addEventListener('drop', function (e) {
+                e.preventDefault();
+                var col = body.closest('.kanban-column');
+                if (col) col.classList.remove('drag-over');
+
+                if (!draggedCard) return;
+
+                var newStatus = col.getAttribute('data-status');
+                var oldStatus = draggedCard.getAttribute('data-status');
+                var ticketId  = draggedCard.getAttribute('data-ticket-id');
+
+                if (placeholder && placeholder.parentNode) {
+                    body.insertBefore(draggedCard, placeholder);
+                    placeholder.remove();
+                } else {
+                    body.appendChild(draggedCard);
+                }
+                draggedCard.style.display = '';
+
+                var emptyDiv = body.querySelector('.kanban-empty-col');
+                if (emptyDiv) emptyDiv.remove();
+
+                // Add empty state to old column if needed
+                var oldCol = document.getElementById('kanban-body-' + oldStatus);
+                if (oldCol) {
+                    var remaining = oldCol.querySelectorAll('.ticket-card-kanban:not(.hidden-by-filter)');
+                    if (remaining.length === 0 && !oldCol.querySelector('.kanban-empty-col')) {
+                        var emptyEl = document.createElement('div');
+                        emptyEl.className = 'kanban-empty-col';
+                        emptyEl.innerHTML = '<i class="fas fa-inbox"></i><span>Aucun ticket</span>';
+                        oldCol.appendChild(emptyEl);
+                    }
+                }
+
+                if (newStatus !== oldStatus) {
+                    draggedCard.setAttribute('data-status', newStatus);
+                    updateTicketStatusCard(draggedCard, newStatus);
+                    saveTicketStatus(ticketId, newStatus, draggedCard);
+                }
+
+                updateColumnCounts();
+            });
+        });
+    }
+
+    /**
+     * @description Find the element after which to insert the dragged card
+     * @param {Element} container The column body
+     * @param {number} y Mouse Y position
+     * @returns {Element|null}
+     */
+    function getDragAfterElement(container, y) {
+        var draggableElements = Array.from(
+            container.querySelectorAll('.ticket-card-kanban:not(.dragging):not(.hidden-by-filter)')
+        );
+        var result = null;
+        var closestOffset = Number.NEGATIVE_INFINITY;
+        draggableElements.forEach(function (child) {
+            var box = child.getBoundingClientRect();
+            var offset = y - box.top - box.height / 2;
+            if (offset < 0 && offset > closestOffset) {
+                closestOffset = offset;
+                result = child;
+            }
+        });
+        return result;
+    }
+
+    /**
+     * @description Update card status badge after drag
+     * @param {Element} card The ticket card
+     * @param {string} newStatus Status code
+     */
+    function updateTicketStatusCard(card, newStatus) {
+        var info = STATUS_MAP[newStatus];
+        if (!info) return;
+        var dot = card.querySelector('.tc-status-dot');
+        var label = card.querySelector('.tc-status-label');
+        if (dot) dot.style.backgroundColor = info.color;
+        if (label) label.textContent = info.label;
+    }
+
+    /**
+     * @description AJAX call to save new ticket status via setStatut()
+     * @param {string} ticketId Ticket row ID
+     * @param {string} newStatus New status code
+     * @param {Element} card The ticket card element
+     */
+    function saveTicketStatus(ticketId, newStatus, card) {
+        card.classList.add('kanban-card-loading');
+        card.style.position = 'relative';
+
+        var token = '';
+        var tokenInput = document.querySelector('input[name="token"]');
+        if (tokenInput) token = tokenInput.value;
+
+        var baseUrl = window.location.pathname;
+        var params = 'action=updateticketstatus'
+            + '&token=' + encodeURIComponent(token)
+            + '&ticketid=' + encodeURIComponent(ticketId)
+            + '&newstatus=' + encodeURIComponent(newStatus);
+
+        var xhr = new XMLHttpRequest();
+        xhr.open('GET', baseUrl + '?' + params, true);
+        xhr.onload = function () {
+            card.classList.remove('kanban-card-loading');
+            try {
+                var res = JSON.parse(xhr.responseText);
+                if (res.success) {
+                    card.style.borderColor = '#22c55e';
+                    card.style.boxShadow = '0 0 0 2px rgba(34,197,94,0.3)';
+                    setTimeout(function () {
+                        card.style.borderColor = '';
+                        card.style.boxShadow = '';
+                    }, 1500);
+                } else {
+                    card.style.borderColor = '#ef4444';
+                    card.style.boxShadow = '0 0 0 2px rgba(239,68,68,0.3)';
+                    console.error('Ticket status update failed:', res.error);
+                    setTimeout(function () {
+                        card.style.borderColor = '';
+                        card.style.boxShadow = '';
+                    }, 3000);
+                }
+            } catch (e) {
+                console.error('Invalid JSON response:', xhr.responseText);
+            }
+        };
+        xhr.onerror = function () {
+            card.classList.remove('kanban-card-loading');
+            console.error('Network error during ticket status update');
+        };
+        xhr.send();
+    }
+
+    /**
+     * @description Recalculate all column counters
+     */
+    function updateColumnCounts() {
+        document.querySelectorAll('.kanban-column').forEach(function (col) {
+            var st = col.getAttribute('data-status');
+            var visibleCards = col.querySelectorAll('.ticket-card-kanban:not(.hidden-by-filter)');
+            var count = visibleCards.length;
+            var countEl = document.getElementById('col-count-' + st);
+            if (countEl) countEl.textContent = count;
+            var sfCount = document.getElementById('sf-count-' + st);
+            if (sfCount) sfCount.textContent = count;
+        });
+    }
+
+})();

--- a/js/reedcrm_tickets_kanban.js
+++ b/js/reedcrm_tickets_kanban.js
@@ -1,303 +1,586 @@
-﻿/**
+/**
  * @file    js/reedcrm_tickets_kanban.js
  * @ingroup reedcrm
- * @brief   Kanban board interactions: filter, search, drag & drop, view toggle, column resize
+ * @brief   Kanban + Notion table: inline editing, filters, drag & drop
  */
 (function () {
     'use strict';
 
     var isMobile = /Mobi|Android|iPhone|iPad/i.test(navigator.userAgent) || window.innerWidth < 768;
-
-    /** @type {Object<string, {label: string, color: string}>} Dolibarr 23 Ticket status map */
     var STATUS_MAP = {
-        '0': { label: 'Non lu',         color: '#e74c3c' },
-        '1': { label: 'Lu',             color: '#f39c12' },
-        '2': { label: 'Assign\u00e9',   color: '#f1c40f' },
-        '3': { label: 'En cours',       color: '#3498db' },
-        '5': { label: "Besoin d'info",  color: '#e67e22' },
-        '7': { label: 'En attente',     color: '#9b59b6' },
-        '8': { label: 'Ferm\u00e9',     color: '#2ecc71' },
-        '9': { label: 'Annul\u00e9',    color: '#7f8c8d' }
+        '0': { label: 'Non lu', color: '#e74c3c' },
+        '1': { label: 'Lu', color: '#f39c12' },
+        '2': { label: 'Assign\u00e9', color: '#f1c40f' },
+        '3': { label: 'En cours', color: '#3498db' },
+        '5': { label: "Besoin d'info", color: '#e67e22' },
+        '7': { label: 'En attente', color: '#9b59b6' },
+        '8': { label: 'Ferm\u00e9', color: '#2ecc71' },
+        '9': { label: 'Annul\u00e9', color: '#7f8c8d' }
     };
 
     document.addEventListener('DOMContentLoaded', function () {
-        initAssigneeFilter();
-        initSearchFilter();
-        initColumnToggle();
         initViewToggle();
-        initStatusFilter();
-        initAssigneePicker();
+        initNotionTableSearch();
+        initInlineEditing();
+        initKanbanColumnToggle();
+        initKanbanAssigneeFilter();
         if (!isMobile) {
-            initDragAndDrop();
-            initColumnResize();
-        } else {
-            document.querySelectorAll('.ticket-card-kanban').forEach(function (card) {
-                card.setAttribute('draggable', 'false');
-                card.style.cursor = 'default';
-            });
+            initKanbanDragAndDrop();
+            initKanbanAssigneePicker();
         }
     });
 
-    // ── VIEW TOGGLE (Kanban / List) ───────────────────────────────────
-    /**
-     * @description Toggle between Kanban board and list view
-     */
-    function initViewToggle() {
-        var toggleBtns = document.querySelectorAll('.view-toggle-btn');
-        var board = document.getElementById('kanban-board');
-        if (!board || !toggleBtns.length) return;
+    // ═══════════════════════════════════════════════════════════════════
+    // VIEW TOGGLE
+    // ═══════════════════════════════════════════════════════════════════
 
-        toggleBtns.forEach(function (btn) {
+    /** @description Toggle between Kanban and Notion table views */
+    function initViewToggle() {
+        var btns = document.querySelectorAll('.view-toggle-btn');
+        var tableWrap = document.getElementById('notion-table-wrapper');
+        var kanbanWrap = document.getElementById('kanban-view-section');
+        if (!btns.length) return;
+
+        btns.forEach(function (btn) {
             btn.addEventListener('click', function () {
-                toggleBtns.forEach(function (b) { b.classList.remove('active'); });
+                btns.forEach(function (b) { b.classList.remove('active'); });
                 btn.classList.add('active');
-                var viewMode = btn.getAttribute('data-view');
-                if (viewMode === 'list') {
-                    board.classList.add('kanban-list-mode');
-                } else {
-                    board.classList.remove('kanban-list-mode');
+                var mode = btn.getAttribute('data-view');
+                if (tableWrap) tableWrap.style.display = (mode === 'table') ? '' : 'none';
+                if (kanbanWrap) kanbanWrap.style.display = (mode === 'kanban') ? '' : 'none';
+            });
+        });
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // NOTION TABLE — COLUMN SEARCH (auto-submit on change/enter)
+    // ═══════════════════════════════════════════════════════════════════
+
+    /** @description Auto-submit search form on select change or Enter in inputs */
+    function initNotionTableSearch() {
+        var form = document.getElementById('notion-search-form');
+        if (!form) return;
+
+        // Selects: auto submit on change
+        form.querySelectorAll('.nt-search-select').forEach(function (sel) {
+            sel.addEventListener('change', function () { form.submit(); });
+        });
+
+        // Text inputs: submit on Enter
+        form.querySelectorAll('.nt-search-input').forEach(function (inp) {
+            inp.addEventListener('keydown', function (e) {
+                if (e.key === 'Enter') {
+                    e.preventDefault();
+                    form.submit();
                 }
             });
         });
     }
 
-    // ── STATUS FILTER (Notion-like column visibility toggles) ─────────
-    /**
-     * @description Creates status filter chips below the assignee filter to show/hide columns
-     */
-    function initStatusFilter() {
-        var filtersContainer = document.getElementById('kanban-filters');
-        if (!filtersContainer) return;
+    // ═══════════════════════════════════════════════════════════════════
+    // NOTION TABLE — INLINE EDITING
+    // ═══════════════════════════════════════════════════════════════════
 
-        var statusRow = document.createElement('div');
-        statusRow.className = 'kanban-status-filters';
-        statusRow.id = 'kanban-status-filters';
+    var activeDropdown = null;
 
-        // Label
-        var label = document.createElement('span');
-        label.className = 'status-filter-label';
-        label.innerHTML = '<i class="fas fa-filter"></i> Statuts';
-        statusRow.appendChild(label);
-
-        // One toggle per status column
-        document.querySelectorAll('.kanban-column').forEach(function (col) {
-            var st = col.getAttribute('data-status');
-            var info = STATUS_MAP[st];
-            if (!info) return;
-
-            var btn = document.createElement('button');
-            btn.className = 'status-filter-chip active';
-            btn.setAttribute('data-status-filter', st);
-            btn.title = 'Afficher/masquer ' + info.label;
-            btn.innerHTML = '<span class="sf-dot" style="background:' + info.color + '"></span>'
-                + '<span class="sf-label">' + info.label + '</span>'
-                + '<span class="sf-count" id="sf-count-' + st + '">' + (col.querySelectorAll('.ticket-card-kanban').length) + '</span>';
-
-            btn.addEventListener('click', function () {
-                btn.classList.toggle('active');
-                var isVisible = btn.classList.contains('active');
-                col.style.display = isVisible ? '' : 'none';
-            });
-
-            statusRow.appendChild(btn);
+    /** @description Initialize inline editing on all editable cells */
+    function initInlineEditing() {
+        // Close dropdowns on outside click
+        document.addEventListener('click', function (e) {
+            if (activeDropdown && !activeDropdown.contains(e.target) && !e.target.closest('.nt-editable.nt-editing')) {
+                closeActiveDropdown();
+            }
         });
 
-        filtersContainer.appendChild(statusRow);
+        document.querySelectorAll('.nt-editable').forEach(function (cell) {
+            cell.addEventListener('click', function (e) {
+                if (cell.classList.contains('nt-editing')) return;
+                e.stopPropagation();
+                var editType = cell.getAttribute('data-edit-type');
+                var field = cell.getAttribute('data-field');
+                var currentVal = cell.getAttribute('data-value') || '';
+                var row = cell.closest('.nt-data-row');
+                var ticketId = row ? row.getAttribute('data-ticket-id') : '';
+
+                closeActiveDropdown();
+
+                switch (editType) {
+                    case 'text':
+                        startTextEdit(cell, field, currentVal, ticketId);
+                        break;
+                    case 'select':
+                        startSelectEdit(cell, field, currentVal, ticketId);
+                        break;
+                    case 'user':
+                        startUserEdit(cell, field, currentVal, ticketId);
+                        break;
+                    case 'tags':
+                        startTagsEdit(cell, field, currentVal, ticketId);
+                        break;
+                }
+            });
+        });
     }
 
-    // ── COLUMN TOGGLE (click header to collapse) ──────────────────────
-    /**
-     * @description All column headers are clickable to toggle collapse
-     */
-    function initColumnToggle() {
-        document.querySelectorAll('.kanban-column-header').forEach(function (header) {
-            // The toggle button itself
-            var toggleBtn = header.querySelector('.kanban-column-toggle');
+    // ── TEXT EDIT ──────────────────────────────────────────────────────
 
-            // Make the entire header clickable (except toggle btn which has its own handler)
-            header.style.cursor = 'pointer';
-            header.addEventListener('click', function (e) {
-                // Don't double-trigger if clicking the toggle button
-                if (toggleBtn && (e.target === toggleBtn || toggleBtn.contains(e.target))) return;
-                var col = header.closest('.kanban-column');
-                if (col) {
-                    col.classList.toggle('collapsed');
-                    // Update chevron
-                    var icon = header.querySelector('.kanban-column-toggle i');
-                    if (icon) {
-                        // Icon rotation is handled by CSS
+    /**
+     * @description Start inline text editing
+     * @param {Element} cell
+     * @param {string} field
+     * @param {string} currentVal
+     * @param {string} ticketId
+     */
+    function startTextEdit(cell, field, currentVal, ticketId) {
+        cell.classList.add('nt-editing');
+        var origHtml = cell.innerHTML;
+        var input = document.createElement('input');
+        input.type = 'text';
+        input.className = 'nt-inline-input';
+        input.value = currentVal;
+        cell.textContent = '';
+        cell.appendChild(input);
+        input.focus();
+        input.select();
+
+        function save() {
+            var newVal = input.value.trim();
+            if (newVal === currentVal) {
+                cancel();
+                return;
+            }
+            cell.classList.remove('nt-editing');
+            cell.classList.add('nt-cell-saving');
+            ajaxSaveField(ticketId, field, newVal, function (ok) {
+                cell.classList.remove('nt-cell-saving');
+                if (ok) {
+                    cell.setAttribute('data-value', newVal);
+                    cell.textContent = '';
+                    var span = document.createElement('span');
+                    span.className = 'nt-cell-text';
+                    span.textContent = newVal || 'Sans titre';
+                    cell.appendChild(span);
+                    flashCell(cell, true);
+                } else {
+                    cell.innerHTML = origHtml;
+                    flashCell(cell, false);
+                }
+            });
+        }
+
+        function cancel() {
+            cell.classList.remove('nt-editing');
+            cell.innerHTML = origHtml;
+        }
+
+        input.addEventListener('keydown', function (e) {
+            if (e.key === 'Enter') { e.preventDefault(); save(); }
+            if (e.key === 'Escape') { e.preventDefault(); cancel(); }
+        });
+        input.addEventListener('blur', function () {
+            setTimeout(save, 100);
+        });
+    }
+
+    // ── SELECT EDIT (severity, status) ────────────────────────────────
+
+    /**
+     * @description Start inline select editing
+     * @param {Element} cell
+     * @param {string} field
+     * @param {string} currentVal
+     * @param {string} ticketId
+     */
+    function startSelectEdit(cell, field, currentVal, ticketId) {
+        cell.classList.add('nt-editing');
+        var origHtml = cell.innerHTML;
+        var options = [];
+
+        if (field === 'severity') {
+            options = (window.KANBAN_SEVERITIES || []).map(function (s) {
+                return { value: s.code, label: s.label };
+            });
+        } else if (field === 'status') {
+            options = (window.KANBAN_STATUSES || []).map(function (s) {
+                return { value: String(s.code), label: s.label };
+            });
+        }
+
+        var select = document.createElement('select');
+        select.className = 'nt-inline-select';
+        options.forEach(function (opt) {
+            var o = document.createElement('option');
+            o.value = opt.value;
+            o.textContent = opt.label;
+            if (opt.value === currentVal) o.selected = true;
+            select.appendChild(o);
+        });
+
+        cell.textContent = '';
+        cell.appendChild(select);
+        select.focus();
+
+        function save() {
+            var newVal = select.value;
+            if (newVal === currentVal) { cancel(); return; }
+            cell.classList.remove('nt-editing');
+            cell.classList.add('nt-cell-saving');
+            ajaxSaveField(ticketId, field, newVal, function (ok) {
+                cell.classList.remove('nt-cell-saving');
+                if (ok) {
+                    cell.setAttribute('data-value', newVal);
+                    cell.textContent = '';
+                    if (field === 'severity') {
+                        var badge = document.createElement('span');
+                        badge.className = 'nt-severity-badge nt-severity-' + newVal.toLowerCase();
+                        var lbl = options.find(function (o) { return o.value === newVal; });
+                        badge.textContent = lbl ? lbl.label : newVal;
+                        cell.appendChild(badge);
+                    } else if (field === 'status') {
+                        var info = STATUS_MAP[newVal] || { label: '?', color: '#ccc' };
+                        var sb = document.createElement('span');
+                        sb.className = 'nt-status-badge';
+                        sb.style.setProperty('--st-color', info.color);
+                        var dot = document.createElement('span');
+                        dot.className = 'nt-status-dot';
+                        dot.style.background = info.color;
+                        sb.appendChild(dot);
+                        sb.appendChild(document.createTextNode(' ' + info.label));
+                        cell.appendChild(sb);
+                    }
+                    flashCell(cell, true);
+                } else {
+                    cell.innerHTML = origHtml;
+                    flashCell(cell, false);
+                }
+            });
+        }
+
+        function cancel() {
+            cell.classList.remove('nt-editing');
+            cell.innerHTML = origHtml;
+        }
+
+        select.addEventListener('change', save);
+        select.addEventListener('keydown', function (e) {
+            if (e.key === 'Escape') cancel();
+        });
+        select.addEventListener('blur', function () { setTimeout(function () { if (cell.classList.contains('nt-editing')) cancel(); }, 150); });
+    }
+
+    // ── USER EDIT ─────────────────────────────────────────────────────
+
+    /**
+     * @description Start user picker dropdown
+     * @param {Element} cell
+     * @param {string} field
+     * @param {string} currentVal
+     * @param {string} ticketId
+     */
+    function startUserEdit(cell, field, currentVal, ticketId) {
+        cell.classList.add('nt-editing');
+        var origHtml = cell.innerHTML;
+        var users = window.KANBAN_USERS || [];
+        var currentId = parseInt(currentVal, 10) || 0;
+
+        var dd = document.createElement('div');
+        dd.className = 'nt-user-picker';
+
+        // Non assigné
+        dd.appendChild(createUserItem(0, 'Non assigné', '?', '', currentId === 0));
+        var sep = document.createElement('div');
+        sep.className = 'nt-user-picker-sep';
+        dd.appendChild(sep);
+
+        users.forEach(function (u) {
+            dd.appendChild(createUserItem(u.id, u.name, u.initials, u.photo, currentId === u.id));
+        });
+
+        cell.appendChild(dd);
+        activeDropdown = dd;
+
+        function createUserItem(id, name, initials, photo, selected) {
+            var btn = document.createElement('button');
+            btn.type = 'button';
+            btn.className = 'nt-user-picker-item' + (selected ? ' selected' : '');
+            var avatar = document.createElement('div');
+            avatar.className = 'nt-user-picker-avatar';
+            if (photo) {
+                var img = document.createElement('img');
+                img.src = photo;
+                img.alt = initials;
+                avatar.appendChild(img);
+            } else {
+                avatar.textContent = initials || '?';
+            }
+            btn.appendChild(avatar);
+            var nameSpan = document.createElement('span');
+            nameSpan.textContent = name;
+            btn.appendChild(nameSpan);
+            if (selected) {
+                var check = document.createElement('i');
+                check.className = 'fas fa-check nt-user-picker-check';
+                btn.appendChild(check);
+            }
+            btn.addEventListener('click', function (e) {
+                e.stopPropagation();
+                selectUser(id, name, initials, photo);
+            });
+            return btn;
+        }
+
+        function selectUser(id, name, initials, photo) {
+            closeActiveDropdown();
+            cell.classList.remove('nt-editing');
+            cell.classList.add('nt-cell-saving');
+            ajaxSaveField(ticketId, field, String(id), function (ok) {
+                cell.classList.remove('nt-cell-saving');
+                if (ok) {
+                    cell.setAttribute('data-value', String(id));
+                    cell.textContent = '';
+                    if (id > 0) {
+                        var chip = document.createElement('div');
+                        chip.className = 'nt-user-chip';
+                        if (photo) {
+                            var img = document.createElement('img');
+                            img.src = photo;
+                            img.className = 'nt-user-avatar';
+                            chip.appendChild(img);
+                        } else {
+                            var av = document.createElement('span');
+                            av.className = 'nt-user-avatar nt-user-initials';
+                            av.textContent = initials;
+                            chip.appendChild(av);
+                        }
+                        var nm = document.createElement('span');
+                        nm.className = 'nt-user-name';
+                        nm.textContent = name;
+                        chip.appendChild(nm);
+                        cell.appendChild(chip);
+                    } else {
+                        var empty = document.createElement('span');
+                        empty.className = 'nt-empty-value';
+                        empty.textContent = '-';
+                        cell.appendChild(empty);
+                    }
+                    flashCell(cell, true);
+                } else {
+                    cell.innerHTML = origHtml;
+                    flashCell(cell, false);
+                }
+            });
+        }
+    }
+
+    // ── TAGS EDIT ─────────────────────────────────────────────────────
+
+    /**
+     * @description Start multi-select tag picker
+     * @param {Element} cell
+     * @param {string} field
+     * @param {string} currentVal comma-separated IDs
+     * @param {string} ticketId
+     */
+    function startTagsEdit(cell, field, currentVal, ticketId) {
+        cell.classList.add('nt-editing');
+        var origHtml = cell.innerHTML;
+        var allTags = window.KANBAN_TAGS || [];
+        var selectedIds = currentVal ? currentVal.split(',').map(Number).filter(Boolean) : [];
+
+        var dd = document.createElement('div');
+        dd.className = 'nt-tag-picker';
+
+        allTags.forEach(function (tag) {
+            var isSelected = selectedIds.indexOf(tag.id) >= 0;
+            var item = document.createElement('button');
+            item.type = 'button';
+            item.className = 'nt-tag-picker-item' + (isSelected ? ' selected' : '');
+            item.setAttribute('data-tag-id', tag.id);
+
+            var dot = document.createElement('span');
+            dot.className = 'nt-tag-picker-dot';
+            dot.style.background = '#' + tag.color;
+            item.appendChild(dot);
+
+            var lbl = document.createElement('span');
+            lbl.textContent = tag.label;
+            item.appendChild(lbl);
+
+            if (isSelected) {
+                var check = document.createElement('i');
+                check.className = 'fas fa-check nt-tag-picker-check';
+                item.appendChild(check);
+            }
+
+            item.addEventListener('click', function (e) {
+                e.stopPropagation();
+                var idx = selectedIds.indexOf(tag.id);
+                if (idx >= 0) {
+                    selectedIds.splice(idx, 1);
+                    item.classList.remove('selected');
+                    var existCheck = item.querySelector('.nt-tag-picker-check');
+                    if (existCheck) existCheck.remove();
+                } else {
+                    selectedIds.push(tag.id);
+                    item.classList.add('selected');
+                    var c = document.createElement('i');
+                    c.className = 'fas fa-check nt-tag-picker-check';
+                    item.appendChild(c);
+                }
+                // Save immediately on each toggle
+                saveTags();
+            });
+
+            dd.appendChild(item);
+        });
+
+        cell.appendChild(dd);
+        activeDropdown = dd;
+
+        function saveTags() {
+            var val = selectedIds.join(',');
+            ajaxSaveField(ticketId, field, val, function (ok) {
+                if (ok) {
+                    cell.setAttribute('data-value', val);
+                    // Rebuild tag chips (keep dropdown open)
+                    var existing = cell.querySelectorAll('.nt-tag-chip, .nt-empty-value');
+                    existing.forEach(function (el) { el.remove(); });
+                    if (selectedIds.length === 0) {
+                        var empty = document.createElement('span');
+                        empty.className = 'nt-empty-value';
+                        empty.textContent = '-';
+                        cell.insertBefore(empty, dd);
+                    } else {
+                        selectedIds.forEach(function (id) {
+                            var tagInfo = allTags.find(function (t) { return t.id === id; });
+                            if (tagInfo) {
+                                var chip = document.createElement('span');
+                                chip.className = 'nt-tag-chip';
+                                chip.style.setProperty('--tag-color', '#' + tagInfo.color);
+                                chip.setAttribute('data-tag-id', id);
+                                chip.textContent = tagInfo.label;
+                                cell.insertBefore(chip, dd);
+                            }
+                        });
                     }
                 }
             });
+        }
+    }
 
-            if (toggleBtn) {
-                toggleBtn.addEventListener('click', function (e) {
+    // ── AJAX SAVE ─────────────────────────────────────────────────────
+
+    /**
+     * @description Generic AJAX field save
+     * @param {string} ticketId
+     * @param {string} field
+     * @param {string} value
+     * @param {function} callback (success: boolean)
+     */
+    function ajaxSaveField(ticketId, field, value, callback) {
+        var token = '';
+        var tokenInput = document.querySelector('input[name="token"]');
+        if (tokenInput) token = tokenInput.value;
+
+        var baseUrl = window.location.pathname;
+        var params = 'action=updateticketfield'
+            + '&token=' + encodeURIComponent(token)
+            + '&ticketid=' + encodeURIComponent(ticketId)
+            + '&field=' + encodeURIComponent(field)
+            + '&value=' + encodeURIComponent(value);
+
+        var xhr = new XMLHttpRequest();
+        xhr.open('GET', baseUrl + '?' + params, true);
+        xhr.onload = function () {
+            try {
+                var res = JSON.parse(xhr.responseText);
+                callback(!!res.success);
+            } catch (e) {
+                console.error('Invalid JSON:', xhr.responseText);
+                callback(false);
+            }
+        };
+        xhr.onerror = function () { callback(false); };
+        xhr.send();
+    }
+
+    /** @description Flash green or red on a cell after save */
+    function flashCell(cell, success) {
+        var cls = success ? 'nt-cell-success' : 'nt-cell-error';
+        cell.classList.add(cls);
+        setTimeout(function () { cell.classList.remove(cls); }, 1000);
+    }
+
+    /** @description Close active dropdown */
+    function closeActiveDropdown() {
+        if (activeDropdown) {
+            var parent = activeDropdown.closest('.nt-editing');
+            activeDropdown.remove();
+            activeDropdown = null;
+            if (parent) parent.classList.remove('nt-editing');
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // KANBAN — COLUMN TOGGLE
+    // ═══════════════════════════════════════════════════════════════════
+
+    function initKanbanColumnToggle() {
+        document.querySelectorAll('.kanban-column-header').forEach(function (header) {
+            header.addEventListener('click', function (e) {
+                if (e.target.closest('.kanban-column-toggle')) return;
+                var col = header.closest('.kanban-column');
+                if (col) col.classList.toggle('collapsed');
+            });
+            var btn = header.querySelector('.kanban-column-toggle');
+            if (btn) {
+                btn.addEventListener('click', function (e) {
                     e.stopPropagation();
-                    var col = toggleBtn.closest('.kanban-column');
+                    var col = btn.closest('.kanban-column');
                     if (col) col.classList.toggle('collapsed');
                 });
             }
         });
     }
 
-    // ── COLUMN RESIZE (Notion-like drag to resize) ────────────────────
-    /**
-     * @description Adds resize handles to Kanban columns for width adjustment
-     */
-    function initColumnResize() {
-        var columns = document.querySelectorAll('.kanban-column');
-        columns.forEach(function (col) {
-            var handle = document.createElement('div');
-            handle.className = 'kanban-resize-handle';
-            handle.title = 'Ajuster la largeur';
-            col.appendChild(handle);
+    // ═══════════════════════════════════════════════════════════════════
+    // KANBAN — ASSIGNEE FILTER
+    // ═══════════════════════════════════════════════════════════════════
 
-            var startX, startWidth;
-
-            handle.addEventListener('mousedown', function (e) {
-                e.preventDefault();
-                e.stopPropagation();
-                startX = e.clientX;
-                startWidth = col.offsetWidth;
-                col.classList.add('resizing');
-                document.body.style.cursor = 'col-resize';
-                document.body.style.userSelect = 'none';
-
-                function onMouseMove(ev) {
-                    var diff = ev.clientX - startX;
-                    var newWidth = Math.max(200, Math.min(600, startWidth + diff));
-                    col.style.flex = '0 0 ' + newWidth + 'px';
-                    col.style.minWidth = newWidth + 'px';
-                    col.style.maxWidth = newWidth + 'px';
-                }
-
-                function onMouseUp() {
-                    col.classList.remove('resizing');
-                    document.body.style.cursor = '';
-                    document.body.style.userSelect = '';
-                    document.removeEventListener('mousemove', onMouseMove);
-                    document.removeEventListener('mouseup', onMouseUp);
-                }
-
-                document.addEventListener('mousemove', onMouseMove);
-                document.addEventListener('mouseup', onMouseUp);
-            });
-        });
-    }
-
-    // ── ASSIGNEE FILTER ───────────────────────────────────────────────
-    /**
-     * @description Filter tickets by assigned user via chip buttons
-     */
-    function initAssigneeFilter() {
+    function initKanbanAssigneeFilter() {
         var chips = document.querySelectorAll('.kanban-chip[data-filter-user]');
         chips.forEach(function (chip) {
             chip.addEventListener('click', function () {
                 chips.forEach(function (c) { c.classList.remove('active'); });
                 chip.classList.add('active');
-                applyFilters();
+                applyKanbanFilter();
             });
         });
     }
 
-    // ── SEARCH FILTER ─────────────────────────────────────────────────
-    /**
-     * @description Real-time text search across ticket cards
-     */
-    function initSearchFilter() {
-        var input = document.getElementById('kanban-search-input');
-        if (!input) return;
-
-        var debounceTimer = null;
-        input.addEventListener('input', function () {
-            clearTimeout(debounceTimer);
-            debounceTimer = setTimeout(function () {
-                applyFilters();
-            }, 200);
+    function applyKanbanFilter() {
+        var active = document.querySelector('.kanban-chip.active');
+        var filterUser = active ? active.getAttribute('data-filter-user') : 'all';
+        document.querySelectorAll('.ticket-card-kanban').forEach(function (card) {
+            var uid = card.getAttribute('data-assignee') || '0';
+            var match = (filterUser === 'all') || (uid === filterUser);
+            card.classList.toggle('hidden-by-filter', !match);
         });
-    }
-
-    // ── APPLY ALL FILTERS ─────────────────────────────────────────────
-    /**
-     * @description Combined filter: assignee + text search. Updates counts.
-     */
-    function applyFilters() {
-        var activeChip = document.querySelector('.kanban-chip.active');
-        var filterUser = activeChip ? activeChip.getAttribute('data-filter-user') : 'all';
-        var searchInput = document.getElementById('kanban-search-input');
-        var searchTerm = (searchInput ? searchInput.value : '').toLowerCase().trim();
-
-        var allCards = document.querySelectorAll('.ticket-card-kanban');
-        var visibleByCol = {};
-        var totalVisible = 0;
-
-        allCards.forEach(function (card) {
-            var cardAssignee = card.getAttribute('data-assignee') || '0';
-            var cardSearch = card.getAttribute('data-search') || '';
-            var cardStatus = card.getAttribute('data-status') || '0';
-
-            var matchUser = (filterUser === 'all') || (cardAssignee === filterUser);
-            var matchText = !searchTerm || cardSearch.indexOf(searchTerm) >= 0;
-
-            if (matchUser && matchText) {
-                card.classList.remove('hidden-by-filter');
-                totalVisible++;
-                visibleByCol[cardStatus] = (visibleByCol[cardStatus] || 0) + 1;
-            } else {
-                card.classList.add('hidden-by-filter');
-            }
-        });
-
-        // Update column counters + status filter counters
+        // Update counts
         document.querySelectorAll('.kanban-column').forEach(function (col) {
             var st = col.getAttribute('data-status');
-            var count = visibleByCol[st] || 0;
+            var visible = col.querySelectorAll('.ticket-card-kanban:not(.hidden-by-filter)');
             var countEl = document.getElementById('col-count-' + st);
-            if (countEl) countEl.textContent = count;
-            // Update status filter chip count
-            var sfCount = document.getElementById('sf-count-' + st);
-            if (sfCount) sfCount.textContent = count;
-
-            // Show/hide empty state
-            var body = col.querySelector('.kanban-column-body');
-            var cards = body.querySelectorAll('.ticket-card-kanban:not(.hidden-by-filter)');
-            var emptyDiv = body.querySelector('.kanban-empty-col');
-            if (cards.length === 0 && !emptyDiv) {
-                var empty = document.createElement('div');
-                empty.className = 'kanban-empty-col';
-                empty.innerHTML = '<i class="fas fa-inbox"></i><span>Aucun ticket</span>';
-                body.appendChild(empty);
-            } else if (cards.length > 0 && emptyDiv) {
-                emptyDiv.remove();
-            }
+            if (countEl) countEl.textContent = visible.length;
         });
-
-        // Update assignee chip counts based on text filter only
-        if (searchTerm) {
-            var countsByUser = { 'all': 0, '0': 0 };
-            allCards.forEach(function (card) {
-                var cs = card.getAttribute('data-search') || '';
-                if (cs.indexOf(searchTerm) >= 0) {
-                    countsByUser['all']++;
-                    var uid = card.getAttribute('data-assignee') || '0';
-                    countsByUser[uid] = (countsByUser[uid] || 0) + 1;
-                }
-            });
-            document.querySelectorAll('.kanban-chip').forEach(function (chip) {
-                var uid = chip.getAttribute('data-filter-user');
-                var cntEl = chip.querySelector('.chip-count');
-                if (cntEl) cntEl.textContent = countsByUser[uid] || 0;
-            });
-        }
     }
 
-    // ── DRAG & DROP (Desktop only) ────────────────────────────────────
-    /**
-     * @description Drag tickets between columns to change status
-     */
-    function initDragAndDrop() {
+    // ═══════════════════════════════════════════════════════════════════
+    // KANBAN — DRAG & DROP
+    // ═══════════════════════════════════════════════════════════════════
+
+    function initKanbanDragAndDrop() {
         var draggedCard = null;
-        var placeholder = null;
 
         document.querySelectorAll('.ticket-card-kanban').forEach(function (card) {
             card.addEventListener('dragstart', function (e) {
@@ -305,27 +588,13 @@
                 card.classList.add('dragging');
                 e.dataTransfer.effectAllowed = 'move';
                 e.dataTransfer.setData('text/plain', card.getAttribute('data-ticket-id'));
-
-                placeholder = document.createElement('div');
-                placeholder.className = 'kanban-drop-placeholder';
-                placeholder.style.height = card.offsetHeight + 'px';
-
-                setTimeout(function () {
-                    card.style.display = 'none';
-                }, 0);
+                setTimeout(function () { card.style.display = 'none'; }, 0);
             });
-
             card.addEventListener('dragend', function () {
                 card.classList.remove('dragging');
                 card.style.display = '';
                 draggedCard = null;
-                document.querySelectorAll('.kanban-column').forEach(function (col) {
-                    col.classList.remove('drag-over');
-                });
-                if (placeholder && placeholder.parentNode) {
-                    placeholder.remove();
-                }
-                placeholder = null;
+                document.querySelectorAll('.kanban-column').forEach(function (c) { c.classList.remove('drag-over'); });
             });
         });
 
@@ -335,411 +604,134 @@
                 e.dataTransfer.dropEffect = 'move';
                 var col = body.closest('.kanban-column');
                 if (col) col.classList.add('drag-over');
-
-                if (placeholder) {
-                    var afterElement = getDragAfterElement(body, e.clientY);
-                    if (afterElement) {
-                        body.insertBefore(placeholder, afterElement);
-                    } else {
-                        body.appendChild(placeholder);
-                    }
-                }
             });
-
             body.addEventListener('dragleave', function (e) {
                 if (!body.contains(e.relatedTarget)) {
                     var col = body.closest('.kanban-column');
                     if (col) col.classList.remove('drag-over');
                 }
             });
-
             body.addEventListener('drop', function (e) {
                 e.preventDefault();
                 var col = body.closest('.kanban-column');
                 if (col) col.classList.remove('drag-over');
-
                 if (!draggedCard) return;
 
                 var newStatus = col.getAttribute('data-status');
                 var oldStatus = draggedCard.getAttribute('data-status');
-                var ticketId  = draggedCard.getAttribute('data-ticket-id');
+                var ticketId = draggedCard.getAttribute('data-ticket-id');
 
-                if (placeholder && placeholder.parentNode) {
-                    body.insertBefore(draggedCard, placeholder);
-                    placeholder.remove();
-                } else {
-                    body.appendChild(draggedCard);
-                }
+                body.appendChild(draggedCard);
                 draggedCard.style.display = '';
 
+                // Remove empty state
                 var emptyDiv = body.querySelector('.kanban-empty-col');
                 if (emptyDiv) emptyDiv.remove();
 
-                // Add empty state to old column if needed
-                var oldCol = document.getElementById('kanban-body-' + oldStatus);
-                if (oldCol) {
-                    var remaining = oldCol.querySelectorAll('.ticket-card-kanban:not(.hidden-by-filter)');
-                    if (remaining.length === 0 && !oldCol.querySelector('.kanban-empty-col')) {
-                        var emptyEl = document.createElement('div');
-                        emptyEl.className = 'kanban-empty-col';
-                        emptyEl.innerHTML = '<i class="fas fa-inbox"></i><span>Aucun ticket</span>';
-                        oldCol.appendChild(emptyEl);
-                    }
-                }
-
                 if (newStatus !== oldStatus) {
                     draggedCard.setAttribute('data-status', newStatus);
-                    updateTicketStatusCard(draggedCard, newStatus);
-                    saveTicketStatus(ticketId, newStatus, draggedCard);
+                    ajaxSaveField(ticketId, 'status', newStatus, function (ok) {
+                        if (ok) {
+                            draggedCard.style.borderColor = '#22c55e';
+                            setTimeout(function () { draggedCard.style.borderColor = ''; }, 1500);
+                        }
+                    });
                 }
-
-                updateColumnCounts();
             });
         });
     }
 
-    /**
-     * @description Find the element after which to insert the dragged card
-     * @param {Element} container The column body
-     * @param {number} y Mouse Y position
-     * @returns {Element|null}
-     */
-    function getDragAfterElement(container, y) {
-        var draggableElements = Array.from(
-            container.querySelectorAll('.ticket-card-kanban:not(.dragging):not(.hidden-by-filter)')
-        );
-        var result = null;
-        var closestOffset = Number.NEGATIVE_INFINITY;
-        draggableElements.forEach(function (child) {
-            var box = child.getBoundingClientRect();
-            var offset = y - box.top - box.height / 2;
-            if (offset < 0 && offset > closestOffset) {
-                closestOffset = offset;
-                result = child;
-            }
-        });
-        return result;
-    }
+    // ═══════════════════════════════════════════════════════════════════
+    // KANBAN — ASSIGNEE PICKER (on card avatar)
+    // ═══════════════════════════════════════════════════════════════════
 
-    /**
-     * @description Update card status badge after drag
-     * @param {Element} card The ticket card
-     * @param {string} newStatus Status code
-     */
-    function updateTicketStatusCard(card, newStatus) {
-        var info = STATUS_MAP[newStatus];
-        if (!info) return;
-        var dot = card.querySelector('.tc-status-dot');
-        var label = card.querySelector('.tc-status-label');
-        if (dot) dot.style.backgroundColor = info.color;
-        if (label) label.textContent = info.label;
-    }
-
-    /**
-     * @description AJAX call to save new ticket status via setStatut()
-     * @param {string} ticketId Ticket row ID
-     * @param {string} newStatus New status code
-     * @param {Element} card The ticket card element
-     */
-    function saveTicketStatus(ticketId, newStatus, card) {
-        card.classList.add('kanban-card-loading');
-        card.style.position = 'relative';
-
-        var token = '';
-        var tokenInput = document.querySelector('input[name="token"]');
-        if (tokenInput) token = tokenInput.value;
-
-        var baseUrl = window.location.pathname;
-        var params = 'action=updateticketstatus'
-            + '&token=' + encodeURIComponent(token)
-            + '&ticketid=' + encodeURIComponent(ticketId)
-            + '&newstatus=' + encodeURIComponent(newStatus);
-
-        var xhr = new XMLHttpRequest();
-        xhr.open('GET', baseUrl + '?' + params, true);
-        xhr.onload = function () {
-            card.classList.remove('kanban-card-loading');
-            try {
-                var res = JSON.parse(xhr.responseText);
-                if (res.success) {
-                    card.style.borderColor = '#22c55e';
-                    card.style.boxShadow = '0 0 0 2px rgba(34,197,94,0.3)';
-                    setTimeout(function () {
-                        card.style.borderColor = '';
-                        card.style.boxShadow = '';
-                    }, 1500);
-                } else {
-                    card.style.borderColor = '#ef4444';
-                    card.style.boxShadow = '0 0 0 2px rgba(239,68,68,0.3)';
-                    console.error('Ticket status update failed:', res.error);
-                    setTimeout(function () {
-                        card.style.borderColor = '';
-                        card.style.boxShadow = '';
-                    }, 3000);
-                }
-            } catch (e) {
-                console.error('Invalid JSON response:', xhr.responseText);
-            }
-        };
-        xhr.onerror = function () {
-            card.classList.remove('kanban-card-loading');
-            console.error('Network error during ticket status update');
-        };
-        xhr.send();
-    }
-
-    /**
-     * @description Recalculate all column counters
-     */
-    function updateColumnCounts() {
-        document.querySelectorAll('.kanban-column').forEach(function (col) {
-            var st = col.getAttribute('data-status');
-            var visibleCards = col.querySelectorAll('.ticket-card-kanban:not(.hidden-by-filter)');
-            var count = visibleCards.length;
-            var countEl = document.getElementById('col-count-' + st);
-            if (countEl) countEl.textContent = count;
-            var sfCount = document.getElementById('sf-count-' + st);
-            if (sfCount) sfCount.textContent = count;
-        });
-    }
-
-    // ── ASSIGNEE PICKER DROPDOWN ──────────────────────────────────────
-    /**
-     * @description Click on assignee avatar to show a dropdown of all users
-     */
-    function initAssigneePicker() {
+    function initKanbanAssigneePicker() {
         var users = window.KANBAN_USERS || [];
-        var activeDropdown = null;
+        var kanbanDD = null;
 
-        // Close dropdown on outside click
         document.addEventListener('click', function (e) {
-            if (activeDropdown && !activeDropdown.contains(e.target) && !e.target.closest('.tc-assignee-picker')) {
-                closeDropdown();
+            if (kanbanDD && !kanbanDD.contains(e.target) && !e.target.closest('.tc-assignee-picker')) {
+                if (kanbanDD.parentNode) kanbanDD.remove();
+                kanbanDD = null;
             }
         });
 
         document.querySelectorAll('.tc-assignee-picker').forEach(function (picker) {
             picker.addEventListener('click', function (e) {
                 e.stopPropagation();
-                e.preventDefault();
-
-                // Close existing dropdown
-                if (activeDropdown) {
-                    var wasOnSame = activeDropdown.parentElement === picker;
-                    closeDropdown();
-                    if (wasOnSame) return;
-                }
+                if (kanbanDD) { kanbanDD.remove(); kanbanDD = null; return; }
 
                 var ticketId = picker.getAttribute('data-ticket-id');
-                var currentAssignee = parseInt(picker.getAttribute('data-current-assignee') || '0', 10);
+                var currentId = parseInt(picker.getAttribute('data-current-assignee') || '0', 10);
 
-                // Build dropdown
                 var dd = document.createElement('div');
                 dd.className = 'assignee-dropdown';
 
-                // "Non assigné" option
-                var unassignItem = createDropdownItem(0, 'Non assigné', '?', '', currentAssignee === 0);
-                unassignItem.addEventListener('click', function (ev) {
-                    ev.stopPropagation();
-                    selectAssignee(ticketId, 0, picker);
-                });
-                dd.appendChild(unassignItem);
+                // Non assigné
+                var unItem = document.createElement('button');
+                unItem.type = 'button';
+                unItem.className = 'assignee-dropdown-item' + (currentId === 0 ? ' selected' : '');
+                unItem.textContent = 'Non assigné';
+                unItem.addEventListener('click', function (ev) { ev.stopPropagation(); pickUser(0); });
+                dd.appendChild(unItem);
 
-                // Separator
                 var sep = document.createElement('div');
                 sep.className = 'assignee-dropdown-separator';
                 dd.appendChild(sep);
 
-                // All users
                 users.forEach(function (u) {
-                    var item = createDropdownItem(u.id, u.name, u.initials, u.photo, currentAssignee === u.id);
-                    item.addEventListener('click', function (ev) {
-                        ev.stopPropagation();
-                        selectAssignee(ticketId, u.id, picker);
-                    });
+                    var item = document.createElement('button');
+                    item.type = 'button';
+                    item.className = 'assignee-dropdown-item' + (currentId === u.id ? ' selected' : '');
+                    var av = document.createElement('div');
+                    av.className = 'dd-avatar';
+                    if (u.photo) {
+                        var img = document.createElement('img');
+                        img.src = u.photo;
+                        av.appendChild(img);
+                    } else {
+                        av.textContent = u.initials || '?';
+                    }
+                    item.appendChild(av);
+                    var nm = document.createElement('span');
+                    nm.textContent = u.name;
+                    item.appendChild(nm);
+                    item.addEventListener('click', function (ev) { ev.stopPropagation(); pickUser(u.id); });
                     dd.appendChild(item);
                 });
 
                 picker.appendChild(dd);
-                activeDropdown = dd;
-            });
-        });
+                kanbanDD = dd;
 
-        /**
-         * @description Create a single dropdown item element
-         * @param {number} userId
-         * @param {string} name
-         * @param {string} initials
-         * @param {string} photoUrl
-         * @param {boolean} isSelected
-         * @returns {HTMLElement}
-         */
-        function createDropdownItem(userId, name, initials, photoUrl, isSelected) {
-            var btn = document.createElement('button');
-            btn.type = 'button';
-            btn.className = 'assignee-dropdown-item' + (isSelected ? ' selected' : '');
-            btn.setAttribute('data-user-id', userId);
-
-            var avatarHtml = '';
-            if (photoUrl) {
-                avatarHtml = '<div class="dd-avatar"><img src="' + photoUrl + '" alt="' + initials + '"></div>';
-            } else {
-                avatarHtml = '<div class="dd-avatar">' + (initials || '?') + '</div>';
-            }
-
-            btn.innerHTML = avatarHtml
-                + '<span>' + escapeHtml(name) + '</span>'
-                + (isSelected ? '<i class="fas fa-check dd-check"></i>' : '');
-
-            return btn;
-        }
-
-        /**
-         * @description AJAX call to assign a user to a ticket
-         * @param {string} ticketId
-         * @param {number} newAssigneeId
-         * @param {Element} pickerEl
-         */
-        function selectAssignee(ticketId, newAssigneeId, pickerEl) {
-            closeDropdown();
-
-            var card = pickerEl.closest('.ticket-card-kanban');
-            if (!card) return;
-
-            card.classList.add('kanban-card-loading');
-            card.style.position = 'relative';
-
-            var token = '';
-            var tokenInput = document.querySelector('input[name="token"]');
-            if (tokenInput) token = tokenInput.value;
-
-            var baseUrl = window.location.pathname;
-            var params = 'action=updateticketassignee'
-                + '&token=' + encodeURIComponent(token)
-                + '&ticketid=' + encodeURIComponent(ticketId)
-                + '&assigneeid=' + encodeURIComponent(newAssigneeId);
-
-            var xhr = new XMLHttpRequest();
-            xhr.open('GET', baseUrl + '?' + params, true);
-            xhr.onload = function () {
-                card.classList.remove('kanban-card-loading');
-                try {
-                    var res = JSON.parse(xhr.responseText);
-                    if (res.success) {
-                        // Update card data
-                        card.setAttribute('data-assignee', String(newAssigneeId));
-                        pickerEl.setAttribute('data-current-assignee', String(newAssigneeId));
-
-                        // Update avatar display
-                        updatePickerAvatar(pickerEl, newAssigneeId);
-
-                        // Update status if changed by assignUser()
-                        if (typeof res.new_status !== 'undefined') {
-                            var newSt = String(res.new_status);
-                            var oldSt = card.getAttribute('data-status');
-                            if (newSt !== oldSt) {
-                                card.setAttribute('data-status', newSt);
-                                updateTicketStatusCard(card, newSt);
-                                // Move card to correct column
-                                var targetBody = document.getElementById('kanban-body-' + newSt);
-                                if (targetBody) {
-                                    targetBody.appendChild(card);
-                                    // Remove empty state from target
-                                    var emptyEl = targetBody.querySelector('.kanban-empty-col');
-                                    if (emptyEl) emptyEl.remove();
-                                }
-                                updateColumnCounts();
+                function pickUser(userId) {
+                    dd.remove();
+                    kanbanDD = null;
+                    ajaxSaveField(ticketId, 'assignee', String(userId), function (ok) {
+                        if (ok) {
+                            picker.setAttribute('data-current-assignee', String(userId));
+                            // Update avatar
+                            var caret = picker.querySelector('.tc-assignee-caret');
+                            picker.textContent = '';
+                            var u = users.find(function (x) { return x.id === userId; });
+                            if (u && u.photo) {
+                                var img = document.createElement('img');
+                                img.src = u.photo;
+                                img.className = 'tc-assignee-img';
+                                picker.appendChild(img);
+                            } else {
+                                picker.appendChild(document.createTextNode(u ? u.initials : '?'));
+                            }
+                            if (caret) picker.appendChild(caret);
+                            else {
+                                var nc = document.createElement('i');
+                                nc.className = 'fas fa-caret-down tc-assignee-caret';
+                                picker.appendChild(nc);
                             }
                         }
-
-                        // Success flash
-                        card.style.borderColor = '#22c55e';
-                        card.style.boxShadow = '0 0 0 2px rgba(34,197,94,0.3)';
-                        setTimeout(function () {
-                            card.style.borderColor = '';
-                            card.style.boxShadow = '';
-                        }, 1500);
-                    } else {
-                        console.error('Assignee update failed:', res.error);
-                        card.style.borderColor = '#ef4444';
-                        card.style.boxShadow = '0 0 0 2px rgba(239,68,68,0.3)';
-                        setTimeout(function () {
-                            card.style.borderColor = '';
-                            card.style.boxShadow = '';
-                        }, 3000);
-                    }
-                } catch (e) {
-                    console.error('Invalid JSON response:', xhr.responseText);
+                    });
                 }
-            };
-            xhr.onerror = function () {
-                card.classList.remove('kanban-card-loading');
-                console.error('Network error during assignee update');
-            };
-            xhr.send();
-        }
-
-        /**
-         * @description Update the avatar display in the picker after reassignment
-         * @param {Element} pickerEl
-         * @param {number} userId
-         */
-        function updatePickerAvatar(pickerEl, userId) {
-            // Remove existing content except the caret
-            var caret = pickerEl.querySelector('.tc-assignee-caret');
-            pickerEl.textContent = '';
-
-            if (userId > 0) {
-                var user = null;
-                for (var i = 0; i < users.length; i++) {
-                    if (users[i].id === userId) { user = users[i]; break; }
-                }
-                if (user) {
-                    if (user.photo) {
-                        var img = document.createElement('img');
-                        img.src = user.photo;
-                        img.alt = user.initials;
-                        img.className = 'tc-assignee-img';
-                        pickerEl.appendChild(img);
-                    } else {
-                        pickerEl.appendChild(document.createTextNode(user.initials || '?'));
-                    }
-                } else {
-                    pickerEl.appendChild(document.createTextNode('?'));
-                }
-            } else {
-                pickerEl.appendChild(document.createTextNode('?'));
-            }
-
-            // Re-add caret
-            if (caret) {
-                pickerEl.appendChild(caret);
-            } else {
-                var newCaret = document.createElement('i');
-                newCaret.className = 'fas fa-caret-down tc-assignee-caret';
-                pickerEl.appendChild(newCaret);
-            }
-        }
-
-        function closeDropdown() {
-            if (activeDropdown) {
-                activeDropdown.remove();
-                activeDropdown = null;
-            }
-        }
-
-        /**
-         * @description Escape HTML characters
-         * @param {string} str
-         * @returns {string}
-         */
-        function escapeHtml(str) {
-            if (!str) return '';
-            var div = document.createElement('div');
-            div.appendChild(document.createTextNode(str));
-            return div.innerHTML;
-        }
+            });
+        });
     }
 
 })();
-

--- a/js/reedcrm_tickets_kanban.js
+++ b/js/reedcrm_tickets_kanban.js
@@ -26,6 +26,7 @@
         initColumnToggle();
         initViewToggle();
         initStatusFilter();
+        initAssigneePicker();
         if (!isMobile) {
             initDragAndDrop();
             initColumnResize();
@@ -502,4 +503,243 @@
         });
     }
 
+    // ── ASSIGNEE PICKER DROPDOWN ──────────────────────────────────────
+    /**
+     * @description Click on assignee avatar to show a dropdown of all users
+     */
+    function initAssigneePicker() {
+        var users = window.KANBAN_USERS || [];
+        var activeDropdown = null;
+
+        // Close dropdown on outside click
+        document.addEventListener('click', function (e) {
+            if (activeDropdown && !activeDropdown.contains(e.target) && !e.target.closest('.tc-assignee-picker')) {
+                closeDropdown();
+            }
+        });
+
+        document.querySelectorAll('.tc-assignee-picker').forEach(function (picker) {
+            picker.addEventListener('click', function (e) {
+                e.stopPropagation();
+                e.preventDefault();
+
+                // Close existing dropdown
+                if (activeDropdown) {
+                    var wasOnSame = activeDropdown.parentElement === picker;
+                    closeDropdown();
+                    if (wasOnSame) return;
+                }
+
+                var ticketId = picker.getAttribute('data-ticket-id');
+                var currentAssignee = parseInt(picker.getAttribute('data-current-assignee') || '0', 10);
+
+                // Build dropdown
+                var dd = document.createElement('div');
+                dd.className = 'assignee-dropdown';
+
+                // "Non assigné" option
+                var unassignItem = createDropdownItem(0, 'Non assigné', '?', '', currentAssignee === 0);
+                unassignItem.addEventListener('click', function (ev) {
+                    ev.stopPropagation();
+                    selectAssignee(ticketId, 0, picker);
+                });
+                dd.appendChild(unassignItem);
+
+                // Separator
+                var sep = document.createElement('div');
+                sep.className = 'assignee-dropdown-separator';
+                dd.appendChild(sep);
+
+                // All users
+                users.forEach(function (u) {
+                    var item = createDropdownItem(u.id, u.name, u.initials, u.photo, currentAssignee === u.id);
+                    item.addEventListener('click', function (ev) {
+                        ev.stopPropagation();
+                        selectAssignee(ticketId, u.id, picker);
+                    });
+                    dd.appendChild(item);
+                });
+
+                picker.appendChild(dd);
+                activeDropdown = dd;
+            });
+        });
+
+        /**
+         * @description Create a single dropdown item element
+         * @param {number} userId
+         * @param {string} name
+         * @param {string} initials
+         * @param {string} photoUrl
+         * @param {boolean} isSelected
+         * @returns {HTMLElement}
+         */
+        function createDropdownItem(userId, name, initials, photoUrl, isSelected) {
+            var btn = document.createElement('button');
+            btn.type = 'button';
+            btn.className = 'assignee-dropdown-item' + (isSelected ? ' selected' : '');
+            btn.setAttribute('data-user-id', userId);
+
+            var avatarHtml = '';
+            if (photoUrl) {
+                avatarHtml = '<div class="dd-avatar"><img src="' + photoUrl + '" alt="' + initials + '"></div>';
+            } else {
+                avatarHtml = '<div class="dd-avatar">' + (initials || '?') + '</div>';
+            }
+
+            btn.innerHTML = avatarHtml
+                + '<span>' + escapeHtml(name) + '</span>'
+                + (isSelected ? '<i class="fas fa-check dd-check"></i>' : '');
+
+            return btn;
+        }
+
+        /**
+         * @description AJAX call to assign a user to a ticket
+         * @param {string} ticketId
+         * @param {number} newAssigneeId
+         * @param {Element} pickerEl
+         */
+        function selectAssignee(ticketId, newAssigneeId, pickerEl) {
+            closeDropdown();
+
+            var card = pickerEl.closest('.ticket-card-kanban');
+            if (!card) return;
+
+            card.classList.add('kanban-card-loading');
+            card.style.position = 'relative';
+
+            var token = '';
+            var tokenInput = document.querySelector('input[name="token"]');
+            if (tokenInput) token = tokenInput.value;
+
+            var baseUrl = window.location.pathname;
+            var params = 'action=updateticketassignee'
+                + '&token=' + encodeURIComponent(token)
+                + '&ticketid=' + encodeURIComponent(ticketId)
+                + '&assigneeid=' + encodeURIComponent(newAssigneeId);
+
+            var xhr = new XMLHttpRequest();
+            xhr.open('GET', baseUrl + '?' + params, true);
+            xhr.onload = function () {
+                card.classList.remove('kanban-card-loading');
+                try {
+                    var res = JSON.parse(xhr.responseText);
+                    if (res.success) {
+                        // Update card data
+                        card.setAttribute('data-assignee', String(newAssigneeId));
+                        pickerEl.setAttribute('data-current-assignee', String(newAssigneeId));
+
+                        // Update avatar display
+                        updatePickerAvatar(pickerEl, newAssigneeId);
+
+                        // Update status if changed by assignUser()
+                        if (typeof res.new_status !== 'undefined') {
+                            var newSt = String(res.new_status);
+                            var oldSt = card.getAttribute('data-status');
+                            if (newSt !== oldSt) {
+                                card.setAttribute('data-status', newSt);
+                                updateTicketStatusCard(card, newSt);
+                                // Move card to correct column
+                                var targetBody = document.getElementById('kanban-body-' + newSt);
+                                if (targetBody) {
+                                    targetBody.appendChild(card);
+                                    // Remove empty state from target
+                                    var emptyEl = targetBody.querySelector('.kanban-empty-col');
+                                    if (emptyEl) emptyEl.remove();
+                                }
+                                updateColumnCounts();
+                            }
+                        }
+
+                        // Success flash
+                        card.style.borderColor = '#22c55e';
+                        card.style.boxShadow = '0 0 0 2px rgba(34,197,94,0.3)';
+                        setTimeout(function () {
+                            card.style.borderColor = '';
+                            card.style.boxShadow = '';
+                        }, 1500);
+                    } else {
+                        console.error('Assignee update failed:', res.error);
+                        card.style.borderColor = '#ef4444';
+                        card.style.boxShadow = '0 0 0 2px rgba(239,68,68,0.3)';
+                        setTimeout(function () {
+                            card.style.borderColor = '';
+                            card.style.boxShadow = '';
+                        }, 3000);
+                    }
+                } catch (e) {
+                    console.error('Invalid JSON response:', xhr.responseText);
+                }
+            };
+            xhr.onerror = function () {
+                card.classList.remove('kanban-card-loading');
+                console.error('Network error during assignee update');
+            };
+            xhr.send();
+        }
+
+        /**
+         * @description Update the avatar display in the picker after reassignment
+         * @param {Element} pickerEl
+         * @param {number} userId
+         */
+        function updatePickerAvatar(pickerEl, userId) {
+            // Remove existing content except the caret
+            var caret = pickerEl.querySelector('.tc-assignee-caret');
+            pickerEl.textContent = '';
+
+            if (userId > 0) {
+                var user = null;
+                for (var i = 0; i < users.length; i++) {
+                    if (users[i].id === userId) { user = users[i]; break; }
+                }
+                if (user) {
+                    if (user.photo) {
+                        var img = document.createElement('img');
+                        img.src = user.photo;
+                        img.alt = user.initials;
+                        img.className = 'tc-assignee-img';
+                        pickerEl.appendChild(img);
+                    } else {
+                        pickerEl.appendChild(document.createTextNode(user.initials || '?'));
+                    }
+                } else {
+                    pickerEl.appendChild(document.createTextNode('?'));
+                }
+            } else {
+                pickerEl.appendChild(document.createTextNode('?'));
+            }
+
+            // Re-add caret
+            if (caret) {
+                pickerEl.appendChild(caret);
+            } else {
+                var newCaret = document.createElement('i');
+                newCaret.className = 'fas fa-caret-down tc-assignee-caret';
+                pickerEl.appendChild(newCaret);
+            }
+        }
+
+        function closeDropdown() {
+            if (activeDropdown) {
+                activeDropdown.remove();
+                activeDropdown = null;
+            }
+        }
+
+        /**
+         * @description Escape HTML characters
+         * @param {string} str
+         * @returns {string}
+         */
+        function escapeHtml(str) {
+            if (!str) return '';
+            var div = document.createElement('div');
+            div.appendChild(document.createTextNode(str));
+            return div.innerHTML;
+        }
+    }
+
 })();
+

--- a/view/frontend/pwa_tickets.php
+++ b/view/frontend/pwa_tickets.php
@@ -1,8 +1,8 @@
-<?php
+﻿<?php
 /**
  * \file    view/frontend/pwa_tickets.php
  * \ingroup reedcrm
- * \brief   Page to list Tickets on frontend App view
+ * \brief   Page to list Tickets in Kanban view on frontend App
  */
 
 if (file_exists('../reedcrm.main.inc.php')) {
@@ -15,32 +15,185 @@ if (file_exists('../reedcrm.main.inc.php')) {
 
 global $conf, $db, $hookmanager, $langs, $user;
 
-saturne_load_langs(['ticket']);
+require_once DOL_DOCUMENT_ROOT . '/ticket/class/ticket.class.php';
+require_once DOL_DOCUMENT_ROOT . '/societe/class/societe.class.php';
+require_once DOL_DOCUMENT_ROOT . '/user/class/user.class.php';
+
+saturne_load_langs(['ticket', 'users', 'companies', 'main']);
 
 $title    = $langs->trans('Tickets');
 $help_url = 'FR:Module_ReedCRM';
-$moreJS   = ['/custom/saturne/js/saturne.min.js', '/custom/reedcrm/js/reedcrm.min.js'];
-$moreCSS  = ['/custom/reedcrm/css/reedcrm.min.css'];
+$moreJS   = [
+    '/custom/saturne/js/saturne.min.js',
+    '/custom/reedcrm/js/reedcrm.min.js',
+    '/custom/reedcrm/js/reedcrm_tickets_kanban.js'
+];
+$moreCSS  = [
+    '/custom/saturne/css/saturne.min.css',
+    '/custom/reedcrm/css/reedcrm.min.css',
+    '/custom/reedcrm/css/reedcrm_tickets_kanban.css'
+];
 
 $conf->dol_hide_topmenu  = 1;
 $conf->dol_hide_leftmenu = 1;
+$conf->global->MAIN_FAVICON_URL = DOL_URL_ROOT . '/custom/reedcrm/img/reedcrm_color_512.png';
 
+// --- ACTIONS (AJAX status change via drag & drop) ---
+$action = GETPOST('action', 'aZ09');
+if ($action == 'updateticketstatus') {
+    header('Content-Type: application/json; charset=utf-8');
+    $ticketId  = GETPOST('ticketid', 'int');
+    $newStatus = GETPOST('newstatus', 'int');
+    $res = ['success' => false];
+
+    if ($ticketId > 0 && in_array($newStatus, [
+        Ticket::STATUS_NOT_READ,      // 0
+        Ticket::STATUS_READ,          // 1
+        Ticket::STATUS_ASSIGNED,      // 2
+        Ticket::STATUS_IN_PROGRESS,   // 3
+        Ticket::STATUS_NEED_MORE_INFO,// 5
+        Ticket::STATUS_WAITING,       // 7
+        Ticket::STATUS_CLOSED,        // 8
+        Ticket::STATUS_CANCELED,      // 9
+    ])) {
+        $ticket = new Ticket($db);
+        $fetchRes = $ticket->fetch($ticketId);
+        if ($fetchRes > 0 && $ticket->id > 0) {
+            // Use close() for closing statuses, setStatut() for others
+            if ($newStatus == Ticket::STATUS_CLOSED) {
+                $result = $ticket->close($user, 0); // mode 0 = solved
+            } elseif ($newStatus == Ticket::STATUS_CANCELED) {
+                $result = $ticket->close($user, 1); // mode 1 = canceled
+            } else {
+                $result = $ticket->setStatut($newStatus, null, '', 'TICKET_MODIFY');
+            }
+            if ($result >= 0) {
+                $res['success'] = true;
+                $res['new_status'] = $newStatus;
+            } else {
+                $res['error'] = $ticket->error ?: 'Update failed';
+            }
+        } else {
+            $res['error'] = 'Ticket not found (id=' . $ticketId . ')';
+        }
+    } else {
+        $res['error'] = 'Invalid parameters (id=' . $ticketId . ', status=' . $newStatus . ')';
+    }
+    echo json_encode($res);
+    exit;
+}
+
+// --- PERMISSION CHECK ---
 llxHeader('', $title, $help_url, '', 0, 0, $moreJS, $moreCSS, '', 'template-pwa pwa-tickets-list');
 
-if (!$user->rights->ticket->read) {
+if (!$user->hasRight('ticket', 'read')) {
     accessforbidden($langs->trans('NotEnoughPermissions'), 0);
     exit;
 }
 
-// Define specific indicators for this page (optional)
-$pwaHeaderCenterHtml = '<div style="background: #e2e8f0; padding: 4px 10px; border-radius: 12px; font-size: 13px; font-weight: bold; color: #475569;"><i class="fas fa-ticket-alt"></i> 99 Tickets</div>';
+// --- FETCH ALL TICKETS ---
+$sql  = "SELECT t.rowid, t.ref, t.track_id, t.subject, t.message, t.fk_statut as status,";
+$sql .= " t.fk_soc, t.fk_user_assign, t.fk_user_create, t.datec, t.date_read, t.date_close,";
+$sql .= " t.severity_code, t.type_code, t.category_code, t.progress,";
+$sql .= " s.nom as company_name";
+$sql .= " FROM " . MAIN_DB_PREFIX . "ticket as t";
+$sql .= " LEFT JOIN " . MAIN_DB_PREFIX . "societe as s ON s.rowid = t.fk_soc";
+$sql .= " WHERE t.entity IN (" . getEntity('ticket') . ")";
+$sql .= " ORDER BY t.datec DESC";
+
+$tickets = [];
+$assignees = [];
+$resql = $db->query($sql);
+if ($resql) {
+    while ($obj = $db->fetch_object($resql)) {
+        $tickets[] = $obj;
+        if (!empty($obj->fk_user_assign) && $obj->fk_user_assign > 0) {
+            $assignees[$obj->fk_user_assign] = true;
+        }
+    }
+    $db->free($resql);
+}
+$totalTickets = count($tickets);
+
+// --- FETCH ASSIGNEE USER DATA ---
+$usersData = [];
+if (!empty($assignees)) {
+    $userIds = array_keys($assignees);
+    $sqlU  = "SELECT u.rowid, u.firstname, u.lastname, u.login, u.photo";
+    $sqlU .= " FROM " . MAIN_DB_PREFIX . "user as u";
+    $sqlU .= " WHERE u.rowid IN (" . implode(',', array_map('intval', $userIds)) . ")";
+    $resU = $db->query($sqlU);
+    if ($resU) {
+        while ($uObj = $db->fetch_object($resU)) {
+            $usersData[$uObj->rowid] = $uObj;
+        }
+        $db->free($resU);
+    }
+}
+
+// --- Status Map (Dolibarr 23 Ticket constants) ---
+$statusMap = [
+    Ticket::STATUS_NOT_READ       => ['label' => 'Non lu',         'color' => '#e74c3c'],
+    Ticket::STATUS_READ           => ['label' => 'Lu',             'color' => '#f39c12'],
+    Ticket::STATUS_ASSIGNED       => ['label' => 'Assigné',        'color' => '#f1c40f'],
+    Ticket::STATUS_IN_PROGRESS    => ['label' => 'En cours',       'color' => '#3498db'],
+    Ticket::STATUS_NEED_MORE_INFO => ['label' => "Besoin d'info",  'color' => '#e67e22'],
+    Ticket::STATUS_WAITING        => ['label' => 'En attente',     'color' => '#9b59b6'],
+    Ticket::STATUS_CLOSED         => ['label' => 'Fermé',          'color' => '#2ecc71'],
+    Ticket::STATUS_CANCELED       => ['label' => 'Annulé',         'color' => '#7f8c8d'],
+];
+
+// --- Severity Map ---
+$severityMap = [
+    'LOW'      => 'Basse',
+    'NORMAL'   => 'Normale',
+    'HIGH'     => 'Haute',
+    'BLOCKING' => 'Bloquante',
+];
+
+// Group tickets by status
+$ticketsByStatus = [];
+foreach (array_keys($statusMap) as $st) {
+    $ticketsByStatus[$st] = [];
+}
+foreach ($tickets as $t) {
+    $st = (int)$t->status;
+    if (!isset($ticketsByStatus[$st])) {
+        $ticketsByStatus[$st] = [];
+    }
+    $ticketsByStatus[$st][] = $t;
+}
+
+// --- Expose CSRF token for AJAX ---
+$csrfToken = newToken();
+
+// --- SEARCH BAR + COUNTER + VIEW TOGGLE FOR HEADER ---
+$pwaHeaderCenterHtml  = '<div style="display: flex; align-items: center; width: 100%; justify-content: center; gap: 8px;">';
+$pwaHeaderCenterHtml .= '  <div style="white-space: nowrap; background: #e2e8f0; padding: 4px 10px; border-radius: 12px; font-size: 13px; font-weight: bold; color: #475569;"><i class="fas fa-ticket-alt"></i> ' . $totalTickets . '</div>';
+
+// View toggle: Kanban / List
+$pwaHeaderCenterHtml .= '  <div class="kanban-view-toggle" id="kanban-view-toggle">';
+$pwaHeaderCenterHtml .= '    <button class="view-toggle-btn active" data-view="kanban" title="Vue Kanban"><i class="fas fa-columns"></i></button>';
+$pwaHeaderCenterHtml .= '    <button class="view-toggle-btn" data-view="list" title="Vue Liste"><i class="fas fa-list"></i></button>';
+$pwaHeaderCenterHtml .= '  </div>';
+
+$pwaHeaderCenterHtml .= '  <div id="kanban-search-bar" style="display: flex; gap: 6px; flex: 1; max-width: 400px;">';
+$pwaHeaderCenterHtml .= '    <div style="position: relative; flex: 1; min-width: 40px;">';
+$pwaHeaderCenterHtml .= '      <i class="fas fa-search" style="position: absolute; left: 10px; top: 50%; transform: translateY(-50%); color: #94a3b8; font-size: 0.85em;"></i>';
+$pwaHeaderCenterHtml .= '      <input type="text" id="kanban-search-input" placeholder="Rechercher..." style="width: 100%; padding: 6px 10px 6px 28px; border: 1px solid #cbd5e0; border-radius: 20px; font-size: 14px; outline: none; box-shadow: inset 0 1px 2px rgba(0,0,0,0.05); transition: border-color 0.2s; box-sizing: border-box;">';
+$pwaHeaderCenterHtml .= '    </div>';
+$pwaHeaderCenterHtml .= '  </div>';
+$pwaHeaderCenterHtml .= '</div>';
+
 require_once __DIR__ . '/../../core/tpl/frontend/reedcrm_pwa_header.tpl.php';
 
-print '<div class="pwa-container" style="padding: 15px;">';
-print '  <h2><i class="fas fa-ticket-alt" style="color: #64748b;"></i> ' . $langs->trans('Tickets') . '</h2>';
-print '  <p style="color: #64748b;">La liste optimisée App sera développée ici lors de la prochaine étape !</p>';
-print '</div>';
+// Output CSRF token for JS
+print '<input type="hidden" name="token" value="' . $csrfToken . '">';
 
+// --- KANBAN TEMPLATE ---
+require_once __DIR__ . '/../../core/tpl/frontend/reedcrm_tickets_kanban.tpl.php';
+
+// --- BOTTOM NAV ---
 require_once __DIR__ . '/../../core/tpl/frontend/reedcrm_pwa_bottom_nav.tpl.php';
 
 llxFooter();

--- a/view/frontend/pwa_tickets.php
+++ b/view/frontend/pwa_tickets.php
@@ -83,6 +83,37 @@ if ($action == 'updateticketstatus') {
     exit;
 }
 
+// --- AJAX: Change assigned user ---
+if ($action == 'updateticketassignee') {
+    header('Content-Type: application/json; charset=utf-8');
+    $ticketId   = GETPOST('ticketid', 'int');
+    $assigneeId = GETPOST('assigneeid', 'int');
+    $res = ['success' => false];
+
+    if ($ticketId > 0) {
+        $ticket = new Ticket($db);
+        $fetchRes = $ticket->fetch($ticketId);
+        if ($fetchRes > 0 && $ticket->id > 0) {
+            $result = $ticket->assignUser($user, $assigneeId > 0 ? $assigneeId : 0);
+            if ($result > 0) {
+                $res['success']     = true;
+                $res['assignee_id'] = $assigneeId;
+                // Return new status (assignUser changes it)
+                $ticket->fetch($ticketId);
+                $res['new_status']  = (int)$ticket->fk_statut;
+            } else {
+                $res['error'] = $ticket->error ?: 'Assign failed';
+            }
+        } else {
+            $res['error'] = 'Ticket not found';
+        }
+    } else {
+        $res['error'] = 'Invalid ticket ID';
+    }
+    echo json_encode($res);
+    exit;
+}
+
 // --- PERMISSION CHECK ---
 llxHeader('', $title, $help_url, '', 0, 0, $moreJS, $moreCSS, '', 'template-pwa pwa-tickets-list');
 
@@ -115,20 +146,24 @@ if ($resql) {
 }
 $totalTickets = count($tickets);
 
-// --- FETCH ASSIGNEE USER DATA ---
+// --- FETCH ALL INTERNAL USERS (for assignee dropdown + filter chips) ---
 $usersData = [];
-if (!empty($assignees)) {
-    $userIds = array_keys($assignees);
-    $sqlU  = "SELECT u.rowid, u.firstname, u.lastname, u.login, u.photo";
-    $sqlU .= " FROM " . MAIN_DB_PREFIX . "user as u";
-    $sqlU .= " WHERE u.rowid IN (" . implode(',', array_map('intval', $userIds)) . ")";
-    $resU = $db->query($sqlU);
-    if ($resU) {
-        while ($uObj = $db->fetch_object($resU)) {
+$allInternalUsers = [];
+$sqlU  = "SELECT u.rowid, u.firstname, u.lastname, u.login, u.photo, u.statut as user_status";
+$sqlU .= " FROM " . MAIN_DB_PREFIX . "user as u";
+$sqlU .= " WHERE u.entity IN (" . getEntity('user') . ")";
+$sqlU .= " AND u.statut = 1"; // active users only
+$sqlU .= " ORDER BY u.firstname ASC, u.lastname ASC";
+$resU = $db->query($sqlU);
+if ($resU) {
+    while ($uObj = $db->fetch_object($resU)) {
+        $allInternalUsers[$uObj->rowid] = $uObj;
+        // Also populate usersData for assignees that have tickets
+        if (isset($assignees[$uObj->rowid])) {
             $usersData[$uObj->rowid] = $uObj;
         }
-        $db->free($resU);
     }
+    $db->free($resU);
 }
 
 // --- Status Map (Dolibarr 23 Ticket constants) ---
@@ -190,6 +225,20 @@ require_once __DIR__ . '/../../core/tpl/frontend/reedcrm_pwa_header.tpl.php';
 // Output CSRF token for JS
 print '<input type="hidden" name="token" value="' . $csrfToken . '">';
 
+// Output all internal users as JSON for assignee dropdown
+$usersJsonData = [];
+foreach ($allInternalUsers as $uid => $uObj) {
+    $fn = trim(($uObj->firstname ?? '') . ' ' . ($uObj->lastname ?? ''));
+    if (empty($fn)) $fn = $uObj->login ?? 'User #' . $uid;
+    $usersJsonData[] = [
+        'id'       => (int)$uid,
+        'name'     => $fn,
+        'initials' => mb_strtoupper(mb_substr($uObj->firstname ?? '', 0, 1) . mb_substr($uObj->lastname ?? '', 0, 1)),
+        'photo'    => (!empty($uObj->photo) && trim($uObj->photo) !== '') ? DOL_URL_ROOT . '/viewimage.php?modulepart=user&file=' . urlencode($uid . '/' . $uObj->photo) : '',
+    ];
+}
+print '<script>window.KANBAN_USERS = ' . json_encode($usersJsonData) . ';</script>';
+
 // --- KANBAN TEMPLATE ---
 require_once __DIR__ . '/../../core/tpl/frontend/reedcrm_tickets_kanban.tpl.php';
 
@@ -198,3 +247,5 @@ require_once __DIR__ . '/../../core/tpl/frontend/reedcrm_pwa_bottom_nav.tpl.php'
 
 llxFooter();
 $db->close();
+
+

--- a/view/frontend/pwa_tickets.php
+++ b/view/frontend/pwa_tickets.php
@@ -2,7 +2,7 @@
 /**
  * \file    view/frontend/pwa_tickets.php
  * \ingroup reedcrm
- * \brief   Page to list Tickets in Kanban view on frontend App
+ * \brief   Page to list Tickets in Kanban + Notion table view on frontend PWA
  */
 
 if (file_exists('../reedcrm.main.inc.php')) {
@@ -18,8 +18,9 @@ global $conf, $db, $hookmanager, $langs, $user;
 require_once DOL_DOCUMENT_ROOT . '/ticket/class/ticket.class.php';
 require_once DOL_DOCUMENT_ROOT . '/societe/class/societe.class.php';
 require_once DOL_DOCUMENT_ROOT . '/user/class/user.class.php';
+require_once DOL_DOCUMENT_ROOT . '/categories/class/categorie.class.php';
 
-saturne_load_langs(['ticket', 'users', 'companies', 'main']);
+saturne_load_langs(['ticket', 'users', 'companies', 'main', 'categories']);
 
 $title    = $langs->trans('Tickets');
 $help_url = 'FR:Module_ReedCRM';
@@ -38,77 +39,111 @@ $conf->dol_hide_topmenu  = 1;
 $conf->dol_hide_leftmenu = 1;
 $conf->global->MAIN_FAVICON_URL = DOL_URL_ROOT . '/custom/reedcrm/img/reedcrm_color_512.png';
 
-// --- ACTIONS (AJAX status change via drag & drop) ---
-$action = GETPOST('action', 'aZ09');
-if ($action == 'updateticketstatus') {
-    header('Content-Type: application/json; charset=utf-8');
-    $ticketId  = GETPOST('ticketid', 'int');
-    $newStatus = GETPOST('newstatus', 'int');
-    $res = ['success' => false];
-
-    if ($ticketId > 0 && in_array($newStatus, [
-        Ticket::STATUS_NOT_READ,      // 0
-        Ticket::STATUS_READ,          // 1
-        Ticket::STATUS_ASSIGNED,      // 2
-        Ticket::STATUS_IN_PROGRESS,   // 3
-        Ticket::STATUS_NEED_MORE_INFO,// 5
-        Ticket::STATUS_WAITING,       // 7
-        Ticket::STATUS_CLOSED,        // 8
-        Ticket::STATUS_CANCELED,      // 9
-    ])) {
-        $ticket = new Ticket($db);
-        $fetchRes = $ticket->fetch($ticketId);
-        if ($fetchRes > 0 && $ticket->id > 0) {
-            // Use close() for closing statuses, setStatut() for others
-            if ($newStatus == Ticket::STATUS_CLOSED) {
-                $result = $ticket->close($user, 0); // mode 0 = solved
-            } elseif ($newStatus == Ticket::STATUS_CANCELED) {
-                $result = $ticket->close($user, 1); // mode 1 = canceled
-            } else {
-                $result = $ticket->setStatut($newStatus, null, '', 'TICKET_MODIFY');
-            }
-            if ($result >= 0) {
-                $res['success'] = true;
-                $res['new_status'] = $newStatus;
-            } else {
-                $res['error'] = $ticket->error ?: 'Update failed';
-            }
-        } else {
-            $res['error'] = 'Ticket not found (id=' . $ticketId . ')';
-        }
-    } else {
-        $res['error'] = 'Invalid parameters (id=' . $ticketId . ', status=' . $newStatus . ')';
-    }
-    echo json_encode($res);
-    exit;
+// --- SERVER-SIDE SORT ---
+$sortfield = GETPOST('sortfield', 'aZ09') ?: 'datec';
+$sortorder = GETPOST('sortorder', 'aZ') ?: 'DESC';
+$allowedSort = ['ref', 'datec', 'subject', 'severity_code', 'fk_statut', 'fk_user_assign'];
+if (!in_array($sortfield, $allowedSort)) {
+    $sortfield = 'datec';
+}
+if (!in_array(strtoupper($sortorder), ['ASC', 'DESC'])) {
+    $sortorder = 'DESC';
 }
 
-// --- AJAX: Change assigned user ---
-if ($action == 'updateticketassignee') {
+// --- COLUMN SEARCH PARAMS ---
+$s_ref       = trim(GETPOST('s_ref', 'alpha'));
+$s_subject   = trim(GETPOST('s_subject', 'alpha'));
+$s_severity  = trim(GETPOST('s_severity', 'alpha'));
+$s_author    = trim(GETPOST('s_author', 'alpha'));
+$s_assignee  = GETPOST('s_assignee', 'int');
+$s_status    = GETPOST('s_status', 'int');
+$s_tags      = trim(GETPOST('s_tags', 'alpha'));
+$viewmode    = GETPOST('viewmode', 'alpha') ?: 'table';
+
+// --- ACTIONS (AJAX) ---
+$action = GETPOST('action', 'aZ09');
+
+// AJAX: Update a ticket field
+if ($action == 'updateticketfield') {
     header('Content-Type: application/json; charset=utf-8');
-    $ticketId   = GETPOST('ticketid', 'int');
-    $assigneeId = GETPOST('assigneeid', 'int');
+    $ticketId = GETPOST('ticketid', 'int');
+    $field    = GETPOST('field', 'aZ09');
+    $value    = GETPOST('value', 'alphanohtml');
     $res = ['success' => false];
 
-    if ($ticketId > 0) {
+    if ($ticketId > 0 && !empty($field)) {
         $ticket = new Ticket($db);
         $fetchRes = $ticket->fetch($ticketId);
         if ($fetchRes > 0 && $ticket->id > 0) {
-            $result = $ticket->assignUser($user, $assigneeId > 0 ? $assigneeId : 0);
-            if ($result > 0) {
-                $res['success']     = true;
-                $res['assignee_id'] = $assigneeId;
-                // Return new status (assignUser changes it)
-                $ticket->fetch($ticketId);
-                $res['new_status']  = (int)$ticket->fk_statut;
-            } else {
-                $res['error'] = $ticket->error ?: 'Assign failed';
+            switch ($field) {
+                case 'subject':
+                    $ticket->subject = $value;
+                    $result = $ticket->update($user);
+                    $res['success'] = ($result >= 0);
+                    if ($result < 0) $res['error'] = $ticket->error;
+                    break;
+
+                case 'severity':
+                    $ticket->severity_code = $value;
+                    $result = $ticket->update($user);
+                    $res['success'] = ($result >= 0);
+                    if ($result < 0) $res['error'] = $ticket->error;
+                    break;
+
+                case 'status':
+                    $newStatus = (int)$value;
+                    if ($newStatus == Ticket::STATUS_CLOSED) {
+                        $result = $ticket->close($user, 0);
+                    } elseif ($newStatus == Ticket::STATUS_CANCELED) {
+                        $result = $ticket->close($user, 1);
+                    } else {
+                        $result = $ticket->setStatut($newStatus, null, '', 'TICKET_MODIFY');
+                    }
+                    $res['success'] = ($result >= 0);
+                    if ($result < 0) $res['error'] = $ticket->error;
+                    break;
+
+                case 'assignee':
+                    $assigneeId = (int)$value;
+                    $result = $ticket->assignUser($user, $assigneeId > 0 ? $assigneeId : 0);
+                    $res['success'] = ($result > 0);
+                    if ($result <= 0) $res['error'] = $ticket->error;
+                    // Return new status
+                    $ticket->fetch($ticketId);
+                    $res['new_status'] = (int)$ticket->fk_statut;
+                    break;
+
+                case 'tags':
+                    // value = comma-separated category IDs
+                    $catIds = array_filter(array_map('intval', explode(',', $value)));
+                    // Remove all existing ticket categories
+                    $cat = new Categorie($db);
+                    $existingCats = $cat->getListForItem($ticketId, 'ticket');
+                    if (is_array($existingCats)) {
+                        foreach ($existingCats as $existCat) {
+                            $catToDel = new Categorie($db);
+                            $catToDel->fetch($existCat['id']);
+                            $catToDel->del_type($ticket, 'ticket');
+                        }
+                    }
+                    // Add new categories
+                    foreach ($catIds as $catId) {
+                        $catToAdd = new Categorie($db);
+                        if ($catToAdd->fetch($catId) > 0) {
+                            $catToAdd->add_type($ticket, 'ticket');
+                        }
+                    }
+                    $res['success'] = true;
+                    break;
+
+                default:
+                    $res['error'] = 'Unknown field: ' . $field;
             }
         } else {
             $res['error'] = 'Ticket not found';
         }
     } else {
-        $res['error'] = 'Invalid ticket ID';
+        $res['error'] = 'Invalid parameters';
     }
     echo json_encode($res);
     exit;
@@ -122,15 +157,97 @@ if (!$user->hasRight('ticket', 'read')) {
     exit;
 }
 
+// --- FETCH DICTIONARIES ---
+// Severities
+$severities = [];
+$resSev = $db->query("SELECT code, label FROM " . MAIN_DB_PREFIX . "c_ticket_severity WHERE active = 1 ORDER BY pos");
+if ($resSev) {
+    while ($obj = $db->fetch_object($resSev)) {
+        $severities[$obj->code] = $langs->trans($obj->label);
+    }
+    $db->free($resSev);
+}
+
+// Types
+$ticketTypes = [];
+$resType = $db->query("SELECT code, label FROM " . MAIN_DB_PREFIX . "c_ticket_type WHERE active = 1 ORDER BY pos");
+if ($resType) {
+    while ($obj = $db->fetch_object($resType)) {
+        $ticketTypes[$obj->code] = $langs->trans($obj->label);
+    }
+    $db->free($resType);
+}
+
+// All available tag categories for tickets
+$allTagCategories = [];
+$resCat = $db->query("SELECT c.rowid, c.label, c.color FROM " . MAIN_DB_PREFIX . "categorie c WHERE c.type = " . Categorie::TYPE_TICKET . " AND c.entity IN (" . getEntity('categorie') . ") ORDER BY c.label");
+if ($resCat) {
+    while ($obj = $db->fetch_object($resCat)) {
+        $allTagCategories[$obj->rowid] = ['label' => $obj->label, 'color' => $obj->color ?: 'cccccc'];
+    }
+    $db->free($resCat);
+}
+
+// --- FETCH ALL INTERNAL USERS ---
+$allInternalUsers = [];
+$sqlU  = "SELECT u.rowid, u.firstname, u.lastname, u.login, u.photo";
+$sqlU .= " FROM " . MAIN_DB_PREFIX . "user as u";
+$sqlU .= " WHERE u.entity IN (" . getEntity('user') . ") AND u.statut = 1";
+$sqlU .= " ORDER BY u.firstname ASC, u.lastname ASC";
+$resU = $db->query($sqlU);
+if ($resU) {
+    while ($uObj = $db->fetch_object($resU)) {
+        $allInternalUsers[$uObj->rowid] = $uObj;
+    }
+    $db->free($resU);
+}
+
 // --- FETCH ALL TICKETS ---
-$sql  = "SELECT t.rowid, t.ref, t.track_id, t.subject, t.message, t.fk_statut as status,";
+$sql  = "SELECT DISTINCT t.rowid, t.ref, t.track_id, t.subject, t.message, t.fk_statut as status,";
 $sql .= " t.fk_soc, t.fk_user_assign, t.fk_user_create, t.datec, t.date_read, t.date_close,";
 $sql .= " t.severity_code, t.type_code, t.category_code, t.progress,";
-$sql .= " s.nom as company_name";
+$sql .= " s.nom as company_name,";
+$sql .= " ua.firstname as assign_firstname, ua.lastname as assign_lastname, ua.login as assign_login, ua.photo as assign_photo,";
+$sql .= " uc.firstname as author_firstname, uc.lastname as author_lastname, uc.login as author_login, uc.photo as author_photo";
 $sql .= " FROM " . MAIN_DB_PREFIX . "ticket as t";
 $sql .= " LEFT JOIN " . MAIN_DB_PREFIX . "societe as s ON s.rowid = t.fk_soc";
+$sql .= " LEFT JOIN " . MAIN_DB_PREFIX . "user as ua ON ua.rowid = t.fk_user_assign";
+$sql .= " LEFT JOIN " . MAIN_DB_PREFIX . "user as uc ON uc.rowid = t.fk_user_create";
+
+// Join for tag search
+if (!empty($s_tags)) {
+    $sql .= " INNER JOIN " . MAIN_DB_PREFIX . "categorie_ticket as ct ON ct.fk_ticket = t.rowid";
+    $sql .= " INNER JOIN " . MAIN_DB_PREFIX . "categorie as catf ON catf.rowid = ct.fk_categorie";
+}
+
 $sql .= " WHERE t.entity IN (" . getEntity('ticket') . ")";
-$sql .= " ORDER BY t.datec DESC";
+
+// Column filters
+if (!empty($s_ref)) {
+    $sql .= " AND t.ref LIKE '%" . $db->escape($s_ref) . "%'";
+}
+if (!empty($s_subject)) {
+    $sql .= " AND t.subject LIKE '%" . $db->escape($s_subject) . "%'";
+}
+if (!empty($s_severity)) {
+    $sql .= " AND t.severity_code = '" . $db->escape($s_severity) . "'";
+}
+if (!empty($s_author)) {
+    $sql .= " AND (uc.firstname LIKE '%" . $db->escape($s_author) . "%' OR uc.lastname LIKE '%" . $db->escape($s_author) . "%')";
+}
+if ($s_assignee !== '' && $s_assignee > 0) {
+    $sql .= " AND t.fk_user_assign = " . (int)$s_assignee;
+} elseif ($s_assignee === '0') {
+    $sql .= " AND (t.fk_user_assign IS NULL OR t.fk_user_assign = 0)";
+}
+if ($s_status !== '' && $s_status >= 0) {
+    $sql .= " AND t.fk_statut = " . (int)$s_status;
+}
+if (!empty($s_tags)) {
+    $sql .= " AND catf.label LIKE '%" . $db->escape($s_tags) . "%'";
+}
+
+$sql .= " ORDER BY t." . $sortfield . " " . $sortorder;
 
 $tickets = [];
 $assignees = [];
@@ -146,86 +263,87 @@ if ($resql) {
 }
 $totalTickets = count($tickets);
 
-// --- FETCH ALL INTERNAL USERS (for assignee dropdown + filter chips) ---
-$usersData = [];
-$allInternalUsers = [];
-$sqlU  = "SELECT u.rowid, u.firstname, u.lastname, u.login, u.photo, u.statut as user_status";
-$sqlU .= " FROM " . MAIN_DB_PREFIX . "user as u";
-$sqlU .= " WHERE u.entity IN (" . getEntity('user') . ")";
-$sqlU .= " AND u.statut = 1"; // active users only
-$sqlU .= " ORDER BY u.firstname ASC, u.lastname ASC";
-$resU = $db->query($sqlU);
-if ($resU) {
-    while ($uObj = $db->fetch_object($resU)) {
-        $allInternalUsers[$uObj->rowid] = $uObj;
-        // Also populate usersData for assignees that have tickets
-        if (isset($assignees[$uObj->rowid])) {
-            $usersData[$uObj->rowid] = $uObj;
+// Fetch tags for each ticket
+$ticketTags = [];
+if (!empty($tickets)) {
+    $ticketIds = array_map(function($t) { return (int)$t->rowid; }, $tickets);
+    $sqlTags  = "SELECT ct.fk_ticket, c.rowid as cat_id, c.label, c.color";
+    $sqlTags .= " FROM " . MAIN_DB_PREFIX . "categorie_ticket as ct";
+    $sqlTags .= " INNER JOIN " . MAIN_DB_PREFIX . "categorie as c ON c.rowid = ct.fk_categorie";
+    $sqlTags .= " WHERE ct.fk_ticket IN (" . implode(',', $ticketIds) . ")";
+    $sqlTags .= " ORDER BY c.label";
+    $resTags = $db->query($sqlTags);
+    if ($resTags) {
+        while ($tagObj = $db->fetch_object($resTags)) {
+            $ticketTags[(int)$tagObj->fk_ticket][] = [
+                'id'    => (int)$tagObj->cat_id,
+                'label' => $tagObj->label,
+                'color' => $tagObj->color ?: 'cccccc'
+            ];
         }
+        $db->free($resTags);
     }
-    $db->free($resU);
 }
 
-// --- Status Map (Dolibarr 23 Ticket constants) ---
+// --- Status Map (Dolibarr 23) ---
 $statusMap = [
-    Ticket::STATUS_NOT_READ       => ['label' => 'Non lu',         'color' => '#e74c3c'],
-    Ticket::STATUS_READ           => ['label' => 'Lu',             'color' => '#f39c12'],
-    Ticket::STATUS_ASSIGNED       => ['label' => 'Assigné',        'color' => '#f1c40f'],
-    Ticket::STATUS_IN_PROGRESS    => ['label' => 'En cours',       'color' => '#3498db'],
-    Ticket::STATUS_NEED_MORE_INFO => ['label' => "Besoin d'info",  'color' => '#e67e22'],
-    Ticket::STATUS_WAITING        => ['label' => 'En attente',     'color' => '#9b59b6'],
-    Ticket::STATUS_CLOSED         => ['label' => 'Fermé',          'color' => '#2ecc71'],
-    Ticket::STATUS_CANCELED       => ['label' => 'Annulé',         'color' => '#7f8c8d'],
+    Ticket::STATUS_NOT_READ       => ['label' => $langs->trans('Unread') ?: 'Non lu',       'color' => '#e74c3c'],
+    Ticket::STATUS_READ           => ['label' => $langs->trans('Read') ?: 'Lu',              'color' => '#f39c12'],
+    Ticket::STATUS_ASSIGNED       => ['label' => $langs->trans('Assigned') ?: 'Assigné',     'color' => '#f1c40f'],
+    Ticket::STATUS_IN_PROGRESS    => ['label' => $langs->trans('InProgress') ?: 'En cours',  'color' => '#3498db'],
+    Ticket::STATUS_NEED_MORE_INFO => ['label' => $langs->trans('NeedMoreInformation') ?: "Besoin d'info", 'color' => '#e67e22'],
+    Ticket::STATUS_WAITING        => ['label' => $langs->trans('OnHold') ?: 'En attente',    'color' => '#9b59b6'],
+    Ticket::STATUS_CLOSED         => ['label' => $langs->trans('Closed') ?: 'Fermé',         'color' => '#2ecc71'],
+    Ticket::STATUS_CANCELED       => ['label' => $langs->trans('Canceled') ?: 'Annulé',      'color' => '#7f8c8d'],
 ];
 
-// --- Severity Map ---
 $severityMap = [
-    'LOW'      => 'Basse',
-    'NORMAL'   => 'Normale',
-    'HIGH'     => 'Haute',
-    'BLOCKING' => 'Bloquante',
+    'LOW'      => $severities['LOW'] ?? 'Basse',
+    'NORMAL'   => $severities['NORMAL'] ?? 'Normale',
+    'HIGH'     => $severities['HIGH'] ?? 'Haute',
+    'BLOCKING' => $severities['BLOCKING'] ?? 'Bloquante',
 ];
 
-// Group tickets by status
+// Group tickets by status (for Kanban view)
 $ticketsByStatus = [];
 foreach (array_keys($statusMap) as $st) {
     $ticketsByStatus[$st] = [];
 }
 foreach ($tickets as $t) {
     $st = (int)$t->status;
-    if (!isset($ticketsByStatus[$st])) {
-        $ticketsByStatus[$st] = [];
-    }
+    if (!isset($ticketsByStatus[$st])) $ticketsByStatus[$st] = [];
     $ticketsByStatus[$st][] = $t;
 }
 
-// --- Expose CSRF token for AJAX ---
+// UsersData for Kanban filter chips (only assigned users)
+$usersData = [];
+foreach ($allInternalUsers as $uid => $uObj) {
+    if (isset($assignees[$uid])) {
+        $usersData[$uid] = $uObj;
+    }
+}
+
+// --- CSRF TOKEN ---
 $csrfToken = newToken();
 
-// --- SEARCH BAR + COUNTER + VIEW TOGGLE FOR HEADER ---
+// --- HEADER ---
 $pwaHeaderCenterHtml  = '<div style="display: flex; align-items: center; width: 100%; justify-content: center; gap: 8px;">';
 $pwaHeaderCenterHtml .= '  <div style="white-space: nowrap; background: #e2e8f0; padding: 4px 10px; border-radius: 12px; font-size: 13px; font-weight: bold; color: #475569;"><i class="fas fa-ticket-alt"></i> ' . $totalTickets . '</div>';
 
-// View toggle: Kanban / List
+// View toggle
 $pwaHeaderCenterHtml .= '  <div class="kanban-view-toggle" id="kanban-view-toggle">';
-$pwaHeaderCenterHtml .= '    <button class="view-toggle-btn active" data-view="kanban" title="Vue Kanban"><i class="fas fa-columns"></i></button>';
-$pwaHeaderCenterHtml .= '    <button class="view-toggle-btn" data-view="list" title="Vue Liste"><i class="fas fa-list"></i></button>';
+$pwaHeaderCenterHtml .= '    <button class="view-toggle-btn' . ($viewmode == 'kanban' ? ' active' : '') . '" data-view="kanban" title="Vue Kanban"><i class="fas fa-columns"></i></button>';
+$pwaHeaderCenterHtml .= '    <button class="view-toggle-btn' . ($viewmode == 'table' ? ' active' : '') . '" data-view="table" title="Vue Table"><i class="fas fa-list"></i></button>';
 $pwaHeaderCenterHtml .= '  </div>';
 
-$pwaHeaderCenterHtml .= '  <div id="kanban-search-bar" style="display: flex; gap: 6px; flex: 1; max-width: 400px;">';
-$pwaHeaderCenterHtml .= '    <div style="position: relative; flex: 1; min-width: 40px;">';
-$pwaHeaderCenterHtml .= '      <i class="fas fa-search" style="position: absolute; left: 10px; top: 50%; transform: translateY(-50%); color: #94a3b8; font-size: 0.85em;"></i>';
-$pwaHeaderCenterHtml .= '      <input type="text" id="kanban-search-input" placeholder="Rechercher..." style="width: 100%; padding: 6px 10px 6px 28px; border: 1px solid #cbd5e0; border-radius: 20px; font-size: 14px; outline: none; box-shadow: inset 0 1px 2px rgba(0,0,0,0.05); transition: border-color 0.2s; box-sizing: border-box;">';
-$pwaHeaderCenterHtml .= '    </div>';
-$pwaHeaderCenterHtml .= '  </div>';
 $pwaHeaderCenterHtml .= '</div>';
 
 require_once __DIR__ . '/../../core/tpl/frontend/reedcrm_pwa_header.tpl.php';
 
-// Output CSRF token for JS
+// Hidden token
 print '<input type="hidden" name="token" value="' . $csrfToken . '">';
 
-// Output all internal users as JSON for assignee dropdown
+// JSON data for JS
 $usersJsonData = [];
 foreach ($allInternalUsers as $uid => $uObj) {
     $fn = trim(($uObj->firstname ?? '') . ' ' . ($uObj->lastname ?? ''));
@@ -237,9 +355,25 @@ foreach ($allInternalUsers as $uid => $uObj) {
         'photo'    => (!empty($uObj->photo) && trim($uObj->photo) !== '') ? DOL_URL_ROOT . '/viewimage.php?modulepart=user&file=' . urlencode($uid . '/' . $uObj->photo) : '',
     ];
 }
-print '<script>window.KANBAN_USERS = ' . json_encode($usersJsonData) . ';</script>';
 
-// --- KANBAN TEMPLATE ---
+$tagsJsonData = [];
+foreach ($allTagCategories as $catId => $catInfo) {
+    $tagsJsonData[] = [
+        'id'    => (int)$catId,
+        'label' => $catInfo['label'],
+        'color' => $catInfo['color'],
+    ];
+}
+
+print '<script>';
+print 'window.KANBAN_USERS = ' . json_encode($usersJsonData) . ';';
+print 'window.KANBAN_TAGS = ' . json_encode($tagsJsonData) . ';';
+print 'window.KANBAN_STATUSES = ' . json_encode(array_map(function($k, $v) { return ['code' => $k, 'label' => $v['label'], 'color' => $v['color']]; }, array_keys($statusMap), array_values($statusMap))) . ';';
+print 'window.KANBAN_SEVERITIES = ' . json_encode(array_map(function($k, $v) { return ['code' => $k, 'label' => $v]; }, array_keys($severityMap), array_values($severityMap))) . ';';
+print 'window.KANBAN_VIEW = ' . json_encode($viewmode) . ';';
+print '</script>';
+
+// --- TEMPLATE ---
 require_once __DIR__ . '/../../core/tpl/frontend/reedcrm_tickets_kanban.tpl.php';
 
 // --- BOTTOM NAV ---
@@ -247,5 +381,3 @@ require_once __DIR__ . '/../../core/tpl/frontend/reedcrm_pwa_bottom_nav.tpl.php'
 
 llxFooter();
 $db->close();
-
-


### PR DESCRIPTION
## Description

Nouvelle page `pwa_tickets.php?source=pwa` avec vue **Kanban** interactive pour la gestion des tickets.

Fixes #682

## Fonctionnalités

### Vue Kanban par statut
- 8 colonnes : Non lu, Lu, Assigné, En cours, Besoin d'info, En attente, Fermé, Annulé
- Compteurs dynamiques par colonne
- Colonnes collapsibles (clic sur le header)
- **Colonnes redimensionnables** par drag du bord droit (desktop)

### Carte ticket (design extension)
- Réf cliquable + Tiers + Date + Temps écoulé
- Sévérité + Avancement %
- Sujet + pastille statut colorée + lien messagerie
- Avatar assigné (photo ou initiales)
- Aperçu du message

### Filtres (Notion-like)
- **Filtre assigné** : chips avec compteurs dynamiques
- **Filtre statut** : toggles pour afficher/masquer les colonnes
- **Recherche texte** : filtre temps réel sur ref/sujet/tiers

### Vue Kanban / Liste
- Toggle dans le header pour basculer entre vue Kanban (colonnes) et vue Liste (sections empilées)

### Drag & Drop (desktop)
- Changement de statut par glisser-déposer entre colonnes
- AJAX avec `setStatut()` / `close()` pour persistance
- Désactivé automatiquement en mode PWA mobile

## Fichiers

| Fichier | Action |
|---------|--------|
| `view/frontend/pwa_tickets.php` | REWRITE |
| `core/tpl/frontend/reedcrm_tickets_kanban.tpl.php` | NEW |
| `css/reedcrm_tickets_kanban.css` | NEW |
| `js/reedcrm_tickets_kanban.js` | NEW |

## Compatibilité
- Dolibarr 23 (status codes: 0,1,2,3,5,7,8,9)
- Vanilla JS (conforme AGENTS.md)
- Responsive mobile/desktop