### PR TITLE
feat: add quick-add / inline selector for SALESREPINTERNAL in project card header

### DIFF
--- a/class/actions_reedcrm.class.php
+++ b/class/actions_reedcrm.class.php
@@ -2151,9 +2151,64 @@ class ActionsReedcrm
                 $originHtml .= '<div class="reedcrm-hidden-origin-selector-wrap" style="display:none; margin-left:6px;">' . $hiddenOriginSelect . '</div>';
                 $originHtml .= '</div>';
 
+                // Fetch linked SALESREPINTERNAL user (Commercial affecté au projet)
+                $salesrepUserId = 0;
+                $salesrepName = '';
+                $sqlSalesRep = "SELECT u.rowid, u.firstname, u.lastname
+                                FROM " . MAIN_DB_PREFIX . "element_contact ec
+                                JOIN " . MAIN_DB_PREFIX . "c_type_contact ctc ON ctc.rowid = ec.fk_c_type_contact
+                                JOIN " . MAIN_DB_PREFIX . "user u ON u.rowid = ec.fk_socpeople
+                                WHERE ec.element_id = " . (int)$object->id . "
+                                  AND ctc.element = 'project'
+                                  AND ctc.code = 'SALESREPINTERNAL'
+                                  AND ctc.source = 'internal'
+                                LIMIT 1";
+                $resqlSalesRep = $db->query($sqlSalesRep);
+                if ($resqlSalesRep && $db->num_rows($resqlSalesRep) > 0) {
+                    $objSalesRep = $db->fetch_object($resqlSalesRep);
+                    $salesrepUserId = (int)$objSalesRep->rowid;
+                    $salesrepName = trim($objSalesRep->firstname . ' ' . $objSalesRep->lastname);
+                }
+                
+                if (empty($salesrepName)) {
+                    $salesrepLabel = '<span style="color:#cbd5e0; font-style:italic;">Commercial</span>';
+                } else {
+                    $salesrepLabel = dol_escape_htmltag($salesrepName);
+                }
+
+                // Query list of active users to build select HTML options
+                $salesrepUsers = [];
+                $sqlUsers = "SELECT rowid, firstname, lastname FROM " . MAIN_DB_PREFIX . "user WHERE statut = 1 ORDER BY lastname, firstname";
+                $resqlUsers = $db->query($sqlUsers);
+                if ($resqlUsers) {
+                    while ($uObj = $db->fetch_object($resqlUsers)) {
+                        $salesrepUsers[] = [
+                            'id' => (int)$uObj->rowid,
+                            'name' => trim($uObj->firstname . ' ' . $uObj->lastname)
+                        ];
+                    }
+                }
+
+                $hiddenSalesRepSelect = '<select id="reedcrm_inline_salesrep" name="salesrepinternal" class="flat" style="width: 180px;">';
+                $hiddenSalesRepSelect .= '<option value="">' . dol_escape_htmltag($langs->trans('None')) . '</option>';
+                foreach ($salesrepUsers as $u) {
+                    $selected = ($u['id'] == $salesrepUserId) ? ' selected' : '';
+                    $hiddenSalesRepSelect .= '<option value="' . $u['id'] . '"' . $selected . '>' . dol_escape_htmltag($u['name']) . '</option>';
+                }
+                $hiddenSalesRepSelect .= '</select>';
+
+                // Build Salesrep HTML badge
+                $salesrepHtml = '<div class="contact-inline-wrapper reedcrm-header-salesrep-master" style="display: inline-flex; align-items: center; background: #f8fbff; border: 1px solid #e2e8f0; border-radius: 6px; padding: 4px 8px 4px 6px; vertical-align: middle; font-weight: 500; font-size: 0.9em; margin-bottom: 2px; color: #4a5568;">';
+                $salesrepHtml .= '<img src="' . dol_buildpath('/custom/reedcrm/img/object_reedcrm_color.png', 1) . '" style="height: 18px; width: 18px; object-fit: contain; margin-right: 8px; border-right: 1px solid #cbd5e0; padding-right: 8px;" alt="ReedCRM" />';
+                $salesrepHtml .= '<i class="fas fa-user-tie" style="color: #64748b; margin-right: 6px;"></i>';
+                $salesrepHtml .= '<a href="#" class="classlink inline-edit-salesrep-badge" style="cursor: pointer; transition: color 0.3s; color: #0f172a; border-bottom: 1px dashed #cbd5e0; line-height: 1; padding-bottom: 1px;" title="' . dol_escape_htmltag($langs->trans('Edit')) . '">' . $salesrepLabel . '</a>';
+                $salesrepHtml .= '<div class="reedcrm-hidden-salesrep-selector-wrap" style="display:none; margin-left:6px;">' . $hiddenSalesRepSelect . '</div>';
+                $salesrepHtml .= '</div>';
+
                 $assetsHtml .= '<script>
                     (function() {
                         var originHtmlStr = ' . json_encode($originHtml) . ';
+                        var salesrepHtmlStr = ' . json_encode($salesrepHtml) . ';
                         
                         function processOriginField() {
                             // 1. Hide the original row
@@ -2193,8 +2248,19 @@ class ActionsReedcrm
                                             row.appendChild(companyWrapper);
                                         }
                                         companyWrapper.parentElement.appendChild(node);
+                                        
+                                        // Teleport salesrep node
+                                        var tempWrapSales = document.createElement("div");
+                                        tempWrapSales.innerHTML = salesrepHtmlStr;
+                                        var nodeSales = tempWrapSales.firstElementChild;
+                                        companyWrapper.parentElement.appendChild(nodeSales);
                                     } else {
                                         flexContainer.appendChild(node);
+                                        
+                                        var tempWrapSales = document.createElement("div");
+                                        tempWrapSales.innerHTML = salesrepHtmlStr;
+                                        var nodeSales = tempWrapSales.firstElementChild;
+                                        flexContainer.appendChild(nodeSales);
                                     }
                                 }
                             }, 100);

--- a/core/tpl/frontend/reedcrm_quickcreation_actions_frontend.tpl.php
+++ b/core/tpl/frontend/reedcrm_quickcreation_actions_frontend.tpl.php
@@ -216,6 +216,57 @@ if ($action == 'updateopporigin') {
     exit;
 }
 
+if ($action == 'updateoppsalesrep') {
+    $projectId = GETPOST('projectid', 'int');
+    $salesrepId = GETPOST('salesrepid', 'int');
+    $res = array('success' => false);
+
+    if ($projectId > 0) {
+        $proj = new Project($db);
+        if ($proj->fetch($projectId) > 0) {
+            $db->begin();
+            
+            // Delete existing internal SALESREPINTERNAL contacts for the project
+            $sqlDelete = "DELETE ec FROM " . MAIN_DB_PREFIX . "element_contact ec
+                          JOIN " . MAIN_DB_PREFIX . "c_type_contact ctc ON ctc.rowid = ec.fk_c_type_contact
+                          WHERE ec.element_id = " . (int)$projectId . "
+                            AND ctc.element = 'project'
+                            AND ctc.code = 'SALESREPINTERNAL'
+                            AND ctc.source = 'internal'";
+            $resDelete = $db->query($sqlDelete);
+            
+            $resAdd = 1;
+            if ($salesrepId > 0) {
+                // Add new internal SALESREPINTERNAL contact
+                $resAdd = $proj->add_contact($salesrepId, 'SALESREPINTERNAL', 'internal');
+            }
+
+            if ($resDelete !== false && $resAdd > 0) {
+                $db->commit();
+                $res['success'] = true;
+                if ($salesrepId > 0) {
+                    require_once DOL_DOCUMENT_ROOT . '/user/class/user.class.php';
+                    $u = new User($db);
+                    if ($u->fetch($salesrepId) > 0) {
+                        $res['new_salesrep_name'] = trim($u->firstname . ' ' . $u->lastname);
+                    } else {
+                        $res['new_salesrep_name'] = '';
+                    }
+                } else {
+                    $res['new_salesrep_name'] = '';
+                }
+            } else {
+                $db->rollback();
+                $res['error'] = 'Could not update sales representative link';
+            }
+        }
+    }
+    header('Content-Type: application/json');
+    echo json_encode($res);
+    exit;
+}
+
+
 if ($action == 'updateopptitle') {
     $projectId = GETPOST('projectid', 'int');
     $newTitle = trim(GETPOST('title'));

--- a/js/modules/contact_inline.js
+++ b/js/modules/contact_inline.js
@@ -15,6 +15,7 @@ window.saturne.contact_inline.event = function() {
     $(document).on('click', '.inline-edit-proj-amount', window.saturne.contact_inline.editAmount);
     $(document).on('click', '.inline-edit-company-badge', window.saturne.contact_inline.startCompanyEdit);
     $(document).on('click', '.inline-edit-origin-badge', window.saturne.contact_inline.startOriginEdit);
+    $(document).on('click', '.inline-edit-salesrep-badge', window.saturne.contact_inline.startSalesRepEdit);
 };
 
 window.saturne.contact_inline.copyToClipboard = function(e) {
@@ -365,10 +366,7 @@ window.saturne.contact_inline.startOriginEdit = function(e) {
                 aTag.show();
             }
         }, 100);
-    });
-};
-
-// Apply the material look (blue base / red invalid) on an inline editor input. Uses inline
+  // Apply the material look (blue base / red invalid) on an inline editor input. Uses inline
 // !important so it beats the backend list theme's stronger global input border rule.
 window.saturne.contact_inline.applyInputMaterial = function(el, invalid) {
     if (!el) return;
@@ -386,6 +384,94 @@ window.saturne.contact_inline.cancelInlineEdit = function(span, input, originalH
         input[0].iti.destroy();
     }
     span.html(originalHtml);
+};
+
+window.saturne.contact_inline.startSalesRepEdit = function(e) {
+    if ($(e.target).hasClass('select2-selection__choice__remove') || $(e.target).closest('.select2-container').length > 0) return;
+    
+    e.preventDefault();
+    e.stopPropagation();
+    
+    let aTag = $(this);
+    let originalHtml = aTag.html();
+    
+    let hiddenSelectorWrap = aTag.parent().find('.reedcrm-hidden-salesrep-selector-wrap');
+    if (hiddenSelectorWrap.length === 0) return;
+    
+    aTag.hide();
+    hiddenSelectorWrap.show();
+    
+    let selectElem = hiddenSelectorWrap.find('select');
+    if (selectElem.length === 0) return;
+    
+    try {
+        // Ensure Select2 is instantiated
+        if (!selectElem.data('select2') && !selectElem.hasClass('select2-hidden-accessible')) {
+            selectElem.select2({ width: '180px' });
+        } else {
+            let sc = selectElem.next('.select2-container');
+            if (sc.length > 0) {
+                sc.css('width', '180px');
+            }
+        }
+        
+        selectElem.select2('open');
+    } catch (err) {
+        console.error("SELECT2 ERROR: ", err);
+        return;
+    }
+    
+    selectElem.off('change.inlineedit').on('change.inlineedit', function() {
+        let newSalesrep = $(this).val();
+        let newSalesrepText = $(this).find('option:selected').text();
+        let projId = $('#reedcrm-inline-data').data('project-id');
+        let token = $('input[name="token"]').val() || '';
+        
+        let url = 'undefined' != typeof dolibarr_main_url_root && dolibarr_main_url_root ? dolibarr_main_url_root : '';
+        if (!url) {
+            if (document.URL.indexOf('/projet/') > 0) url = document.URL.substring(0, document.URL.indexOf('/projet/'));
+            else if (document.URL.indexOf('/custom/') > 0) url = document.URL.substring(0, document.URL.indexOf('/custom/'));
+        }
+        let ajaxUrl = url + '/custom/reedcrm/view/frontend/quickcreation.php?action=updateoppsalesrep';
+        
+        aTag.html('<i class="fas fa-spinner fa-spin" style="color: #9b59b6;"></i> Enregistrement...');
+        hiddenSelectorWrap.hide();
+        aTag.show();
+        
+        $.ajax({
+            url: ajaxUrl,
+            type: 'POST',
+            data: { projectid: projId, salesrepid: newSalesrep, token: token },
+            dataType: 'json',
+            success: function(res) {
+                if (res.success) {
+                    if (res.new_salesrep_name) {
+                        aTag.text(res.new_salesrep_name);
+                    } else {
+                        aTag.html('<span style="color:#cbd5e0; font-style:italic;">Commercial</span>');
+                    }
+                    aTag.css('color', '#2ecc71');
+                    setTimeout(() => aTag.css('color', ''), 1500);
+                } else {
+                    alert("Erreur: " + (res.error || "Inconnue"));
+                    aTag.html(originalHtml);
+                }
+            },
+            error: function() {
+                alert("Impossible de joindre le serveur");
+                aTag.html(originalHtml);
+            }
+        });
+    });
+    
+    selectElem.off('select2:close').on('select2:close', function () {
+        setTimeout(function() {
+            if (hiddenSelectorWrap.is(':visible')) {
+                hiddenSelectorWrap.hide();
+                aTag.show();
+            }
+        }, 100);
+    });
 };
 
 window.saturne.contact_inline.startInlineEdit = function(e) {

--- a/js/reedcrm.min.js
+++ b/js/reedcrm.min.js
@@ -1,1 +1,4433 @@
-"use strict";window.reedcrm||(window.reedcrm={},window.reedcrm.scriptsLoaded=!1),window.reedcrm.scriptsLoaded||(window.reedcrm.init=function(){window.reedcrm.load_list_script()},window.reedcrm.load_list_script=function(){if(!window.reedcrm.scriptsLoaded){let e=void 0,t=void 0;for(e in window.reedcrm)for(t in window.reedcrm[e].init&&window.reedcrm[e].init(),window.reedcrm[e])window.reedcrm[e]&&window.reedcrm[e][t]&&window.reedcrm[e][t].init&&window.reedcrm[e][t].init();window.reedcrm.scriptsLoaded=!0}},window.reedcrm.refresh=function(){let e=void 0,t=void 0;for(e in window.reedcrm)for(t in window.reedcrm[e].refresh&&window.reedcrm[e].refresh(),window.reedcrm[e])window.reedcrm[e]&&window.reedcrm[e][t]&&window.reedcrm[e][t].refresh&&window.reedcrm[e][t].refresh()},$(document).ready(window.reedcrm.init)),window.saturne.contact_inline={},window.saturne.contact_inline.init=function(){window.saturne.contact_inline.mountCardUi(),window.saturne.contact_inline.event()},window.saturne.contact_inline.event=function(){$(document).on("click",".copy-action-icon",window.saturne.contact_inline.copyToClipboard),$(document).on("click",".inline-edit-proj-title, .inline-edit-contact",window.saturne.contact_inline.startInlineEdit),$(document).on("click",".inline-edit-proj-percent",window.saturne.contact_inline.editPercent),$(document).on("click",".inline-edit-proj-amount",window.saturne.contact_inline.editAmount),$(document).on("click",".inline-edit-company-badge",window.saturne.contact_inline.startCompanyEdit),$(document).on("click",".inline-edit-origin-badge",window.saturne.contact_inline.startOriginEdit)},window.saturne.contact_inline.copyToClipboard=function(e){e.preventDefault(),e.stopPropagation();e=$(this).data("copy");let t=$(this),n=t.attr("class"),i=t.css("color");navigator.clipboard&&navigator.clipboard.writeText(e).then(()=>{t.attr("class","fas fa-check").css("color","#38a169"),setTimeout(()=>{t.attr("class",n).css("color",i)},1500)}).catch(e=>console.error("Erreur Copie:",e))},window.saturne.contact_inline.mountCardUi=function(){var e=$("#reedcrm-inline-data");if(0!==e.length&&!(0<$(".reedcrm-card-header-blocks").length)){var n=e.data("project-id"),t=parseFloat(e.data("amount")||0),i=e.data("percent-str"),o=e.data("amount-str"),r=e.data("logo-path"),e=e.data("percent-val"),a=$("div.refidno");if(0<a.length){var c=a.find(".editval");if(0===c.length){var d=a.contents().filter(function(){return 3===this.nodeType&&""!==$.trim(this.nodeValue)}).first();if(0<d.length){var l=$.trim(d.text()),s=$('<div class="reedcrm-header-title-wrapper" style="display: inline-flex; align-items: center; background: #f8fbff; border: 1px solid #e2e8f0; border-radius: 6px; padding: 4px 8px 4px 6px; vertical-align: middle; font-weight: 600; font-size: 0.95em; margin-bottom: 2px;"><img src="'+r+'" style="height: 18px; width: 18px; object-fit: contain; margin-right: 8px; border-right: 1px solid #cbd5e0; padding-right: 8px;" alt="ReedCRM" title="Géré par ReedCRM" /></div>'),d=(d.replaceWith(s),$('<span class="dynamic-libelle-prefix" style="color: #4a5568; cursor: pointer; font-weight: bold; margin-right: 6px; padding-bottom: 1px;" title="Modifier le titre">Libellé :</span>'));let t=$('<span class="inline-edit-proj-title" data-project-id="'+n+'" data-val="" style="color: #0f172a; cursor: pointer; border-bottom: 1px dashed #cbd5e0; line-height: 1; padding-bottom: 1px; transition: color 0.3s; display: inline-flex; min-width: 100px;" title="Modifier le titre"></span>');t.text(l).attr("data-val",l),s.append(d).append(t),d.on("click",function(e){e.stopPropagation(),t.click()})}}else $('<div class="reedcrm-header-title-wrapper" style="display: inline-flex; align-items: center; background: #f8fbff; border: 1px solid #e2e8f0; border-radius: 6px; padding: 4px 8px 4px 6px; vertical-align: middle; font-weight: 600; font-size: 0.95em; margin-bottom: 2px; margin-right: 6px;"><img src="'+r+'" style="height: 18px; width: 18px; object-fit: contain; margin-right: 8px; border-right: 1px solid #cbd5e0; padding-right: 8px;" alt="ReedCRM" title="Géré par ReedCRM" /><span style="color: #4a5568; font-weight: bold; margin-right: 4px;">Libellé :</span></div>').insertBefore(c)}var l=$(".statusref"),s=$(".arearef > div").first(),e=(0===$(".reedcrm-header-stats").length&&(d='<div class="reedcrm-header-stats" style="'+(0<l.length?"":"float: right; ")+'display: inline-flex; align-items: center; background: #f8fbff; border: 1px solid #e2e8f0; border-radius: 6px; padding: 4px 8px 4px 6px; margin-right: 15px; vertical-align: middle; font-weight: 600; font-size: 0.95em;"><img src="'+r+'" style="height: 18px; width: 18px; object-fit: contain; margin-right: 8px; border-right: 1px solid #cbd5e0; padding-right: 8px;" alt="ReedCRM" title="Géré par ReedCRM" /><span class="inline-edit-proj-percent" data-project-id="'+n+'" data-val="'+e+'" style="color: #0f172a; cursor: pointer; border-bottom: 1px dashed #cbd5e0; padding-bottom: 1px; transition: color 0.3s; display: inline-flex; align-items: center; white-space: nowrap; line-height: 1;" title="Modifier la probabilité">'+i+'</span><span style="color: #cbd5e0; margin: 0 6px;">-</span><span class="inline-edit-proj-amount" data-project-id="'+n+'" data-val="'+t+'" style="color: #3b82f6; cursor: pointer; border-bottom: 1px dashed #cbd5e0; padding-bottom: 1px; transition: color 0.3s; display: inline-flex; align-items: center; white-space: nowrap; line-height: 1;" title="Modifier le montant">'+o+"</span></div>",0<l.length?0<(c=l.find(".badge, .status, .label")).length?$(d).insertBefore(c.first()):l.prepend(d):0<s.length&&s.prepend(d)),$(".reedcrm-header-title-wrapper")),i=$(".contact-inline-wrapper.reedcrm-header-contact-master"),t=(0<e.length&&0<i.length&&(n=$('<div class="reedcrm-card-header-blocks" style="display: flex; flex-direction: column; gap: 8px; margin-top: 6px; margin-left: 0; padding-left: 0; align-items: flex-start; clear: both;"></div>'),e.wrap(n),i.appendTo(e.parent()),a.children("br").remove(),e.css({"margin-left":"0","margin-right":"0","margin-bottom":"0"}),i.css({"margin-left":"0","margin-right":"0","margin-bottom":"0"})),a.find('a[href*="socid="]').not(".customer-back").not(".vendor-back").first());0<t.length?(o=t.attr("href"),0<(c=t.find(".fa-building, .fa-building-o, .fa-industry")).length&&(c.remove(),t.html(t.html().replace(/&nbsp;/g,"").trim())),t.parent().hasClass("reedcrm-header-company-wrapper")||(t.wrap('<div class="reedcrm-header-company-wrapper" style="display: inline-flex; align-items: center; background: #f8fbff; border: 1px solid #e2e8f0; border-radius: 6px; padding: 4px 8px 4px 6px; vertical-align: middle; font-weight: 500; font-size: 0.9em; margin-bottom: 2px; color: #4a5568;"></div>'),t.before('<img src="'+r+'" style="height: 18px; width: 18px; object-fit: contain; margin-right: 8px; border-right: 1px solid #cbd5e0; padding-right: 8px;" alt="ReedCRM" />'),t.before('<a href="'+o+'" target="_blank" style="color: #64748b; margin-right: 6px; display: inline-flex; align-items: center;" title="Ouvrir la fiche tiers"><i class="fas fa-building"></i></a>')),t.addClass("inline-edit-company-badge").css({cursor:"pointer",transition:"color 0.3s",color:"#0f172a"}).attr("title","Modifier l'entreprise rattachée"),l=t.closest(".reedcrm-header-company-wrapper"),0<$(".reedcrm-card-header-blocks").length&&0<l.length&&(l.insertAfter($(".reedcrm-header-title-wrapper")),l.css({"margin-left":"0","margin-right":"0","margin-bottom":"0"}))):(s=$(".reedcrm-header-title-wrapper"),d=$(".reedcrm-card-header-blocks"),0<s.length&&(n=$('<div class="reedcrm-header-company-wrapper" style="display: inline-flex; align-items: center; background: #f8fbff; border: 1px solid #e2e8f0; border-radius: 6px; padding: 4px 8px 4px 6px; vertical-align: middle; font-weight: 500; font-size: 0.9em; margin-bottom: 2px; color: #4a5568;"><img src="'+r+'" style="height: 18px; width: 18px; object-fit: contain; margin-right: 8px; border-right: 1px solid #cbd5e0; padding-right: 8px;" alt="ReedCRM" /><a href="#" class="inline-edit-company-badge" style="cursor: pointer; transition: color 0.3s; color: #0f172a; border-bottom: 1px dashed #cbd5e0; line-height: 1; padding-bottom: 1px;" title="Affecter une entreprise"><i class="fas fa-building" style="margin-right:5px; color:#64748b;"></i>Affecter un tiers</a></div>'),0<d.length?(n.insertAfter(s),n.css({"margin-left":"0","margin-right":"0","margin-bottom":"0"})):n.insertAfter(s)))}},window.saturne.contact_inline.startCompanyEdit=function(e){if(!($(e.target).hasClass("select2-selection__choice__remove")||0<$(e.target).closest(".select2-container").length)){e.preventDefault(),e.stopPropagation();let o=$(this),r=o.html(),a=$("#reedcrm-hidden-company-selector");0!==a.length&&(0<o.parent().find("#reedcrm-hidden-company-selector").length?(o.hide(),a.show(),(e=a.find("select")).data("select2")&&e.select2("open")):(o.hide(),a.insertAfter(o).show(),(e=$("#reedcrm_inline_socid")).data("select2")&&e.select2("open"),e.off("change.inlineedit").on("change.inlineedit",function(){var t=$(this).val(),n=$("#reedcrm-inline-data").data("project-id"),i=$('input[name="token"]').val()||"";if(t&&0!=t){let e="undefined"!=typeof dolibarr_main_url_root&&dolibarr_main_url_root?dolibarr_main_url_root:"";e||(0<document.URL.indexOf("/projet/")?e=document.URL.substring(0,document.URL.indexOf("/projet/")):0<document.URL.indexOf("/custom/")&&(e=document.URL.substring(0,document.URL.indexOf("/custom/"))));i=e+"/custom/reedcrm/view/frontend/quickcreation.php?action=updateoppsocid&token="+i;o.html('<i class="fas fa-spinner fa-spin" style="color: #9b59b6;"></i> Enregistrement...'),a.hide(),o.show(),$.ajax({url:i,type:"POST",data:{projectid:n,socid:t},dataType:"json",success:function(e){var t;e.success?e.new_company_url?0<(t=$("<div>").html(e.new_company_url).find("a").first()).length?(o.attr("href",t.attr("href")),o.html(t.html())):o.html(e.new_company_url):o.html(r):(alert("Erreur: "+(e.error||"Inconnue")),o.html(r))},error:function(){alert("Impossible de joindre le serveur"),o.html(r)}})}else a.hide(),o.show()}),e.on("select2:close",function(){setTimeout(function(){a.is(":visible")&&(a.hide(),o.show())},100)})))}},window.saturne.contact_inline.startOriginEdit=function(e){if(!($(e.target).hasClass("select2-selection__choice__remove")||0<$(e.target).closest(".select2-container").length)){e.preventDefault(),e.stopPropagation();let a=$(this),c=a.html(),d=a.parent().find(".reedcrm-hidden-origin-selector-wrap");if(0!==d.length){a.hide(),d.show();var t,e=d.find("select");if(0!==e.length){try{e.data("select2")||e.hasClass("select2-hidden-accessible")?0<(t=e.next(".select2-container")).length&&t.css("width","180px"):e.select2({width:"180px"}),e.select2("open")}catch(e){return void console.error("SELECT2 ERROR: ",e)}e.off("change.inlineedit").on("change.inlineedit",function(){var e=$(this).val();let t=$(this).find("option:selected").text();var n=$("#reedcrm-inline-data").data("project-id"),i=$('input[name="token"]').val()||"";let o="undefined"!=typeof dolibarr_main_url_root&&dolibarr_main_url_root?dolibarr_main_url_root:"";o||(0<document.URL.indexOf("/projet/")?o=document.URL.substring(0,document.URL.indexOf("/projet/")):0<document.URL.indexOf("/custom/")&&(o=document.URL.substring(0,document.URL.indexOf("/custom/"))));var r=o+"/custom/reedcrm/view/frontend/quickcreation.php?action=updateopporigin";a.html('<i class="fas fa-spinner fa-spin" style="color: #9b59b6;"></i> Enregistrement...'),d.hide(),a.show(),$.ajax({url:r,type:"POST",data:{projectid:n,origin:e,token:i},dataType:"json",success:function(e){e.success?(a.text(t),a.css("color","#2ecc71"),setTimeout(()=>a.css("color",""),1500)):(alert("Erreur: "+(e.error||"Inconnue")),a.html(c))},error:function(){alert("Impossible de joindre le serveur"),a.html(c)}})}),e.off("select2:close").on("select2:close",function(){setTimeout(function(){d.is(":visible")&&(d.hide(),a.show())},100)})}}}},window.saturne.contact_inline.startInlineEdit=function(e){if(!(0<$(this).find("input").length)){e.stopPropagation();let t=$(this);e=t.hasClass("inline-edit-proj-title");let n=t.data("val")||"",i=t.html();var a="phone"===t.data("field"),c="website"===t.data("field"),d="email"===t.data("field"),l="firstname"===t.data("field")||"lastname"===t.data("field")||d;let o=$('<input type="'+(a?"tel":c?"url":d?"email":"text")+'" style="width: '+(e?"250px":l?"100%":a||c?"180px":"140px")+"; border: 1px solid #3b82f6; border-radius: 4px; padding: 2px 6px; "+(a?"padding-left: 52px !important; ":"")+'font-weight: inherit; font-size: inherit; color: #0f172a; outline: none; box-sizing: border-box; background: white; margin: 0; display: inline-block; line-height: normal; box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.2);" value="">');if(o.val(n),c&&(""===n||"http://"===n?o.val("https://"):n.startsWith("http://")&&o.val("https://"+n.substring(7))),t.html("").append(o),c&&o.on("input",function(){let e=$(this).val().trim();e.startsWith("www.")&&(e="https://"+e,$(this).val(e));""===e||"https://"===e||"http://"===e||/^(https?:\/\/)?([\w\-]+(\.[\w\-]+)+)([\/?#].*)?$/i.test(e)?$(this).css({"border-color":"#3b82f6",color:"#0f172a","box-shadow":"0 0 0 2px rgba(59, 130, 246, 0.2)"}):$(this).css({"border-color":"#e53935",color:"#e53935","box-shadow":"0 0 0 2px rgba(229, 57, 53, 0.2)"})}),a&&void 0!==window.intlTelInput){let e="undefined"!=typeof dolibarr_main_url_root&&dolibarr_main_url_root?dolibarr_main_url_root:"";e||(0<document.URL.indexOf("/projet/")?e=document.URL.substring(0,document.URL.indexOf("/projet/")):0<document.URL.indexOf("/custom/")&&(e=document.URL.substring(0,document.URL.indexOf("/custom/")))),o[0].iti=window.intlTelInput(o[0],{utilsScript:e+"/custom/reedcrm/js/intl-tel-input/js/utils.js",initialCountry:"fr",preferredCountries:["fr","be","ch","lu","ca"],nationalMode:!1,autoPlaceholder:"polite",dropdownContainer:document.body}),$(".iti__flag-container").css("z-index",9999),o[0].addEventListener("open:countrydropdown",function(){o[0].itiDropdownOpen=!0}),o[0].addEventListener("close:countrydropdown",function(){o[0].itiDropdownOpen=!1,setTimeout(()=>o.focus(),50)})}o.focus(),o.select();let r=e?window.saturne.contact_inline.submitTitleDetail:window.saturne.contact_inline.submitContactDetail;o.on("blur",function(){o[0]&&o[0].itiDropdownOpen||r(t,o,i,n,!1)}),o.on("keydown",function(e){e.stopPropagation(),13===e.which?(e.preventDefault(),o.off("blur"),r(t,o,i,n,!1)):9===e.which&&(e.preventDefault(),o.off("blur"),r(t,o,i,n,!0))}),o.on("click",function(e){e.stopPropagation()})}},window.saturne.contact_inline.submitTitleDetail=function(n,i,o,r,a){function c(){var e=$(".contact-inline-wrapper .inline-edit-contact").first();0<e.length&&e.click()}let d=i.val().trim();if(d===r)n.html(o),a&&c();else{n.data("val",d);var i=n.width(),i=(n.html('<i class="fas fa-spinner fa-spin" style="color: #9b59b6;"></i>').css("min-width",i+"px"),n.data("project-id")),l=$('input[name="token"]').val()||"";let e="undefined"!=typeof dolibarr_main_url_root&&dolibarr_main_url_root?dolibarr_main_url_root:"",t=(e||(0<document.URL.indexOf("/projet/")?e=document.URL.substring(0,document.URL.indexOf("/projet/")):0<document.URL.indexOf("/custom/")&&(e=document.URL.substring(0,document.URL.indexOf("/custom/")))),e+"/custom/reedcrm/view/frontend/quickcreation.php?action=updateopptitle");0<document.URL.indexOf("quickcreation.php")&&(t=document.URL.split("?")[0]+"?action=updateopptitle"),$.ajax({url:t,type:"POST",data:{token:l,projectid:i,title:d},success:function(e){n.css({color:"#2ecc71","min-width":""}),n.html(d||'<span style="color:#cbd5e0; font-style:italic;">Sans titre</span>'),setTimeout(function(){n.css({color:""})},1500),a&&c()},error:function(e){alert("Erreur XHR Titre: "+e.status+"\n"+(e.responseText?e.responseText.substring(0,300):"Aucune reponse")),n.html(o).css("min-width",""),n.data("val",r),n.css({color:"#e74c3c"}),setTimeout(()=>n.css({color:""}),1500)}})}},window.saturne.contact_inline.submitContactDetail=function(n,i,o,r,a){function c(){var e=l.find(".inline-edit-contact:visible"),t=e.index(n);0<=t&&t<e.length-1&&e.eq(t+1).click()}let d=i.val().trim(),l=("phone"===n.data("field")&&i[0].iti&&window.intlTelInputUtils&&i[0].iti.isValidNumber()&&(d=i[0].iti.getNumber()),n.closest(".contact-inline-wrapper")),s=n.data("field");if("email"===s&&""!==d&&!/^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$/.test(d))return alert("Format de l'adresse e-mail invalide."),void i.focus();if("website"===s&&("https://"!==d&&"http://"!==d||(d="",i.val("")),""!==d&&(d.startsWith("http://")||d.startsWith("https://")||(d="https://"+d,i.val(d)),!/^(https?:\/\/)?([\w\-]+(\.[\w\-]+)+)([\/?#].*)?$/i.test(d))))return alert("Format du site web invalide."),void i.focus();if(d===r)n.html(o),a&&c();else{n.data("val",d);var u=n.width(),u=(n.html('<i class="fas fa-spinner fa-spin" style="color: #9b59b6;"></i>').css("min-width",u+"px"),l.data("project-id")),p=l.find('.inline-edit-contact[data-field="firstname"]').data("val"),m=l.find('.inline-edit-contact[data-field="lastname"]').data("val"),f=l.find('.inline-edit-contact[data-field="phone"]').data("val"),w=l.find('.inline-edit-contact[data-field="email"]').data("val"),h=l.find('.inline-edit-contact[data-field="website"]').data("val"),g=$('input[name="token"]').val()||"";let e="undefined"!=typeof dolibarr_main_url_root&&dolibarr_main_url_root?dolibarr_main_url_root:"",t=(e||(0<document.URL.indexOf("/projet/")?e=document.URL.substring(0,document.URL.indexOf("/projet/")):0<document.URL.indexOf("/custom/")&&(e=document.URL.substring(0,document.URL.indexOf("/custom/")))),e+"/custom/reedcrm/view/frontend/quickcreation.php?action=updateoppcontact");0<document.URL.indexOf("quickcreation.php")&&(t=document.URL.split("?")[0]+"?action=updateoppcontact"),$.ajax({url:t,type:"POST",data:{token:g,projectid:u,firstname:p,lastname:m,phone:f,email:w,website:h},success:function(e){n.css({color:"#2ecc71","min-width":""});var t="";"firstname"===s&&(t="Prénom"),"lastname"===s&&(t="Nom"),"phone"===s&&(t="Téléphone"),"email"===s&&(t="Email"),"website"===s&&(t="Site Web"),n.html(d||'<span style="color:#cbd5e0; font-style:italic;">'+t+"</span>"),setTimeout(function(){n.css({color:""})},1500),a&&c()},error:function(e){alert("Erreur XHR Titre: "+e.status+"\n"+(e.responseText?e.responseText.substring(0,300):"Aucune reponse")),n.html(o).css("min-width",""),n.data("val",r),n.css({color:"#e74c3c"}),setTimeout(()=>n.css({color:""}),1500)}}),"phone"===n.data("field")&&i[0].iti&&i[0].iti.destroy()}},window.saturne.contact_inline.editPercent=function(t){if(!(0<$(this).find("input").length)){t.stopPropagation();let o=$(this),r=o.data("project-id"),e=parseInt(o.data("val")),a=o.text(),c=$('<input type="number" min="0" max="100" class="percent-input" style="width: 35px; text-align: center; border: 1px solid #cbd5e1; border-radius: 4px; padding: 0; font-weight: 600; font-size: 1em; color: #0f172a; outline: none; box-sizing: border-box; background: transparent; margin: 0; display: inline-block; vertical-align: middle; line-height: normal; -moz-appearance: textfield;" value="'+e+'">'),n=(0===$("#css-no-spinners").length&&$("head").append('<style id="css-no-spinners">input[type="number"].percent-input::-webkit-outer-spin-button, input[type="number"].percent-input::-webkit-inner-spin-button { -webkit-appearance: none; margin: 0; }</style>'),o.html("").append(c).append('<span style="font-weight:normal; margin-left: 2px;">%</span>'),c.focus(),function(){let n=parseInt(c.val());if((n=100<(n=isNaN(n)||n<0?0:n)?100:n)===e)o.html(a);else{o.html('<i class="fas fa-spinner fa-spin" style="color: #9b59b6; line-height: 22px;"></i>');var i=$('input[name="token"]').val()||"";let e="undefined"!=typeof dolibarr_main_url_root&&dolibarr_main_url_root?dolibarr_main_url_root:"",t=(e||(0<document.URL.indexOf("/projet/")?e=document.URL.substring(0,document.URL.indexOf("/projet/")):0<document.URL.indexOf("/custom/")&&(e=document.URL.substring(0,document.URL.indexOf("/custom/")))),e+"/custom/reedcrm/view/frontend/quickcreation.php?action=updateopppercent");0<document.URL.indexOf("quickcreation.php")&&(t=document.URL.split("?")[0]+"?action=updateopppercent"),$.ajax({url:t,type:"POST",data:{token:i,projectid:r,percent:n},success:function(e){e&&e.success?(o.data("val",n),o.html(n+" %"),o.css({color:"#2ecc71"})):o.html(a).css({color:"#e74c3c"}),setTimeout(()=>o.css({color:"#0f172a"}),1500)},error:function(e){alert("Erreur XHR Percent: "+e.status+"\n"+(e.responseText?e.responseText.substring(0,300):"Aucune reponse")),o.html(a).css({color:"#e74c3c"}),setTimeout(()=>o.css({color:originalColor}),1500)}})}});c.on("blur",n),c.on("keypress",function(e){e.stopPropagation(),13===e.which&&(e.preventDefault(),c.off("blur"),n())}),c.on("keydown",function(t){if(9===t.which){t.preventDefault(),c.off("blur"),n();let e=o.parent().find(".inline-edit-proj-amount");0<e.length&&setTimeout(()=>e.click(),50)}}),c.on("click",function(e){e.stopPropagation()})}},window.saturne.contact_inline.editAmount=function(i){if(!(0<$(this).find("input").length)){i.stopPropagation();let o=$(this),r=o.data("project-id"),e=parseFloat(o.data("val")),a=o.text();i=8<a.length?"80px":"65px";let t=$('<input type="text" class="amount-input" style="width: '+i+'; text-align: center; border: 1px solid #cbd5e1; border-radius: 4px; padding: 0 2px; font-weight: 600; font-size: 1em; color: #3b82f6; outline: none; box-sizing: border-box; background: transparent; margin: 0; display: inline-block; vertical-align: middle; line-height: normal; -moz-appearance: textfield;" value="'+e+'">'),n=(o.html("").append(t).append('<span style="font-weight:normal; margin-left: 4px;">€</span>'),t.focus(),function(){var n=t.val().replace(",",".");let i=parseFloat(n);if((i=isNaN(i)||i<0?0:i)===e)o.html(a);else{o.html('<i class="fas fa-spinner fa-spin" style="color: #9b59b6; line-height: 22px;"></i>');n=$('input[name="token"]').val()||"";let e="undefined"!=typeof dolibarr_main_url_root&&dolibarr_main_url_root?dolibarr_main_url_root:"",t=(e||(0<document.URL.indexOf("/projet/")?e=document.URL.substring(0,document.URL.indexOf("/projet/")):0<document.URL.indexOf("/custom/")&&(e=document.URL.substring(0,document.URL.indexOf("/custom/")))),e+"/custom/reedcrm/view/frontend/quickcreation.php?action=updateoppamount");0<document.URL.indexOf("quickcreation.php")&&(t=document.URL.split("?")[0]+"?action=updateoppamount"),$.ajax({url:t,type:"POST",data:{token:n,projectid:r,amount:i},success:function(e){e&&e.success?(o.data("val",i),o.html(e.formatted_amount),o.css({color:"#2ecc71"})):o.html(a).css({color:"#e74c3c"}),setTimeout(()=>o.css({color:"#3b82f6"}),1500)},error:function(e){alert("Erreur XHR Percent: "+e.status+"\n"+(e.responseText?e.responseText.substring(0,300):"Aucune reponse")),o.html(a).css({color:"#e74c3c"}),setTimeout(()=>o.css({color:"#3b82f6"}),1500)}})}});t.on("blur",n),t.on("keypress",function(e){e.stopPropagation(),13===e.which&&(e.preventDefault(),t.off("blur"),n())}),t.on("keydown",function(e){9===e.which&&(e.preventDefault(),t.off("blur"),n())}),t.on("click",function(e){e.stopPropagation()})}},$(document).ready(function(){void 0!==window.saturne&&window.saturne.contact_inline&&(window.saturne.contact_inline.mountCardUi(),$(document).on("click",".reedcrm-copy-text",window.saturne.contact_inline.copyToClipboard)),$(document).on("click",'[data-action="open-vcard-modal"]',function(){var e=document.getElementById("vcard-modal");e&&(e.style.display="flex")}),$(document).on("click",'[data-action="close-vcard-modal"]',function(){var e=document.getElementById("vcard-modal");e&&(e.style.display="none")}),$(document).on("click",'[data-action="toggle-geoloc-address"]',function(){$("#current-address-block").toggleClass("is-visible")}),$(document).on("mouseenter",".reedcrm-hover-bg",function(){$(this).css({background:"#f1f5f9","border-color":"#e2e8f0"})}).on("mouseleave",".reedcrm-hover-bg",function(){$(this).css({background:"transparent","border-color":"transparent"})}),$(document).on("click","#vcard-modal",function(e){$(e.target).is("#vcard-modal")&&(this.style.display="none")})}),window.saturne.pwa_selectors={},window.saturne.pwa_selectors.init=function(){window.saturne.pwa_selectors.event()},window.saturne.pwa_selectors.getBaseUrl=function(){var e="undefined"!=typeof dolibarr_main_url_root&&dolibarr_main_url_root?dolibarr_main_url_root:"";return e||0<document.URL.indexOf("/custom/")&&(e=document.URL.substring(0,document.URL.indexOf("/custom/"))),e+"/custom/reedcrm/view/frontend/quickcreation.php"},window.saturne.pwa_selectors.event=function(){$(document).on("click",function(e){$(e.target).closest(".pwa-selector-wrap").length||$(".pwa-inline-select-wrap").hide()}),$(document).on("click",".pwa-client-selector",function(e){e.stopPropagation();var a=$(this).data("project-id"),t=$("#pwa-client-wrap-"+a),c=$("#pwa-client-select-"+a),d=window.saturne.pwa_selectors.getBaseUrl(),l=$('input[name="token"]').val()||"";t.is(":visible")?t.hide():($(".pwa-inline-select-wrap").hide(),t.show(),c.data("select2")||(c.select2({placeholder:"Clients récents ou tapez pour chercher...",minimumInputLength:0,language:{searching:function(){return"Chargement..."},noResults:function(){return"Aucun résultat"}},ajax:{url:d,dataType:"json",delay:200,cache:!0,data:function(e){return{action:"search_tiers_ajax",q:e.term||""}},processResults:function(e){return{results:e.results||[]}}}}),c.on("select2:select",function(e){var n=e.params.data.id,i=e.params.data.text,o=(t.hide(),$('.pwa-client-selector[data-project-id="'+a+'"]')),r=o.html();o.html('<i class="fas fa-spinner fa-spin" style="color:#9b59b6;"></i>'),$.post(d+"?action=updateoppsocid&token="+l,{projectid:a,socid:n},function(e){var t;e&&e.success?(t=e.new_company_badge&&e.new_company_badge.trim()?e.new_company_badge+" ":'<i class="far fa-building" style="color:#64748b;"></i> ',o.html(t+'<span style="font-weight:500;">'+$("<span>").text(i).html()+'</span><i class="fas fa-chevron-down" style="color:#94a3b8;font-size:0.8em;"></i>'),o.removeClass("empty").attr("title","Changer le tiers"),(t=e.new_company_card_url||"")&&((e=o.closest(".pwa-selector-wrap").find('a[title="Voir la fiche client"]')).length?e.attr("href",t):o.before('<a href="'+t+'" class="prevent-edit-click" title="Voir la fiche client" style="display:inline-flex;align-items:center;color:#64748b;font-size:1.15em;flex-shrink:0;"><i class="fas fa-building"></i></a>')),c.val(null).trigger("change"),(e=$("#pwa-contact-select-"+a)).removeData("contacts-loaded").empty(),e.data("select2")&&e.select2("destroy"),(t=$('.pwa-contact-tags-wrap[data-project-id="'+a+'"]')).data("tiers-id",n),t.attr("data-tiers-id",n),$('.pwa-contact-selector[data-project-id="'+a+'"]').data("tiers-id",n),$("#pwa-contact-wrap-"+a).hide()):(o.html(r),o.css({border:"1px solid #e74c3c"}),setTimeout(function(){o.css({border:""})},2e3))},"json").fail(function(){o.html(r),o.css({border:"1px solid #e74c3c"}),setTimeout(function(){o.css({border:""})},2e3)})}),c.on("select2:close",function(){setTimeout(function(){t.hide()},100)})),c.select2("open"))}),$(document).on("click",".pwa-add-contact-btn",function(e){e.stopPropagation();var r,e=$(this).closest(".pwa-contact-tags-wrap"),t=e.find(".pwa-contact-add-panel"),n=(e.data("project-id"),e.data("tiers-id")||0),i=window.saturne.pwa_selectors.getBaseUrl();t.is(":visible")?t.hide():($(".pwa-contact-add-panel").hide(),t.show(),n<=0?t.html('<div class="pwa-contact-loading-inline"><i class="fas fa-exclamation-triangle" style="color:#d97706;"></i> Associez d\'abord un client</div>'):(r=[],e.find(".pwa-contact-chip").each(function(){r.push(parseInt($(this).data("contact-id"),10))}),t.html('<div class="pwa-contact-loading-inline"><i class="fas fa-spinner fa-spin"></i> Chargement...</div>'),$.getJSON(i,{action:"search_contact_ajax",socid:n,q:""},function(e){var e=e&&e.results?e.results:[],o=$('<ul class="pwa-contact-list">');0===e.length?o.append('<li class="pwa-contact-list-empty">Aucun contact pour ce client</li>'):$.each(e,function(e,t){var n=-1!==r.indexOf(parseInt(t.id,10)),i=$("<li>").attr("data-contact-id",t.id).attr("data-contact-name",t.text);n?i.addClass("pwa-contact-list-linked").html($("<span>").text(t.text).prop("outerHTML")+'<i class="fas fa-check pwa-linked-check"></i>'):i.text(t.text),o.append(i)}),t.html(o)}).fail(function(){t.html('<div class="pwa-contact-loading-inline" style="color:#e74c3c;"><i class="fas fa-exclamation-circle"></i> Impossible de charger les contacts</div>')})))}),$(document).on("click",".pwa-contact-list li:not(.pwa-contact-list-empty):not(.pwa-contact-list-linked)",function(e){e.stopPropagation();var e=$(this),t=e.closest(".pwa-contact-add-panel"),n=t.closest(".pwa-contact-tags-wrap"),i=n.find(".pwa-add-contact-btn"),o=parseInt(e.data("contact-id"),10),r=e.data("contact-name")||e.text().trim(),e=n.data("project-id"),a=window.saturne.pwa_selectors.getBaseUrl(),c=$('input[name="token"]').val()||"";o&&(t.hide(),i.html('<i class="fas fa-spinner fa-spin"></i>'),$.post(a+"?action=addoppcontact&token="+c,{projectid:e,contactid:o},function(e){var t;i.html('<i class="fas fa-plus"></i>'),e&&e.success&&e.link_id?(t='<span class="pwa-contact-chip" data-link-id="'+e.link_id+'" data-contact-id="'+o+'"><a href="'+e.contact_url+'" class="prevent-edit-click" title="Voir la fiche contact">'+$("<span>").text(r).html()+'</a><span class="pwa-chip-role">- Intervenant</span><span class="pwa-chip-remove prevent-edit-click" data-link-id="'+e.link_id+'" title="Retirer ce contact"><i class="fas fa-unlink" style="font-size:0.75em;"></i></span></span>',i.before(t),n.find(".pwa-contact-icon-nolink").replaceWith('<a href="'+e.contact_url+'" class="pwa-contact-icon-link prevent-edit-click" title="Voir la fiche contact"><i class="fas fa-address-book"></i></a>')):(t=e&&e.error?" ("+e.error+")":"",i.attr("title","Erreur"+t).css({outline:"2px solid #e74c3c"}),setTimeout(function(){i.css({outline:""}).removeAttr("title")},3e3))},"json").fail(function(){i.html('<i class="fas fa-plus"></i>'),i.css({outline:"2px solid #e74c3c"}),setTimeout(function(){i.css({outline:""})},2e3)}))}),$(document).on("click",function(e){$(e.target).closest(".pwa-contact-tags-wrap").length||$(".pwa-contact-add-panel").hide()}),$(document).on("click",".pwa-chip-remove",function(e){e.stopPropagation();var t=$(this),e=parseInt(t.data("link-id"),10),n=t.closest(".pwa-contact-chip"),i=n.closest(".pwa-contact-tags-wrap"),o=window.saturne.pwa_selectors.getBaseUrl(),r=$('input[name="token"]').val()||"";t.html('<i class="fas fa-spinner fa-spin" style="font-size:0.75em;"></i>'),$.post(o+"?action=removeoppcontact&token="+r,{link_id:e},function(e){e&&e.success?(n.css({outline:"2px solid #38a169",transition:"outline 0.2s"}),setTimeout(function(){n.fadeOut(250,function(){$(this).remove(),0===i.find(".pwa-contact-chip").length&&i.find(".pwa-contact-icon-link").replaceWith('<i class="fas fa-address-book pwa-contact-icon-nolink" title="Ajouter un contact"></i>')})},300)):(t.html('<i class="fas fa-unlink" style="font-size:0.75em;"></i>'),n.css({outline:"2px solid #e74c3c"}),setTimeout(function(){n.css({outline:""})},2e3))},"json").fail(function(){t.html('<i class="fas fa-unlink" style="font-size:0.75em;"></i>')})})},window.saturne.quickcreation_form={},window.saturne.quickcreation_form.init=function(){(document.querySelector(".quickcreation-form")||document.getElementById("geoloc-header-wrapper"))&&(window.saturne.quickcreation_form.moveGeolocIcon(),window.saturne.quickcreation_form.initPhoneValidation(),window.saturne.quickcreation_form.initEmailValidation(),window.saturne.quickcreation_form.initWebsiteValidation(),window.saturne.quickcreation_form.initFormSubmit(),window.saturne.quickcreation_form.initOppSlider(),window.saturne.quickcreation_form.initContactSelect())},window.saturne.quickcreation_form.moveGeolocIcon=function(){setTimeout(function(){var e,t=$("#id-top");t.length?(e=t.find(".user-profile-widget")).length?$("#geoloc-header-wrapper").css("display","flex").insertBefore(e):t.append($("#geoloc-header-wrapper").css("display","flex")):(e=$(".login_block, .header-pwa-right, .saturne-header-right").first()).length?$("#geoloc-header-wrapper").css("display","flex").prependTo(e):$("#geoloc-header-wrapper").css({display:"flex",position:"fixed",top:"12px",right:"80px","z-index":"9999",background:"rgba(255,255,255,0.9)",padding:"4px 8px","border-radius":"4px"}).appendTo("body")},500)},window.saturne.quickcreation_form.initPhoneValidation=function(){var o,r,e=document.getElementById("reedcrm-quickcreation-data");e&&(e=e.getAttribute("data-utils-path")||"",o=document.getElementById("projectphone"))&&void 0!==window.intlTelInput&&(r=window.intlTelInput(o,{initialCountry:"fr",utilsScript:e,formatOnDisplay:!0,nationalMode:!0,autoPlaceholder:"aggressive",preferredCountries:["fr","be","ch","lu","mc"]}),o.addEventListener("input",function(){var e,t,n=o.value,i=n.replace(/^(?:\+33|0033)[\s\-.]*0([1-9])/,"+33 $1");i!==n&&(o.value=n=i),window.intlTelInputUtils&&(e=(i=o.selectionStart)===o.value.length,t=n.startsWith("+")?window.intlTelInputUtils.numberFormat.INTERNATIONAL:window.intlTelInputUtils.numberFormat.NATIONAL,t=window.intlTelInputUtils.formatNumber(n,r.getSelectedCountryData().iso2,t))&&t!==n&&(o.value=t,!e)&&o.setSelectionRange&&o.setSelectionRange(i,i),!o.value.trim()||r.isValidNumber()?(o.classList.remove("input-invalid-material"),o.setCustomValidity("")):(o.classList.add("input-invalid-material"),o.setCustomValidity("Numéro de téléphone invalide."))}),e=o.closest("form"))&&e.addEventListener("submit",function(){o.value.trim()&&r.isValidNumber()&&(o.value=r.getNumber())})},window.saturne.quickcreation_form.initEmailValidation=function(){var t=/^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$/;document.querySelectorAll('input[type="email"]').forEach(function(e){e.addEventListener("input",function(){var e=this.value.trim();e&&!t.test(e)?(this.classList.add("input-invalid-material"),this.setCustomValidity("Format de l'adresse e-mail invalide.")):(this.classList.remove("input-invalid-material"),this.setCustomValidity(""))})})},window.saturne.quickcreation_form.initWebsiteValidation=function(){var r=/^([\w\-]+(\.[\w\-]+)+)([\/?#].*)?$/i;document.querySelectorAll(".website-input-group").forEach(function(t){var n=t.querySelector(".url-protocol"),i=t.querySelector(".url-domain"),o=t.querySelector(".url-hidden");function e(){var e=i.value.trim();/^https?:\/\//i.test(e)&&(e=e.toLowerCase().startsWith("http://")?(n.value="http://",e.substring(7)):(n.value="https://",e.substring(8)),i.value=e),e?(o.value=n.value+e,r.test(e)?(t.classList.remove("input-invalid-material"),i.setCustomValidity("")):(t.classList.add("input-invalid-material"),i.setCustomValidity("Format du nom de domaine invalide."))):(o.value="",t.classList.remove("input-invalid-material"),i.setCustomValidity(""))}n.addEventListener("change",e),i.addEventListener("input",e)})},window.saturne.quickcreation_form.initFormSubmit=function(){var o=/^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$/,r=/^([\w\-]+(\.[\w\-]+)+)([\/?#].*)?$/i,a=document.querySelector(".quickcreation-form");a&&a.addEventListener("submit",function(e){var n,t,i;this.checkValidity()&&(n=!1,this.querySelectorAll('input[type="email"]').forEach(function(e){e.value.trim()&&!o.test(e.value.trim())&&(n=!0,e.classList.add("input-invalid-material"),e.reportValidity(),e.focus())}),this.querySelectorAll(".website-input-group").forEach(function(e){var t=e.querySelector(".url-domain");t.value.trim()&&!r.test(t.value.trim())&&(n=!0,e.classList.add("input-invalid-material"),t.reportValidity(),t.focus())}),n?e.preventDefault():(e.preventDefault(),(t=a.querySelector('button[type="submit"]'))&&(i=t.innerHTML,t.innerHTML='<i class="fas fa-spinner fa-spin" style="font-size:20px;color:#fff;"></i>',t.disabled=!0,(e=new FormData(a)).append("ajax_submission","1"),fetch(window.location.href,{method:"POST",body:e}).then(function(e){var t=e.headers.get("content-type");return t&&-1!==t.indexOf("application/json")?e.json():e.text()}).then(function(e){var t,n,i;"object"==typeof e&&e.success?window.location.href=e.redirect_url||window.location.href:"string"==typeof e&&((n=(t=(new DOMParser).parseFromString(e,"text/html")).querySelectorAll(".error,.theme-error,.jnotify-container,.alert-danger,.warning,.theme-warning")).length?(document.querySelectorAll(".error,.theme-error,.jnotify-container,.alert-danger,.warning,.theme-warning").forEach(function(e){e.remove()}),i=document.getElementById("id-container")||a,n.forEach(function(e){i.insertBefore(e,i.firstChild)}),window.scrollTo({top:0,behavior:"smooth"})):t.querySelector(".ok,.theme-success,.theme-statut-ok")?window.location.reload():(document.open(),document.write(e),document.close()))}).catch(function(e){console.error("Erreur de soumission",e),alert("Une erreur technique s'est produite.")}).finally(function(){t.innerHTML=i,t.disabled=!1}))))})},window.saturne.quickcreation_form.initOppSlider=function(){var t=document.getElementById("opp_percent"),n=document.querySelector(".opp_percent-value");function e(){var e=parseInt(t.value)||0,e=(n.textContent=e+"%",e/100);n.style.left="calc("+100*e+"% - "+45*e+"px + 22.5px)"}t&&n&&(e(),t.addEventListener("input",e))},window.saturne.quickcreation_form.initContactSelect=function(){var e,t;function i(){var e;jQuery.fn.select2&&((e=$("#contactid")).hasClass("select2-hidden-accessible")&&e.select2("destroy"),e.select2({width:"100%",language:t,placeholder:"Contact/Adresse"}))}function o(){var e=$("#socid").val()||($("#search_socid").length?$("#search_socid").val():null);e&&0<parseInt(e)?$("#contact-wrapper").slideDown(200):$("#contact-wrapper").slideUp(200)}"undefined"!=typeof jQuery&&(e=document.getElementById("reedcrm-quickcreation-data"),t=e&&e.getAttribute("data-lang")||"fr",i(),o(),$(document).ajaxComplete(function(e,t,n){n.url&&-1!==n.url.indexOf("contacts.php")&&(i(),o())}),$(document).on("change","#socid, #search_socid",o),$(document).on("change","#contactid",function(){var e,t=$(this).val();!t||t<=0||((e=new FormData).append("action","get_contact_details"),e.append("contactid",t),fetch(window.location.href,{method:"POST",body:e}).then(function(e){return e.json()}).then(function(t){var e;t&&t.id&&((e=document.getElementById("projectphone"))&&t.phone&&(e.value=t.phone,e.dispatchEvent(new Event("input",{bubbles:!0}))),document.querySelectorAll('input[type="email"]').forEach(function(e){"options_reedcrm_email"===e.name&&t.email&&(e.value=t.email,e.dispatchEvent(new Event("input",{bubbles:!0})))}),(e=document.getElementById("reedcrm_firstname"))&&t.firstname&&(e.value=t.firstname,e.dispatchEvent(new Event("input"))),e=document.getElementById("reedcrm_lastname"))&&t.lastname&&(e.value=t.lastname,e.dispatchEvent(new Event("input")))}).catch(function(e){console.error("Error fetching contact details",e)}))}))},window.reedcrm.call_list_widget={},window.reedcrm.call_list_widget.init=function(){window.reedcrm.call_list_widget.event(),window.reedcrm.call_list_widget.initSelect2()},window.reedcrm.call_list_widget.initSelect2=function(){"undefined"!=typeof jQuery&&jQuery.fn.select2&&$(".reedcrm-call-list-select").each(function(){$(this).hasClass("select2-hidden-accessible")||($(this).select2({width:"200px",minimumResultsForSearch:1/0}),$(this).on("select2:open",function(e){e.stopPropagation()}))})},window.reedcrm.call_list_widget.event=function(){$(document).off("click",".reedcrm-call-list-add-btn",window.reedcrm.call_list_widget.handleAdd).on("click",".reedcrm-call-list-add-btn",window.reedcrm.call_list_widget.handleAdd),$(document).off("change",".reedcrm-call-list-select",window.reedcrm.call_list_widget.onSelectChange).on("change",".reedcrm-call-list-select",window.reedcrm.call_list_widget.onSelectChange),$(document).off("click",".reedcrm-call-list-default-btn",window.reedcrm.call_list_widget.handleAddDefault).on("click",".reedcrm-call-list-default-btn",window.reedcrm.call_list_widget.handleAddDefault)},window.reedcrm.call_list_widget.onSelectChange=function(){$(this).closest(".reedcrm-add-to-call-list-wrapper").find(".reedcrm-call-list-add-btn").prop("disabled",!$(this).val())},window.reedcrm.call_list_widget.handleAdd=function(){var e,t,n,i,o,r;$(this).prop("disabled")||(e=(i=$(this).closest(".reedcrm-add-to-call-list-wrapper")).data("element-type"),t=i.data("element-id"),n=i.data("ajax-url"),i=i.find(".reedcrm-call-list-select").val(),o=$('input[name="token"]').val()||"",i&&((r=new FormData).append("element_type",e),r.append("element_id",t),r.append("call_list_id",i),r.append("token",o),fetch(n,{method:"POST",body:r}).then(function(e){return e.json()}).then(function(e){e.success?$.jnotify(e.message):$.jnotify(e.message,"error")}).catch(function(){$.jnotify("Erreur réseau","error")})))},window.reedcrm.call_list_widget.handleAddDefault=function(){var t=$(this),e=t.closest(".reedcrm-add-to-call-list-wrapper"),n=e.data("element-type"),i=e.data("element-id"),e=e.data("default-ajax-url"),o=$('input[name="token"]').val()||"",r=new FormData;r.append("element_type",n),r.append("element_id",i),r.append("token",o),fetch(e,{method:"POST",body:r}).then(function(e){return e.json()}).then(function(e){e.success?(t.addClass("is-active"),$.jnotify(e.message)):$.jnotify(e.message,"error")}).catch(function(){$.jnotify("Erreur réseau","error")})},window.reedcrm.address={},window.reedcrm.address.init=function(){window.reedcrm.address.event()},window.reedcrm.address.event=function(){$(document).on("click",'[name="favorite_address"]',window.reedcrm.address.toggleAddressFavorite)},window.reedcrm.address.toggleAddressFavorite=function(){var e=$(this).attr("value");let t=$(this);var n=window.saturne.toolbox.getToken();let i="?";document.URL.match(/\?/)&&(i="&"),$.ajax({url:document.URL+i+"action=toggle_favorite&contact_id="+e+"&token="+n,type:"POST",processData:!1,contentType:!1,success:function(){var e=$(".fas.fa-star");t.hasClass("far")&&(t.removeClass("far"),t.addClass("fas")),e.removeClass("fas").addClass("far")},error:function(){}})},window.saturne=window.saturne||{},window.saturne.call_list={},window.saturne.call_list.init=function(){window.saturne.call_list.event()},window.saturne.call_list.event=function(){$(document).on("change","#call_line_element_type",window.saturne.call_list.onTypeChange),$(document).on("change","#propal_id",window.saturne.call_list.onElementChange),$(document).on("change","#project_id",window.saturne.call_list.onElementChange),$(document).on("submit","#add-call-line-form",window.saturne.call_list.onSubmit)},window.saturne.call_list.onTypeChange=function(){"project"===$(this).val()?($("#call-line-propal-wrap").addClass("hidden"),$("#call-line-project-wrap").removeClass("hidden"),$.fn.select2&&$("#project_id").select2({width:"300px"})):($("#call-line-project-wrap").addClass("hidden"),$("#call-line-propal-wrap").removeClass("hidden"),$.fn.select2&&$("#propal_id").select2({width:"300px"})),window.saturne.call_list.resetContact()},window.saturne.call_list.onElementChange=function(){var e=$(this).val(),t=$("#call_line_element_type").val(),n=$("#call-list-data");e?$.ajax({url:n.data("ajaxUrl"),dataType:"json",data:{element_type:t,element_id:e},success:function(e){var t;e&&e.success&&e.contact_id?(t="<b>"+e.lastname+" "+e.firstname+"</b>",e.phone?t+=" — "+e.phone:t+=' <span class="opacitymedium badge badge-status1">⚠ '+n.data("labelNoPhone")+"</span>",$("#call_line_contact_info").html(t),$("#fk_contact_hidden").val(e.contact_id)):($("#call_line_contact_info").html('<span class="opacitymedium">'+n.data("labelNoContact")+"</span>"),$("#fk_contact_hidden").val(""))},error:function(){window.saturne.call_list.resetContact()}}):window.saturne.call_list.resetContact()},window.saturne.call_list.resetContact=function(){var e=$("#call-list-data");$("#call_line_contact_info").html('<span class="opacitymedium">'+e.data("labelContact")+" : —</span>"),$("#fk_contact_hidden").val("")},window.saturne.call_list.onSubmit=function(e){if(!("project"===$("#call_line_element_type").val()?$("#project_id"):$("#propal_id")).val())return e.preventDefault(),!1},$(document).ready(function(){window.saturne.call_list.init()}),window.reedcrm||(window.reedcrm={}),window.reedcrm.callnotifications={},window.reedcrm.callnotifications.init=function(){console.log("ReedCRM Call Notifications initialized"),window.reedcrm.callnotifications.config(),window.reedcrm.callnotifications.start()},window.reedcrm.callnotifications.config=function(){var e=document.getElementById("reedcrm-call-config");e?(window.reedcrm.callnotifications.frequency=parseInt(e.dataset.frequency)||60,window.reedcrm.callnotifications.autoOpen=parseInt(e.dataset.autoOpen)||0,window.reedcrm.callnotifications.openNewTab=parseInt(e.dataset.openNewTab)||1,window.reedcrm.callnotifications.checkUrl=e.dataset.checkUrl||"",window.reedcrm.callnotifications.trans={incomingCall:e.dataset.transIncomingCall||"Incoming Call",from:e.dataset.transFrom||"From",phone:e.dataset.transPhone||"Phone",email:e.dataset.transEmail||"Email",viewContact:e.dataset.transViewContact||"View Contact"}):(window.reedcrm.callnotifications.frequency=60,window.reedcrm.callnotifications.autoOpen=0,window.reedcrm.callnotifications.openNewTab=1,window.reedcrm.callnotifications.checkUrl="",window.reedcrm.callnotifications.trans={incomingCall:"Incoming Call",from:"From",phone:"Phone",email:"Email",viewContact:"View Contact"}),window.reedcrm.callnotifications.enabled=!0,window.reedcrm.callnotifications.interval=null},window.reedcrm.callnotifications.start=function(){window.reedcrm.callnotifications.checkUrl?setTimeout(function(){console.log("Starting ReedCRM call check with frequency: "+window.reedcrm.callnotifications.frequency+"s"),window.reedcrm.callnotifications.check(),window.reedcrm.callnotifications.interval=setInterval(window.reedcrm.callnotifications.check,1e3*window.reedcrm.callnotifications.frequency)},3e3):console.error("ReedCRM: No check URL configured for call notifications")},window.reedcrm.callnotifications.check=function(){window.reedcrm.callnotifications.enabled&&jQuery.ajax({url:window.reedcrm.callnotifications.checkUrl,type:"GET",dataType:"json",success:function(e){e&&0<e.length&&(console.log("Found "+e.length+" new call events"),jQuery.each(e,function(e,t){window.reedcrm.callnotifications.show(t)}))},error:function(e,t,n){console.error("Error checking call events:",n)}})},window.reedcrm.callnotifications.show=function(t){console.log("Showing call notification:",t);var e=window.reedcrm.callnotifications.trans,n="<strong>"+e.incomingCall+"</strong> : "+t.contact_name;t.caller&&(n+="<br>"+e.from+": "+t.caller),t.contact_phone&&(n+="<br>"+e.phone+": "+t.contact_phone),t.contact_email&&(n+="<br>"+e.email+": "+t.contact_email),n=(n+='<br><br><button type="button" class="button" onclick="window.open(\''+t.url+"', '_blank')\">")+e.viewContact+"</button>",jQuery.jnotify(n,"success",!0,{sticky:!0,timeout:3e4}),window.reedcrm.callnotifications.autoOpen&&setTimeout(function(){var e=window.reedcrm.callnotifications.openNewTab?"_blank":"_self";window.open(t.url,e)},1e3)},window.reedcrm.callnotifications.enable=function(){window.reedcrm.callnotifications.enabled=!0,window.reedcrm.callnotifications.check(),window.reedcrm.callnotifications.interval=setInterval(window.reedcrm.callnotifications.check,1e3*window.reedcrm.callnotifications.frequency),console.log("ReedCRM call notifications enabled")},window.reedcrm.callnotifications.disable=function(){window.reedcrm.callnotifications.enabled=!1,window.reedcrm.callnotifications.interval&&clearInterval(window.reedcrm.callnotifications.interval),console.log("ReedCRM call notifications disabled")},jQuery(document).ready(function(){window.reedcrm.callnotifications.init()}),window.saturne.contact_inline={},window.saturne.contact_inline.init=function(){window.saturne.contact_inline.mountCardUi(),window.saturne.contact_inline.event()},window.saturne.contact_inline.event=function(){$(document).on("click",".copy-action-icon",window.saturne.contact_inline.copyToClipboard),$(document).on("click",".inline-edit-proj-title, .inline-edit-contact",window.saturne.contact_inline.startInlineEdit),$(document).on("click",".inline-edit-proj-percent",window.saturne.contact_inline.editPercent),$(document).on("click",".inline-edit-proj-amount",window.saturne.contact_inline.editAmount),$(document).on("click",".inline-edit-company-badge",window.saturne.contact_inline.startCompanyEdit),$(document).on("click",".inline-edit-origin-badge",window.saturne.contact_inline.startOriginEdit)},window.saturne.contact_inline.copyToClipboard=function(e){e.preventDefault(),e.stopPropagation();e=$(this).data("copy");let t=$(this),n=t.attr("class"),i=t.css("color");navigator.clipboard&&navigator.clipboard.writeText(e).then(()=>{t.attr("class","fas fa-check").css("color","#38a169"),setTimeout(()=>{t.attr("class",n).css("color",i)},1500)}).catch(e=>console.error("Erreur Copie:",e))},window.saturne.contact_inline.mountCardUi=function(){var e=$("#reedcrm-inline-data");if(0!==e.length&&!(0<$(".reedcrm-card-header-blocks").length)){var n=e.data("project-id"),t=parseFloat(e.data("amount")||0),i=e.data("percent-str"),o=e.data("amount-str"),r=e.data("logo-path"),e=e.data("percent-val"),a=$("div.refidno");if(0<a.length){var c=a.find(".editval");if(0===c.length){var d=a.contents().filter(function(){return 3===this.nodeType&&""!==$.trim(this.nodeValue)}).first();if(0<d.length){var l=$.trim(d.text()),s=$('<div class="reedcrm-header-title-wrapper" style="display: inline-flex; align-items: center; background: #f8fbff; border: 1px solid #e2e8f0; border-radius: 6px; padding: 4px 8px 4px 6px; vertical-align: middle; font-weight: 600; font-size: 0.95em; margin-bottom: 2px;"><img src="'+r+'" style="height: 18px; width: 18px; object-fit: contain; margin-right: 8px; border-right: 1px solid #cbd5e0; padding-right: 8px;" alt="ReedCRM" title="Géré par ReedCRM" /></div>'),d=(d.replaceWith(s),$('<span class="dynamic-libelle-prefix" style="color: #4a5568; cursor: pointer; font-weight: bold; margin-right: 6px; padding-bottom: 1px;" title="Modifier le titre">Libellé :</span>'));let t=$('<span class="inline-edit-proj-title" data-project-id="'+n+'" data-val="" style="color: #0f172a; cursor: pointer; border-bottom: 1px dashed #cbd5e0; line-height: 1; padding-bottom: 1px; transition: color 0.3s; display: inline-flex; min-width: 100px;" title="Modifier le titre"></span>');t.text(l).attr("data-val",l),s.append(d).append(t),d.on("click",function(e){e.stopPropagation(),t.click()})}}else $('<div class="reedcrm-header-title-wrapper" style="display: inline-flex; align-items: center; background: #f8fbff; border: 1px solid #e2e8f0; border-radius: 6px; padding: 4px 8px 4px 6px; vertical-align: middle; font-weight: 600; font-size: 0.95em; margin-bottom: 2px; margin-right: 6px;"><img src="'+r+'" style="height: 18px; width: 18px; object-fit: contain; margin-right: 8px; border-right: 1px solid #cbd5e0; padding-right: 8px;" alt="ReedCRM" title="Géré par ReedCRM" /><span style="color: #4a5568; font-weight: bold; margin-right: 4px;">Libellé :</span></div>').insertBefore(c)}var l=$(".statusref"),s=$(".arearef > div").first(),e=(0===$(".reedcrm-header-stats").length&&(d='<div class="reedcrm-header-stats" style="'+(0<l.length?"":"float: right; ")+'display: inline-flex; align-items: center; background: #f8fbff; border: 1px solid #e2e8f0; border-radius: 6px; padding: 4px 8px 4px 6px; margin-right: 15px; vertical-align: middle; font-weight: 600; font-size: 0.95em;"><img src="'+r+'" style="height: 18px; width: 18px; object-fit: contain; margin-right: 8px; border-right: 1px solid #cbd5e0; padding-right: 8px;" alt="ReedCRM" title="Géré par ReedCRM" /><span class="inline-edit-proj-percent" data-project-id="'+n+'" data-val="'+e+'" style="color: #0f172a; cursor: pointer; border-bottom: 1px dashed #cbd5e0; padding-bottom: 1px; transition: color 0.3s; display: inline-flex; align-items: center; white-space: nowrap; line-height: 1;" title="Modifier la probabilité">'+i+'</span><span style="color: #cbd5e0; margin: 0 6px;">-</span><span class="inline-edit-proj-amount" data-project-id="'+n+'" data-val="'+t+'" style="color: #3b82f6; cursor: pointer; border-bottom: 1px dashed #cbd5e0; padding-bottom: 1px; transition: color 0.3s; display: inline-flex; align-items: center; white-space: nowrap; line-height: 1;" title="Modifier le montant">'+o+"</span></div>",0<l.length?0<(c=l.find(".badge, .status, .label")).length?$(d).insertBefore(c.first()):l.prepend(d):0<s.length&&s.prepend(d)),$(".reedcrm-header-title-wrapper")),i=$(".contact-inline-wrapper.reedcrm-header-contact-master"),t=(0<e.length&&0<i.length&&(n=$('<div class="reedcrm-card-header-blocks" style="display: flex; flex-direction: column; gap: 8px; margin-top: 6px; margin-left: 0; padding-left: 0; align-items: flex-start; clear: both;"></div>'),e.wrap(n),i.appendTo(e.parent()),a.children("br").remove(),e.css({"margin-left":"0","margin-right":"0","margin-bottom":"0"}),i.css({"margin-left":"0","margin-right":"0","margin-bottom":"0"})),a.find('a[href*="socid="]').not(".customer-back").not(".vendor-back").first());0<t.length?(o=t.attr("href"),0<(c=t.find(".fa-building, .fa-building-o, .fa-industry")).length&&(c.remove(),t.html(t.html().replace(/&nbsp;/g,"").trim())),t.parent().hasClass("reedcrm-header-company-wrapper")||(t.wrap('<div class="reedcrm-header-company-wrapper" style="display: inline-flex; align-items: center; background: #f8fbff; border: 1px solid #e2e8f0; border-radius: 6px; padding: 4px 8px 4px 6px; vertical-align: middle; font-weight: 500; font-size: 0.9em; margin-bottom: 2px; color: #4a5568;"></div>'),t.before('<img src="'+r+'" style="height: 18px; width: 18px; object-fit: contain; margin-right: 8px; border-right: 1px solid #cbd5e0; padding-right: 8px;" alt="ReedCRM" />'),t.before('<a href="'+o+'" target="_blank" style="color: #64748b; margin-right: 6px; display: inline-flex; align-items: center;" title="Ouvrir la fiche tiers"><i class="fas fa-building"></i></a>')),t.addClass("inline-edit-company-badge").css({cursor:"pointer",transition:"color 0.3s",color:"#0f172a"}).attr("title","Modifier l'entreprise rattachée"),l=t.closest(".reedcrm-header-company-wrapper"),0<$(".reedcrm-card-header-blocks").length&&0<l.length&&(l.insertAfter($(".reedcrm-header-title-wrapper")),l.css({"margin-left":"0","margin-right":"0","margin-bottom":"0"}))):(s=$(".reedcrm-header-title-wrapper"),d=$(".reedcrm-card-header-blocks"),0<s.length&&(n=$('<div class="reedcrm-header-company-wrapper" style="display: inline-flex; align-items: center; background: #f8fbff; border: 1px solid #e2e8f0; border-radius: 6px; padding: 4px 8px 4px 6px; vertical-align: middle; font-weight: 500; font-size: 0.9em; margin-bottom: 2px; color: #4a5568;"><img src="'+r+'" style="height: 18px; width: 18px; object-fit: contain; margin-right: 8px; border-right: 1px solid #cbd5e0; padding-right: 8px;" alt="ReedCRM" /><a href="#" class="inline-edit-company-badge" style="cursor: pointer; transition: color 0.3s; color: #0f172a; border-bottom: 1px dashed #cbd5e0; line-height: 1; padding-bottom: 1px;" title="Affecter une entreprise"><i class="fas fa-building" style="margin-right:5px; color:#64748b;"></i>Affecter un tiers</a></div>'),0<d.length?(n.insertAfter(s),n.css({"margin-left":"0","margin-right":"0","margin-bottom":"0"})):n.insertAfter(s)))}},window.saturne.contact_inline.startCompanyEdit=function(e){if(!($(e.target).hasClass("select2-selection__choice__remove")||0<$(e.target).closest(".select2-container").length)){e.preventDefault(),e.stopPropagation();let o=$(this),r=o.html(),a=$("#reedcrm-hidden-company-selector");0!==a.length&&(0<o.parent().find("#reedcrm-hidden-company-selector").length?(o.hide(),a.show(),(e=a.find("select")).data("select2")&&e.select2("open")):(o.hide(),a.insertAfter(o).show(),(e=$("#reedcrm_inline_socid")).data("select2")&&e.select2("open"),e.off("change.inlineedit").on("change.inlineedit",function(){var t=$(this).val(),n=$("#reedcrm-inline-data").data("project-id"),i=$('input[name="token"]').val()||"";if(t&&0!=t){let e="undefined"!=typeof dolibarr_main_url_root&&dolibarr_main_url_root?dolibarr_main_url_root:"";e||(0<document.URL.indexOf("/projet/")?e=document.URL.substring(0,document.URL.indexOf("/projet/")):0<document.URL.indexOf("/custom/")&&(e=document.URL.substring(0,document.URL.indexOf("/custom/"))));i=e+"/custom/reedcrm/view/frontend/quickcreation.php?action=updateoppsocid&token="+i;o.html('<i class="fas fa-spinner fa-spin" style="color: #9b59b6;"></i> Enregistrement...'),a.hide(),o.show(),$.ajax({url:i,type:"POST",data:{projectid:n,socid:t},dataType:"json",success:function(e){var t;e.success?e.new_company_url?0<(t=$("<div>").html(e.new_company_url).find("a").first()).length?(o.attr("href",t.attr("href")),o.html(t.html())):o.html(e.new_company_url):o.html(r):(alert("Erreur: "+(e.error||"Inconnue")),o.html(r))},error:function(){alert("Impossible de joindre le serveur"),o.html(r)}})}else a.hide(),o.show()}),e.on("select2:close",function(){setTimeout(function(){a.is(":visible")&&(a.hide(),o.show())},100)})))}},window.saturne.contact_inline.startOriginEdit=function(e){if(!($(e.target).hasClass("select2-selection__choice__remove")||0<$(e.target).closest(".select2-container").length)){e.preventDefault(),e.stopPropagation();let a=$(this),c=a.html(),d=a.parent().find(".reedcrm-hidden-origin-selector-wrap");if(0!==d.length){a.hide(),d.show();var t,e=d.find("select");if(0!==e.length){try{e.data("select2")||e.hasClass("select2-hidden-accessible")?0<(t=e.next(".select2-container")).length&&t.css("width","180px"):e.select2({width:"180px"}),e.select2("open")}catch(e){return void console.error("SELECT2 ERROR: ",e)}e.off("change.inlineedit").on("change.inlineedit",function(){var e=$(this).val();let t=$(this).find("option:selected").text();var n=$("#reedcrm-inline-data").data("project-id"),i=$('input[name="token"]').val()||"";let o="undefined"!=typeof dolibarr_main_url_root&&dolibarr_main_url_root?dolibarr_main_url_root:"";o||(0<document.URL.indexOf("/projet/")?o=document.URL.substring(0,document.URL.indexOf("/projet/")):0<document.URL.indexOf("/custom/")&&(o=document.URL.substring(0,document.URL.indexOf("/custom/"))));var r=o+"/custom/reedcrm/view/frontend/quickcreation.php?action=updateopporigin";a.html('<i class="fas fa-spinner fa-spin" style="color: #9b59b6;"></i> Enregistrement...'),d.hide(),a.show(),$.ajax({url:r,type:"POST",data:{projectid:n,origin:e,token:i},dataType:"json",success:function(e){e.success?(a.text(t),a.css("color","#2ecc71"),setTimeout(()=>a.css("color",""),1500)):(alert("Erreur: "+(e.error||"Inconnue")),a.html(c))},error:function(){alert("Impossible de joindre le serveur"),a.html(c)}})}),e.off("select2:close").on("select2:close",function(){setTimeout(function(){d.is(":visible")&&(d.hide(),a.show())},100)})}}}},window.saturne.contact_inline.applyInputMaterial=function(e,t){var n,i;e&&(n=t?"#e53935":"#0f172a",i=t?"0 0 0 2px rgba(229, 57, 53, 0.2)":"0 0 0 2px rgba(59, 130, 246, 0.2)",e.style.setProperty("border","1px solid "+(t?"#e53935":"#3b82f6"),"important"),e.style.setProperty("color",n,"important"),e.style.setProperty("box-shadow",i,"important"))},window.saturne.contact_inline.cancelInlineEdit=function(e,t,n){t&&t[0]&&t[0].iti&&t[0].iti.destroy(),e.html(n)},window.saturne.contact_inline.startInlineEdit=function(e){if(!(0<$(this).find("input").length)){e.stopPropagation();let t=$(this);e=t.hasClass("inline-edit-proj-title");let n=t.data("val")||"",i=t.html();var a="phone"===t.data("field"),c="website"===t.data("field"),d="email"===t.data("field"),l="firstname"===t.data("field")||"lastname"===t.data("field")||d;let o=$('<input type="'+(a?"tel":c?"url":d?"email":"text")+'" style="width: '+(e?"250px":l?"100%":a||c?"180px":"140px")+"; border: 1px solid #3b82f6; border-radius: 4px; padding: 2px 6px; "+(a?"padding-left: 52px !important; ":"")+'font-weight: inherit; font-size: inherit; color: #0f172a; outline: none; box-sizing: border-box; background: white; margin: 0; display: inline-block; line-height: normal; box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.2);" value="">');if(o.val(n),c&&(""===n||"http://"===n?o.val("https://"):n.startsWith("http://")&&o.val("https://"+n.substring(7))),t.html("").append(o),window.saturne.contact_inline.applyInputMaterial(o[0],!1),c&&o.on("input",function(){let e=$(this).val().trim();e.startsWith("www.")&&(e="https://"+e,$(this).val(e));var t=""!==e&&"https://"!==e&&"http://"!==e&&!/^(https?:\/\/)?([\w\-]+(\.[\w\-]+)+)([\/?#].*)?$/i.test(e);window.saturne.contact_inline.applyInputMaterial(this,t)}),d&&o.on("input",function(){var e=$(this).val().trim();window.saturne.contact_inline.applyInputMaterial(this,""!==e&&!/^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$/.test(e))}),a&&void 0!==window.intlTelInput){let e="undefined"!=typeof dolibarr_main_url_root&&dolibarr_main_url_root?dolibarr_main_url_root:"";e||(0<document.URL.indexOf("/projet/")?e=document.URL.substring(0,document.URL.indexOf("/projet/")):0<document.URL.indexOf("/custom/")&&(e=document.URL.substring(0,document.URL.indexOf("/custom/")))),o[0].iti=window.intlTelInput(o[0],{utilsScript:e+"/custom/reedcrm/js/intl-tel-input/js/utils.js",initialCountry:"fr",preferredCountries:["fr","be","ch","lu","ca"],nationalMode:!1,autoPlaceholder:"polite",dropdownContainer:document.body}),$(".iti__flag-container").css("z-index",9999),o[0].addEventListener("open:countrydropdown",function(){o[0].itiDropdownOpen=!0}),o[0].addEventListener("close:countrydropdown",function(){o[0].itiDropdownOpen=!1,setTimeout(()=>o.focus(),50)}),$(o).closest(".iti").on("mousedown",".iti__selected-flag, .iti__flag-container",function(){o[0].itiDropdownOpen=!0})}o.focus(),o.select();let r=e?window.saturne.contact_inline.submitTitleDetail:window.saturne.contact_inline.submitContactDetail;o.on("blur",function(){o[0]&&o[0].itiDropdownOpen||r(t,o,i,n,!1,"blur")}),o.on("keydown",function(e){e.stopPropagation(),13===e.which?(e.preventDefault(),o.off("blur"),r(t,o,i,n,!1,"enter")):9===e.which?(e.preventDefault(),o.off("blur"),r(t,o,i,n,!0,"tab")):27===e.which&&(e.preventDefault(),o.off("blur"),window.saturne.contact_inline.cancelInlineEdit(t,o,i))}),o.on("click",function(e){e.stopPropagation()})}},window.saturne.contact_inline.submitTitleDetail=function(n,i,o,r,a){function c(){var e=$(".contact-inline-wrapper .inline-edit-contact").first();0<e.length&&e.click()}let d=i.val().trim();if(d===r)n.html(o),a&&c();else{n.data("val",d);var i=n.width(),i=(n.html('<i class="fas fa-spinner fa-spin" style="color: #9b59b6;"></i>').css("min-width",i+"px"),n.data("project-id")),l=$('input[name="token"]').val()||"";let e="undefined"!=typeof dolibarr_main_url_root&&dolibarr_main_url_root?dolibarr_main_url_root:"",t=(e||(0<document.URL.indexOf("/projet/")?e=document.URL.substring(0,document.URL.indexOf("/projet/")):0<document.URL.indexOf("/custom/")&&(e=document.URL.substring(0,document.URL.indexOf("/custom/")))),e+"/custom/reedcrm/view/frontend/quickcreation.php?action=updateopptitle");0<document.URL.indexOf("quickcreation.php")&&(t=document.URL.split("?")[0]+"?action=updateopptitle"),$.ajax({url:t,type:"POST",data:{token:l,projectid:i,title:d},success:function(e){n.css({color:"#2ecc71","min-width":""}),n.html(d||'<span style="color:#cbd5e0; font-style:italic;">Sans titre</span>'),setTimeout(function(){n.css({color:""})},1500),a&&c()},error:function(e){alert("Erreur XHR Titre: "+e.status+"\n"+(e.responseText?e.responseText.substring(0,300):"Aucune reponse")),n.html(o).css("min-width",""),n.data("val",r),n.css({color:"#e74c3c"}),setTimeout(()=>n.css({color:""}),1500)}})}},window.saturne.contact_inline.submitContactDetail=function(n,i,o,r,a,c){function d(){var e=s.find(".inline-edit-contact:visible"),t=e.index(n);0<=t&&t<e.length-1&&e.eq(t+1).click()}let l=i.val().trim(),s=("phone"===n.data("field")&&i[0].iti&&window.intlTelInputUtils&&i[0].iti.isValidNumber()&&(l=i[0].iti.getNumber()),n.closest(".contact-inline-wrapper")),u=n.data("field"),e=!1;if("email"===u&&""!==l&&(e=!/^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$/.test(l)),"website"===u&&("https://"!==l&&"http://"!==l||(l="",i.val("")),""!==l)&&(l.startsWith("http://")||l.startsWith("https://")||(l="https://"+l,i.val(l)),e=!/^(https?:\/\/)?([\w\-]+(\.[\w\-]+)+)([\/?#].*)?$/i.test(l)),e)"blur"===c?(window.saturne.contact_inline.cancelInlineEdit(n,i,o),n.data("val",r)):(window.saturne.contact_inline.applyInputMaterial(i[0],!0),i.focus());else if(l===r)n.html(o),a&&d();else{n.data("val",l);var c=n.width(),c=(n.html('<i class="fas fa-spinner fa-spin" style="color: #9b59b6;"></i>').css("min-width",c+"px"),s.data("project-id")),p=s.find('.inline-edit-contact[data-field="firstname"]').data("val"),m=s.find('.inline-edit-contact[data-field="lastname"]').data("val"),f=s.find('.inline-edit-contact[data-field="phone"]').data("val"),w=s.find('.inline-edit-contact[data-field="email"]').data("val"),h=s.find('.inline-edit-contact[data-field="website"]').data("val"),g=$('input[name="token"]').val()||"";let e="undefined"!=typeof dolibarr_main_url_root&&dolibarr_main_url_root?dolibarr_main_url_root:"",t=(e||(0<document.URL.indexOf("/projet/")?e=document.URL.substring(0,document.URL.indexOf("/projet/")):0<document.URL.indexOf("/custom/")&&(e=document.URL.substring(0,document.URL.indexOf("/custom/")))),e+"/custom/reedcrm/view/frontend/quickcreation.php?action=updateoppcontact");0<document.URL.indexOf("quickcreation.php")&&(t=document.URL.split("?")[0]+"?action=updateoppcontact"),$.ajax({url:t,type:"POST",data:{token:g,projectid:c,firstname:p,lastname:m,phone:f,email:w,website:h},success:function(e){n.css({color:"#2ecc71","min-width":""});var t="";"firstname"===u&&(t="Prénom"),"lastname"===u&&(t="Nom"),"phone"===u&&(t="Téléphone"),"email"===u&&(t="Email"),"website"===u&&(t="Site Web"),n.html(l||'<span style="color:#cbd5e0; font-style:italic;">'+t+"</span>"),setTimeout(function(){n.css({color:""})},1500),a&&d()},error:function(e){alert("Erreur XHR Titre: "+e.status+"\n"+(e.responseText?e.responseText.substring(0,300):"Aucune reponse")),n.html(o).css("min-width",""),n.data("val",r),n.css({color:"#e74c3c"}),setTimeout(()=>n.css({color:""}),1500)}}),"phone"===n.data("field")&&i[0].iti&&i[0].iti.destroy()}},window.saturne.contact_inline.editPercent=function(t){if(!(0<$(this).find("input").length)){t.stopPropagation();let o=$(this),r=o.data("project-id"),e=parseInt(o.data("val")),a=o.text(),c=$('<input type="number" min="0" max="100" class="percent-input" style="width: 35px; text-align: center; border: 1px solid #cbd5e1; border-radius: 4px; padding: 0; font-weight: 600; font-size: 1em; color: #0f172a; outline: none; box-sizing: border-box; background: transparent; margin: 0; display: inline-block; vertical-align: middle; line-height: normal; -moz-appearance: textfield;" value="'+e+'">'),n=(0===$("#css-no-spinners").length&&$("head").append('<style id="css-no-spinners">input[type="number"].percent-input::-webkit-outer-spin-button, input[type="number"].percent-input::-webkit-inner-spin-button { -webkit-appearance: none; margin: 0; }</style>'),o.html("").append(c).append('<span style="font-weight:normal; margin-left: 2px;">%</span>'),c.focus(),function(){let n=parseInt(c.val());if((n=100<(n=isNaN(n)||n<0?0:n)?100:n)===e)o.html(a);else{o.html('<i class="fas fa-spinner fa-spin" style="color: #9b59b6; line-height: 22px;"></i>');var i=$('input[name="token"]').val()||"";let e="undefined"!=typeof dolibarr_main_url_root&&dolibarr_main_url_root?dolibarr_main_url_root:"",t=(e||(0<document.URL.indexOf("/projet/")?e=document.URL.substring(0,document.URL.indexOf("/projet/")):0<document.URL.indexOf("/custom/")&&(e=document.URL.substring(0,document.URL.indexOf("/custom/")))),e+"/custom/reedcrm/view/frontend/quickcreation.php?action=updateopppercent");0<document.URL.indexOf("quickcreation.php")&&(t=document.URL.split("?")[0]+"?action=updateopppercent"),$.ajax({url:t,type:"POST",data:{token:i,projectid:r,percent:n},success:function(e){e&&e.success?(o.data("val",n),o.html(n+" %"),o.css({color:"#2ecc71"})):o.html(a).css({color:"#e74c3c"}),setTimeout(()=>o.css({color:"#0f172a"}),1500)},error:function(e){alert("Erreur XHR Percent: "+e.status+"\n"+(e.responseText?e.responseText.substring(0,300):"Aucune reponse")),o.html(a).css({color:"#e74c3c"}),setTimeout(()=>o.css({color:originalColor}),1500)}})}});c.on("blur",n),c.on("keypress",function(e){e.stopPropagation(),13===e.which&&(e.preventDefault(),c.off("blur"),n())}),c.on("keydown",function(t){if(9===t.which){t.preventDefault(),c.off("blur"),n();let e=o.parent().find(".inline-edit-proj-amount");0<e.length&&setTimeout(()=>e.click(),50)}}),c.on("click",function(e){e.stopPropagation()})}},window.saturne.contact_inline.editAmount=function(i){if(!(0<$(this).find("input").length)){i.stopPropagation();let o=$(this),r=o.data("project-id"),e=parseFloat(o.data("val")),a=o.text();i=8<a.length?"80px":"65px";let t=$('<input type="text" class="amount-input" style="width: '+i+'; text-align: center; border: 1px solid #cbd5e1; border-radius: 4px; padding: 0 2px; font-weight: 600; font-size: 1em; color: #3b82f6; outline: none; box-sizing: border-box; background: transparent; margin: 0; display: inline-block; vertical-align: middle; line-height: normal; -moz-appearance: textfield;" value="'+e+'">'),n=(o.html("").append(t).append('<span style="font-weight:normal; margin-left: 4px;">€</span>'),t.focus(),function(){var n=t.val().replace(",",".");let i=parseFloat(n);if((i=isNaN(i)||i<0?0:i)===e)o.html(a);else{o.html('<i class="fas fa-spinner fa-spin" style="color: #9b59b6; line-height: 22px;"></i>');n=$('input[name="token"]').val()||"";let e="undefined"!=typeof dolibarr_main_url_root&&dolibarr_main_url_root?dolibarr_main_url_root:"",t=(e||(0<document.URL.indexOf("/projet/")?e=document.URL.substring(0,document.URL.indexOf("/projet/")):0<document.URL.indexOf("/custom/")&&(e=document.URL.substring(0,document.URL.indexOf("/custom/")))),e+"/custom/reedcrm/view/frontend/quickcreation.php?action=updateoppamount");0<document.URL.indexOf("quickcreation.php")&&(t=document.URL.split("?")[0]+"?action=updateoppamount"),$.ajax({url:t,type:"POST",data:{token:n,projectid:r,amount:i},success:function(e){e&&e.success?(o.data("val",i),o.html(e.formatted_amount),o.css({color:"#2ecc71"})):o.html(a).css({color:"#e74c3c"}),setTimeout(()=>o.css({color:"#3b82f6"}),1500)},error:function(e){alert("Erreur XHR Percent: "+e.status+"\n"+(e.responseText?e.responseText.substring(0,300):"Aucune reponse")),o.html(a).css({color:"#e74c3c"}),setTimeout(()=>o.css({color:"#3b82f6"}),1500)}})}});t.on("blur",n),t.on("keypress",function(e){e.stopPropagation(),13===e.which&&(e.preventDefault(),t.off("blur"),n())}),t.on("keydown",function(e){9===e.which&&(e.preventDefault(),t.off("blur"),n())}),t.on("click",function(e){e.stopPropagation()})}},$(document).ready(function(){void 0!==window.saturne&&window.saturne.contact_inline&&(window.saturne.contact_inline.mountCardUi(),$(document).on("click",".reedcrm-copy-text",window.saturne.contact_inline.copyToClipboard))}),window.reedcrm||(window.reedcrm={}),window.reedcrm.eventpro={},window.reedcrm.eventpro.modalId="eventproCardModal",window.reedcrm.eventpro.refreshTriggered=!1,window.reedcrm.eventpro.init=function(){window.reedcrm.eventpro.event(),window.reedcrm.eventpro.modalCloseWatcher(),window.reedcrm.eventpro.initAddContact(),window.reedcrm.eventpro.initRelaunchTooltips()},window.reedcrm.eventpro.loadModalContent=function(e){var t=$("#"+window.reedcrm.eventpro.modalId+"-content"),n=$("#"+window.reedcrm.eventpro.modalId+"-loader"),i=(n.show().addClass("wpeo-loader"),void 0!==window.saturne&&window.saturne.loader&&window.saturne.loader.display(n),t.hide().empty(),-1!==e.indexOf("?")?"&":"?");$.ajax({url:e+i+"modal=1",type:"GET",success:function(e){t.html(e),t.show(),void 0!==window.saturne&&window.saturne.loader?window.saturne.loader.remove(n):n.hide(),window.reedcrm.eventpro.bindModalContentEvents()},error:function(){void 0!==window.saturne&&window.saturne.loader?window.saturne.loader.remove(n):n.hide(),t.html('<div class="error" style="padding: 20px;">Erreur lors du chargement</div>'),t.show()}})},window.reedcrm.eventpro.bindModalContentEvents=function(){var e=$("#"+window.reedcrm.eventpro.modalId+"-content");e.find("form").off("submit.reedcrm").on("submit.reedcrm",function(e){e.preventDefault();var e=$(this),t=e.attr("action"),n=-1!==t.indexOf("?")?"&":"?";$.ajax({url:t+n+"modal=1",type:"POST",data:e.serialize(),dataType:"json",success:function(e){var t;e&&e.success?(t=$("#"+window.reedcrm.eventpro.modalId).attr("data-project-id"),$("#"+window.reedcrm.eventpro.modalId).removeClass("modal-active"),$("#"+window.reedcrm.eventpro.modalId+"-content").empty(),window.reedcrm.eventpro.refreshProjectRow(t),e.message&&void 0!==window.saturne&&window.saturne.notification&&window.saturne.notification.success(e.message)):(t=e&&e.error?e.error:"Erreur",void 0!==window.saturne&&window.saturne.notification?window.saturne.notification.error(t):alert(t))},error:function(){void 0!==window.saturne&&window.saturne.notification?window.saturne.notification.error("Erreur lors de la soumission"):alert("Erreur lors de la soumission")}})}),e.find('a[href*="tab="]').on("click",function(e){e.preventDefault();e=$(this).attr("href");window.reedcrm.eventpro.loadModalContent(e)})},window.reedcrm.eventpro.refreshProjectRow=function(n){var e,i;n&&(e=window.location.href.split("&action=")[0].split("#")[0],(i=$('tr[data-rowid="'+n+'"]')).length)?(i.css("opacity","0.5"),$.ajax({url:e,type:"GET",success:function(e){var t=$(e).find('tr[data-rowid="'+n+'"]');t.length&&i.length?i.fadeOut(200,function(){i.html(t.html()),i.css("opacity","1"),i.fadeIn(200)}):i.css("opacity","1")},error:function(){i.css("opacity","1")}})):window.location.reload()},window.reedcrm.eventpro.modalCloseWatcher=function(){var t=!1;setInterval(function(){var e=$("#"+window.reedcrm.eventpro.modalId).hasClass("modal-active");t&&!e&&(window.reedcrm.eventpro.refreshTriggered=!1),t=e},200)},window.reedcrm.eventpro.event=function(){var t="#"+window.reedcrm.eventpro.modalId,n=($(document).on("click",t+" .modal-close, "+t+" .modal-close i",function(e){e.preventDefault();e=$(t);e.removeClass("modal-active"),e.find("#"+window.reedcrm.eventpro.modalId+"-content").empty()}),!1);$(document).on("mousedown",t,function(e){n=$(e.target).is(t)}),$(document).on("click",t,function(e){$(e.target).is(t)&&n&&($(this).removeClass("modal-active"),$(this).find("#"+window.reedcrm.eventpro.modalId+"-content").empty())}),$(document).on("click",".reedcrm-modal-open, .reedcrm-card-modal-open",function(e){var t,n=$(this),i=n.attr("data-modal-url"),n=n.attr("data-project-id");i&&((t=$("#"+window.reedcrm.eventpro.modalId)).addClass("modal-active"),t.attr("data-project-id",n),window.reedcrm.eventpro.loadModalContent(i))})},window.reedcrm.eventpro.initAddContact=function(){$(document).on("click",".reedcrm-add-contact-btn",function(e){e.preventDefault(),$(this).closest(".reedcrm-contact-field-wrapper").parent().find(".reedcrm-add-contact-form").slideDown()}),$(document).on("click",".reedcrm-add-contact-cancel",function(e){e.preventDefault();e=$(this).closest(".reedcrm-add-contact-form");e.slideUp(),e.find("input").val("")}),$(document).on("click",".reedcrm-add-contact-submit",function(e){e.preventDefault(),window.reedcrm.eventpro.submitAddContact($(this))})},window.reedcrm.eventpro.submitAddContact=function(e){var n=e.closest(".reedcrm-add-contact-form"),t=n.closest("form"),i=t.find('select[name="contactid"]'),o=t.find('select[name="socid"]').val(),r=n.find("#new_contact_lastname").val().trim();r?o?(o={action:"create_contact",token:t.find('input[name="token"]').val(),from_id:t.find('input[name="from_id"]').val(),from_type:t.find('input[name="from_type"]').val(),socid:o,new_contact_lastname:r,new_contact_firstname:n.find("#new_contact_firstname").val().trim(),new_contact_phone_pro:n.find("#new_contact_phone_pro").val().trim(),new_contact_email:n.find("#new_contact_email").val().trim()},e.prop("disabled",!0),r=((r=t.attr("action"))||window.location.href).split("?")[0],$.ajax({url:r,type:"POST",data:o,dataType:"json",success:function(e){var t;e&&e.success?(t=new Option(e.contact_label,e.contact_id,!0,!0),i.append(t).trigger("change"),n.slideUp(),n.find("input").val(""),void 0!==window.saturne&&window.saturne.notification&&window.saturne.notification.success("Contact créé avec succès")):(t=e&&e.error?e.error:"Erreur lors de la création du contact",void 0!==window.saturne&&window.saturne.notification&&window.saturne.notification.error(t))},error:function(e,t,n){console.error("AJAX Error:",e,t,n);var i,t="Erreur lors de la création du contact";try{e.responseText&&(i=JSON.parse(e.responseText)).error&&(t=i.error)}catch(e){console.error("Error parsing response:",e)}void 0!==window.saturne&&window.saturne.notification&&window.saturne.notification.error(t)},complete:function(){e.prop("disabled",!1)}})):void 0!==window.saturne&&window.saturne.notification&&window.saturne.notification.error("Veuillez sélectionner un tiers"):void 0!==window.saturne&&window.saturne.notification&&window.saturne.notification.error("Le nom est obligatoire")},window.reedcrm.eventpro.initRelaunchTooltips=function(){var s,u=null,p=!1,m=!1;$(document).on("mouseenter",".reedcrm-relaunch-button",function(){var t,e,n,i,o,r=$(this),a=r.data("relaunch-type"),c=r.closest(".reedcrm-relaunch-buttons"),d=c.find(".reedcrm-modal-open").first().data("project-id"),l=c.data("socid")||"";(d||l)&&a&&(clearTimeout(s),u&&(u.remove(),u=null),m=!(p=!1),t={call:"AC_TEL",email:"AC_EMAIL",rdv:"AC_RDV",other:"AC_OTH",all:"all"}[a]||"AC_OTH",o='<div class="reedcrm-relaunch-tooltip">',o=(o='<div class="reedcrm-relaunch-tooltip"><div class="reedcrm-relaunch-tooltip-header"><strong>'+({call:"Appels",email:"Emails",rdv:"RDV",other:"Autres",all:"Relances commerciales"}[a]||a)+'</strong></div><div class="reedcrm-relaunch-tooltip-content">')+'<div class="reedcrm-relaunch-tooltip-loading">'+(void 0!==window.saturne&&window.saturne.loader?"":"Chargement...")+"</div></div></div>",(u=$(o)).css({position:"absolute",zIndex:1e4,display:"none"}),$("body").append(u),a=r.offset(),o=r.outerHeight(),u.css({visibility:"hidden",display:"block"}),e=u.outerWidth(),n=u.outerHeight(),u.css({visibility:"visible",display:"none"}),i=a.left,o=a.top+o+5,(i=i+e>$(window).width()?$(window).width()-e-10:i)<10&&(i=10),o+n>$(window).height()&&(o=a.top-n-5),u.css({left:i+"px",top:(o=o<10?10:o)+"px"}),s=setTimeout(function(){u.fadeIn(200);var e=c.find(".reedcrm-modal-open").first().data("ajax-url")||"/custom/reedcrm/ajax/get_relaunches_list.php";$.ajax({url:e,type:"GET",data:{project_id:d||"",socid:l,action_type:t,limit:r.data("limit")||0,token:$("meta[name=anti-csrf-currenttoken]").attr("content")||""},dataType:"json",success:function(e){m=!1,e&&e.success&&e.html?u.find(".reedcrm-relaunch-tooltip-content").html(e.html):(e=e&&e.error?e.error:"Erreur lors du chargement",u.find(".reedcrm-relaunch-tooltip-content").html('<div class="reedcrm-relaunch-tooltip-empty">'+e+"</div>"))},error:function(e,t,n){m=!1;var i="Erreur lors du chargement";e.responseJSON&&e.responseJSON.error?i=e.responseJSON.error:0===e.status?i="Erreur de connexion":404===e.status?i="Fichier non trouvé":500===e.status&&(i="Erreur serveur"),u.find(".reedcrm-relaunch-tooltip-content").html('<div class="reedcrm-relaunch-tooltip-empty">'+i+"</div>"),console.error("AJAX Error:",t,n,e)}})},300),u.on("mouseenter",function(){p=!0,clearTimeout(s)}),u.on("mouseleave",function(){p=!1,m||u.fadeOut(150,function(){$(this).remove(),u=null})}))}),$(document).on("mouseleave",".reedcrm-relaunch-button",function(){clearTimeout(s),s=setTimeout(function(){!u||p||m||u.fadeOut(150,function(){$(this).remove(),u=null})},150)})},window.reedcrm||(window.reedcrm={}),window.reedcrm.kpiCustomize={},window.reedcrm.kpiCustomize.dragSrc=null,window.reedcrm.kpiCustomize.init=function(){window.reedcrm.kpiCustomize.event()},window.reedcrm.kpiCustomize.event=function(){$(document).on("click",".reedcrm-kpi-customize-toggle",window.reedcrm.kpiCustomize.toggle),$(document).on("click",".reedcrm-kpi-customize-reset",window.reedcrm.kpiCustomize.reset),$(document).on("click",".reedcrm-status-display-toggle",window.reedcrm.kpiCustomize.toggleStatusDisplay),$(document).on("click",".reedcrm-list-density-toggle",window.reedcrm.kpiCustomize.toggleListDensity),$(document).on("click",".kpi-hide-btn",window.reedcrm.kpiCustomize.toggleHide),$(document).on("dragstart",".saturne-kpi-card",window.reedcrm.kpiCustomize.onDragStart),$(document).on("dragover",".saturne-kpi-card",window.reedcrm.kpiCustomize.onDragOver),$(document).on("dragend",".saturne-kpi-card",window.reedcrm.kpiCustomize.onDragEnd)},window.reedcrm.kpiCustomize.url=function(){return(window.saturne&&window.saturne.config&&window.saturne.config.urlRoot?window.saturne.config.urlRoot:"")+"/custom/reedcrm/ajax/save_kpi_layout.php"},window.reedcrm.kpiCustomize.toggle=function(e){e.preventDefault();var t,e=$(".saturne-kpi-cards");e.length&&(t=!e.hasClass("saturne-kpi-customizing"),e.toggleClass("saturne-kpi-customizing",t),$(".reedcrm-kpi-customize-toggle").toggleClass("active",t),$(".reedcrm-kpi-customize-bar").toggleClass("customizing",t),t?e.find(".saturne-kpi-card").attr("draggable","true").each(function(){$(this).find(".kpi-hide-btn").length||$(this).append('<span class="kpi-hide-btn" title="Masquer / afficher"><i class="fas fa-eye-slash"></i></span>')}):(e.find(".saturne-kpi-card").removeAttr("draggable"),window.reedcrm.kpiCustomize.save()))},window.reedcrm.kpiCustomize.toggleHide=function(e){e.preventDefault(),e.stopPropagation(),$(this).closest(".saturne-kpi-card").toggleClass("saturne-kpi-card--hidden"),window.reedcrm.kpiCustomize.save()},window.reedcrm.kpiCustomize.onDragStart=function(e){if($(this).closest(".saturne-kpi-cards").hasClass("saturne-kpi-customizing")&&(window.reedcrm.kpiCustomize.dragSrc=this,$(this).addClass("kpi-dragging"),e.originalEvent.dataTransfer)){e.originalEvent.dataTransfer.effectAllowed="move";try{e.originalEvent.dataTransfer.setData("text/plain","")}catch(e){}}},window.reedcrm.kpiCustomize.onDragOver=function(e){var t,n=window.reedcrm.kpiCustomize.dragSrc;n&&n!==this&&(e.preventDefault(),t=this.getBoundingClientRect(),e.originalEvent.clientX-t.left>t.width/2?this.parentNode.insertBefore(n,this.nextSibling):this.parentNode.insertBefore(n,this))},window.reedcrm.kpiCustomize.onDragEnd=function(){$(this).removeClass("kpi-dragging"),window.reedcrm.kpiCustomize.dragSrc=null,window.reedcrm.kpiCustomize.save()},window.reedcrm.kpiCustomize.save=function(){var t=[],n=[];$(".saturne-kpi-cards .saturne-kpi-card").each(function(){var e=$(this).attr("data-kpi-id");e&&(t.push(e),$(this).hasClass("saturne-kpi-card--hidden"))&&n.push(e)}),$.ajax({url:window.reedcrm.kpiCustomize.url(),method:"POST",dataType:"json",data:{action:"save",token:window.saturne.toolbox.getToken(),layout:JSON.stringify({order:t,hidden:n})}})},window.reedcrm.kpiCustomize.toggleStatusDisplay=function(e){e.preventDefault();e=$(this).data("mode");$.ajax({url:window.reedcrm.kpiCustomize.url(),method:"POST",dataType:"json",data:{action:"set_status_display",token:window.saturne.toolbox.getToken(),mode:e},success:function(){window.location.reload()},error:function(){window.location.reload()}})},window.reedcrm.kpiCustomize.toggleListDensity=function(e){e.preventDefault();e=$(this).data("mode");$.ajax({url:window.reedcrm.kpiCustomize.url(),method:"POST",dataType:"json",data:{action:"set_list_density",token:window.saturne.toolbox.getToken(),mode:e},success:function(){window.location.reload()},error:function(){window.location.reload()}})},window.reedcrm.kpiCustomize.reset=function(e){e.preventDefault(),$.ajax({url:window.reedcrm.kpiCustomize.url(),method:"POST",dataType:"json",data:{action:"reset",token:window.saturne.toolbox.getToken()},success:function(){window.location.reload()},error:function(){window.location.reload()}})},window.reedcrm||(window.reedcrm={}),window.reedcrm.projectPresets={},window.reedcrm.projectPresets.init=function(){window.reedcrm.projectPresets.event()},window.reedcrm.projectPresets.event=function(){$(document).on("click",".reedcrm-save-view",window.reedcrm.projectPresets.saveView),$(document).on("click",".saturne-list-preset-remove",window.reedcrm.projectPresets.deleteView)},window.reedcrm.projectPresets.url=function(){return(window.saturne&&window.saturne.config&&window.saturne.config.urlRoot?window.saturne.config.urlRoot:"")+"/custom/reedcrm/ajax/save_project_view.php"},window.reedcrm.projectPresets.saveView=function(e){e.preventDefault();var n,i,t,e=window.prompt("Nom de la vue ?");e&&(n=new URLSearchParams,i={},(t=$("#searchFormList")).length&&t.serializeArray().forEach(function(e){var t=e.name;if(0===t.indexOf("search_")&&""!==e.value&&"-1"!==e.value&&(!/_mode$/.test(t)||"inc"!==e.value)){if(!/\[\]$/.test(t)){if(i[t])return;i[t]=!0}n.append(t,e.value)}}),(t=new URLSearchParams(window.location.search).get("search_preset"))&&!n.has("search_preset")&&n.append("search_preset",t),$.ajax({url:window.reedcrm.projectPresets.url(),method:"POST",dataType:"json",data:{action:"save",token:window.saturne.toolbox.getToken(),label:e,query:n.toString()},success:function(e){e&&e.success?window.location.reload():window.alert(e&&e.error||"Erreur")},error:function(){window.alert("Erreur")}}))},window.reedcrm.projectPresets.deleteView=function(e){e.preventDefault(),e.stopPropagation();e=$(this).data("remove-key");e&&window.confirm("Supprimer cette vue ?")&&$.ajax({url:window.reedcrm.projectPresets.url(),method:"POST",dataType:"json",data:{action:"delete",token:window.saturne.toolbox.getToken(),key:e},success:function(e){e&&e.success?window.location.reload():window.alert(e&&e.error||"Erreur")},error:function(){window.alert("Erreur")}})},window.reedcrm.quickcreation={},window.reedcrm.quickcreation.latitude=null,window.reedcrm.quickcreation.longitude=null,window.reedcrm.quickcreation.init=function(){window.reedcrm.quickcreation.setAddressBlockState("searching","Détection de la position en cours..."),window.reedcrm.quickcreation.event()},window.reedcrm.quickcreation.event=function(){window.reedcrm.quickcreation.getCurrentPosition(),$(document).on("submit",".quickcreation-form",window.reedcrm.quickcreation.vibratePhone),$(document).on("input","#opp_percent",window.reedcrm.quickcreation.showOppPercentValue)},window.reedcrm.quickcreation.getCurrentPosition=function(){var t,n;navigator.geolocation?(t=!1,n=setTimeout(function(){t||(t=!0,$("#id-container #geolocation-error").val("Timeout"),window.reedcrm.quickcreation.setAddressBlockState("error","Délai dépassé. Autorisez la localisation dans votre navigateur."))},12e3),navigator.geolocation.getCurrentPosition(function(e){t=!0,clearTimeout(n),$("#id-container #geolocation-error").val(""),window.reedcrm.quickcreation.latitude=e.coords.latitude,window.reedcrm.quickcreation.longitude=e.coords.longitude,$("#id-container #latitude").val(window.reedcrm.quickcreation.latitude),$("#id-container #longitude").val(window.reedcrm.quickcreation.longitude),window.reedcrm.quickcreation.resolveCurrentAddress(window.reedcrm.quickcreation.latitude,window.reedcrm.quickcreation.longitude)},function(e){t||(t=!0,clearTimeout(n),$("#id-container #geolocation-error").val(e.message||""),window.reedcrm.quickcreation.setAddressBlockState("error",{1:"Accès à la position refusé.",2:"Position indisponible.",3:"Délai de géolocalisation dépassé."}[e.code]||"Erreur de géolocalisation."))},{timeout:1e4,maximumAge:3e5})):($("#id-container #geolocation-error").val("Geolocation is not supported by this browser."),window.reedcrm.quickcreation.setAddressBlockState("error","Géolocalisation non supportée."))},window.reedcrm.quickcreation.resolveCurrentAddress=function(e,t){$("#current-address-coords").text(e.toFixed(6)+" / "+t.toFixed(6)),$("#current-address-block").attr("href","https://www.google.com/maps/search/?api=1&query="+e+","+t).attr("target","_blank"),$.getJSON("https://nominatim.openstreetmap.org/reverse?lat="+e+"&lon="+t+"&format=json&addressdetails=1",function(e){var t,n,i,o;e&&e.address?(o=(n=e.address).road||n.pedestrian||n.footway||"",i=n.house_number||"",t=n.postcode||"",n=n.city||n.town||n.village||"",o=0<(i=$.grep([i?i+" "+o:o,t,n],function(e){return""!==e})).length?i.join(", "):e.display_name,window.reedcrm.quickcreation.setAddressBlockState("success",o)):window.reedcrm.quickcreation.setAddressBlockState("error","Adresse introuvable.")}).fail(function(){window.reedcrm.quickcreation.setAddressBlockState("error","Impossible de récupérer l'adresse.")})},window.reedcrm.quickcreation.setAddressBlockState=function(e,t){var n=$("#current-address-icon"),i=$("#current-address-text"),o=$("#current-address-ko"),r=(n.removeClass("fa-circle-notch fa-spin fa-map-marker-alt fa-exclamation-triangle"),o.hide(),$("#current-address-block"));"success"===e?(n.addClass("fa-map-marker-alt").css("color","#2ecc71"),i.css("color","#34495e"),r.addClass("is-visible")):"error"===e?(n.addClass("fa-map-marker-alt").css("color","#e74c3c"),o.show(),i.css("color","#e74c3c"),r.addClass("is-visible")):(n.addClass("fa-circle-notch fa-spin").css("color","#3498db"),i.css("color","#94a3b8"),r.removeClass("is-visible")),i.text(t)},window.reedcrm.quickcreation.vibratePhone=function(){"vibrate"in navigator&&navigator.vibrate([1e3,500,200,200,500,1e3]);var e=$(".btn-submit-purple");0===e.length&&(e=$(".page-footer button")),window.saturne.loader.display(e),setTimeout(function(){e.prop("disabled",!0)},10),setTimeout(function(){e.prop("disabled",!1),window.saturne&&window.saturne.loader&&window.saturne.loader.remove(e)},5e3)},window.reedcrm.quickcreation.showOppPercentValue=function(){var e=$("#opp_percent").val();$(".opp_percent-value").text(e+"%"),$("#opp_percent").parent().get(0).style.setProperty("--val",e)},window.reedcrm.quickevent={},window.reedcrm.quickevent.init=function(){window.reedcrm.quickevent.event()},window.reedcrm.quickevent.event=function(){$(document).on("keyup","#label",window.reedcrm.quickevent.labelKeyUp)},window.reedcrm.quickevent.labelKeyUp=function(){$("#label").val().length>=.7*parseInt($("#label").attr("maxlength"))?$(".quickevent-label-warning-notice").removeClass("hidden"):$(".quickevent-label-warning-notice").addClass("hidden")},window.reedcrm||(window.reedcrm={}),window.reedcrm.topMenu={},window.reedcrm.topMenu.keep=["mainmenutd_companylogo","mainmenutd_menu","mainmenutd_home","mainmenutd_companies","mainmenutd_commercial","mainmenutd_project","mainmenutd_agenda","mainmenutd_reedcrm","mainmenutd_"],window.reedcrm.topMenu.init=function(){window.reedcrm.topMenu.build(),window.reedcrm.topMenu.event()},window.reedcrm.topMenu.event=function(){$(document).on("click",".reedcrm-topmenu-more-toggle",function(e){e.preventDefault(),$(this).closest(".reedcrm-topmenu-more").toggleClass("open")}),$(document).on("click",function(e){$(e.target).closest(".reedcrm-topmenu-more").length||$(".reedcrm-topmenu-more").removeClass("open")})},window.reedcrm.topMenu.build=function(){var o,t,e=$('#id-top li[id^="mainmenutd_"]').first();e.length&&!$(".reedcrm-topmenu-more").length&&(e=e.parent(),o=[],e.children('li[id^="mainmenutd_"]').each(function(){var e,t,n,i;-1===window.reedcrm.topMenu.keep.indexOf(this.id)&&(t=(e=$(this).find("a").first()).attr("href"),e.length)&&t&&"#"!==t&&(i=(i=(n=$(this).find(".topmenuimage")).length?n.css("background-image"):"none")&&-1!==i.indexOf("url(")?'<span class="reedcrm-topmenu-more-img" style="background-image:'+i.replace(/"/g,"")+'"></span>':n.html()||'<span class="fas fa-puzzle-piece"></span>',o.push({href:t,label:e.attr("title")||$.trim(e.text()),icon:i}))}),o.length)&&(t='<li class="tmenu reedcrm-topmenu-more"><a href="#" class="tmenuimage tmenu reedcrm-topmenu-more-toggle" title="Plus"><div class="mainmenu topmenuimage"><span class="fas fa-ellipsis-h fa-fw pictofixedwidth"></span></div><span class="mainmenuaspan">Plus</span></a><ul class="reedcrm-topmenu-more-panel">',o.forEach(function(e){t+='<li><a href="'+e.href+'"><span class="reedcrm-topmenu-more-icon">'+e.icon+'</span><span class="reedcrm-topmenu-more-label">'+$("<div>").text(e.label).html()+"</span></a></li>"}),t+="</ul></li>",e.append(t))},window.reedcrm||(window.reedcrm={}),window.reedcrm.vocalPlayer={formatTime:function(e){e=Math.floor(e)||0;return Math.floor(e/60)+":"+((e%=60)<10?"0":"")+e},stop:function(e){var t=e.data("rc-audio"),n=e.data("rc-interval");t&&!t.paused&&t.pause(),n&&(clearInterval(n),e.removeData("rc-interval")),e.find("i").removeClass("fa-pause").addClass("fa-play"),e.removeClass("playing")},init:function(){$(document).on("click",".reedcrm-vocal-player",function(){var e=$(this),t=e.data("audio-url"),n=e.data("rc-audio"),i=e.find(".reedcrm-vocal-time");$(".reedcrm-vocal-player").not(e).each(function(){window.reedcrm.vocalPlayer.stop($(this))}),n||(n=new Audio(t),e.data("rc-audio",n),n.addEventListener("ended",function(){window.reedcrm.vocalPlayer.stop(e)})),n.paused?(n.play(),e.find("i").removeClass("fa-play").addClass("fa-pause"),e.addClass("playing"),t=setInterval(function(){var e=window.reedcrm.vocalPlayer.formatTime(n.currentTime),t=isNaN(n.duration)?"--:--":window.reedcrm.vocalPlayer.formatTime(n.duration);i.text(e+" / "+t)},500),e.data("rc-interval",t)):window.reedcrm.vocalPlayer.stop(e)})}},window.reedcrm.vocalPlayer.init();
+/* --- Source: reedcrm.js --- */
+/* Copyright (C) 2022-2025 EVARISK <technique@evarisk.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Library javascript to enable Browser notifications
+ */
+
+/**
+ * \file    js/reedcrm.js
+ * \ingroup reedcrm
+ * \brief   JavaScript file for module ReedCRM.
+ */
+
+'use strict';
+
+if (!window.reedcrm) {
+  /**
+   * Init ReedCRM JS.
+   *
+   * @memberof ReedCRM_Init
+   *
+   * @since   1.1.0
+   * @version 1.1.0
+   *
+   * @type {Object}
+   */
+  window.reedcrm = {};
+
+  /**
+   * Init scriptsLoaded ReedCRM.
+   *
+   * @memberof ReedCRM_Init
+   *
+   * @since   1.1.0
+   * @version 1.1.0
+   *
+   * @type {Boolean}
+   */
+  window.reedcrm.scriptsLoaded = false;
+}
+
+if (!window.reedcrm.scriptsLoaded) {
+  /**
+   * ReedCRM init.
+   *
+   * @memberof ReedCRM_Init
+   *
+   * @since   1.1.0
+   * @version 1.1.0
+   *
+   * @returns {void}
+   */
+  window.reedcrm.init = function() {
+    window.reedcrm.load_list_script();
+  };
+
+  /**
+   * Load all modules' init.
+   *
+   * @memberof ReedCRM_Init
+   *
+   * @since   1.1.0
+   * @version 1.1.0
+   *
+   * @returns {void}
+   */
+  window.reedcrm.load_list_script = function() {
+    if (!window.reedcrm.scriptsLoaded) {
+      let key = undefined, slug = undefined;
+      for (key in window.reedcrm) {
+        if (window.reedcrm[key].init) {
+          window.reedcrm[key].init();
+        }
+        for (slug in window.reedcrm[key]) {
+          if (window.reedcrm[key] && window.reedcrm[key][slug] && window.reedcrm[key][slug].init) {
+            window.reedcrm[key][slug].init();
+          }
+        }
+      }
+      window.reedcrm.scriptsLoaded = true;
+    }
+  };
+
+  /**
+   * Refresh and reload all modules' init.
+   *
+   * @memberof ReedCRM_Init
+   *
+   * @since   1.1.0
+   * @version 1.1.0
+   *
+   * @returns {void}
+   */
+  window.reedcrm.refresh = function() {
+    let key = undefined;
+    let slug = undefined;
+    for (key in window.reedcrm) {
+      if (window.reedcrm[key].refresh) {
+        window.reedcrm[key].refresh();
+      }
+      for (slug in window.reedcrm[key]) {
+        if (window.reedcrm[key] && window.reedcrm[key][slug] && window.reedcrm[key][slug].refresh) {
+          window.reedcrm[key][slug].refresh();
+        }
+      }
+    }
+  };
+  $(document).ready(window.reedcrm.init);
+}
+
+
+
+
+
+
+
+
+
+
+
+window.saturne.contact_inline = {};
+
+window.saturne.contact_inline.init = function() {
+    window.saturne.contact_inline.mountCardUi();
+    window.saturne.contact_inline.event();
+};
+
+window.saturne.contact_inline.event = function() {
+    // Liste: copy icons, cancel buttons inside standard contacts (if any left)
+    $(document).on('click', '.copy-action-icon', window.saturne.contact_inline.copyToClipboard);
+    
+    // Inline quick-edit click delegator logic (Handles Title, Contact spans, Percent, Amount, Company)
+    $(document).on('click', '.inline-edit-proj-title, .inline-edit-contact', window.saturne.contact_inline.startInlineEdit);
+    $(document).on('click', '.inline-edit-proj-percent', window.saturne.contact_inline.editPercent);
+    $(document).on('click', '.inline-edit-proj-amount', window.saturne.contact_inline.editAmount);
+    $(document).on('click', '.inline-edit-company-badge', window.saturne.contact_inline.startCompanyEdit);
+    $(document).on('click', '.inline-edit-origin-badge', window.saturne.contact_inline.startOriginEdit);
+};
+
+window.saturne.contact_inline.copyToClipboard = function(e) {
+    e.preventDefault();
+    e.stopPropagation();
+    let textToCopy = $(this).data('copy');
+    let icon = $(this);
+    let originalClass = icon.attr('class');
+    let originalColor = icon.css('color');
+    
+    if (navigator.clipboard) {
+        navigator.clipboard.writeText(textToCopy).then(() => {
+            icon.attr('class', 'fas fa-check').css('color', '#38a169');
+            setTimeout(() => { icon.attr('class', originalClass).css('color', originalColor); }, 1500);
+        }).catch(err => console.error('Erreur Copie:', err));
+    }
+};
+
+window.saturne.contact_inline.mountCardUi = function() {
+    let contextData = $('#reedcrm-inline-data');
+    if (contextData.length === 0) return;
+    if ($('.reedcrm-card-header-blocks').length > 0) return; // UI already mounted, prevent duplicates
+    
+    let projId = contextData.data('project-id');
+    let rawAmount = parseFloat(contextData.data('amount') || 0);
+    let percentStr = contextData.data('percent-str');
+    let amountStr = contextData.data('amount-str');
+    let logoPath = contextData.data('logo-path');
+    let percentVal = contextData.data('percent-val');
+    
+    // 1. Title Modification
+    let refidno = $('div.refidno');
+    if (refidno.length > 0) {
+        let editval = refidno.find('.editval');
+        if (editval.length === 0) {
+            let firstNode = refidno.contents().filter(function() {
+                return this.nodeType === 3 && $.trim(this.nodeValue) !== ''; 
+            }).first();
+            
+            if (firstNode.length > 0) {
+                let originalTitle = $.trim(firstNode.text());
+                
+                let wrapperHtml = '<div class="reedcrm-header-title-wrapper" style="display: inline-flex; align-items: center; background: #f8fbff; border: 1px solid #e2e8f0; border-radius: 6px; padding: 4px 8px 4px 6px; vertical-align: middle; font-weight: 600; font-size: 0.95em; margin-bottom: 2px;">' +
+                    '<img src="' + logoPath + '" style="height: 18px; width: 18px; object-fit: contain; margin-right: 8px; border-right: 1px solid #cbd5e0; padding-right: 8px;" alt="ReedCRM" title="Géré par ReedCRM" />' +
+                    '</div>';
+                
+                let wrapper = $(wrapperHtml);
+                firstNode.replaceWith(wrapper);
+                
+                let prefixSpan = $('<span class="dynamic-libelle-prefix" style="color: #4a5568; cursor: pointer; font-weight: bold; margin-right: 6px; padding-bottom: 1px;" title="Modifier le titre">Libellé :</span>');
+                let editableSpan = $('<span class="inline-edit-proj-title" data-project-id="' + projId + '" data-val="" style="color: #0f172a; cursor: pointer; border-bottom: 1px dashed #cbd5e0; line-height: 1; padding-bottom: 1px; transition: color 0.3s; display: inline-flex; min-width: 100px;" title="Modifier le titre"></span>');
+                editableSpan.text(originalTitle).attr('data-val', originalTitle);
+                
+                wrapper.append(prefixSpan).append(editableSpan);
+                prefixSpan.on('click', function(e) { e.stopPropagation(); editableSpan.click(); });
+            }
+        } else {
+             let wrapperHtml = '<div class="reedcrm-header-title-wrapper" style="display: inline-flex; align-items: center; background: #f8fbff; border: 1px solid #e2e8f0; border-radius: 6px; padding: 4px 8px 4px 6px; vertical-align: middle; font-weight: 600; font-size: 0.95em; margin-bottom: 2px; margin-right: 6px;">' +
+                 '<img src="' + logoPath + '" style="height: 18px; width: 18px; object-fit: contain; margin-right: 8px; border-right: 1px solid #cbd5e0; padding-right: 8px;" alt="ReedCRM" title="Géré par ReedCRM" />' +
+                 '<span style="color: #4a5568; font-weight: bold; margin-right: 4px;">Libellé :</span>' +
+                 '</div>';
+             $(wrapperHtml).insertBefore(editval);
+        }
+    }
+    
+    // 2. Probability and Amount
+    let statusRef = $('.statusref');
+    let titleBlock = $('.arearef > div').first();
+    if ($('.reedcrm-header-stats').length === 0) {
+        let statsHtml = '<div class="reedcrm-header-stats" style="' + (statusRef.length > 0 ? '' : 'float: right; ') + 'display: inline-flex; align-items: center; background: #f8fbff; border: 1px solid #e2e8f0; border-radius: 6px; padding: 4px 8px 4px 6px; margin-right: 15px; vertical-align: middle; font-weight: 600; font-size: 0.95em;">' +
+            '<img src="' + logoPath + '" style="height: 18px; width: 18px; object-fit: contain; margin-right: 8px; border-right: 1px solid #cbd5e0; padding-right: 8px;" alt="ReedCRM" title="Géré par ReedCRM" />' +
+            '<span class="inline-edit-proj-percent" data-project-id="'+projId+'" data-val="'+percentVal+'" style="color: #0f172a; cursor: pointer; border-bottom: 1px dashed #cbd5e0; padding-bottom: 1px; transition: color 0.3s; display: inline-flex; align-items: center; white-space: nowrap; line-height: 1;" title="Modifier la probabilité">' + percentStr + '</span>' +
+            '<span style="color: #cbd5e0; margin: 0 6px;">-</span>' +
+            '<span class="inline-edit-proj-amount" data-project-id="'+projId+'" data-val="'+rawAmount+'" style="color: #3b82f6; cursor: pointer; border-bottom: 1px dashed #cbd5e0; padding-bottom: 1px; transition: color 0.3s; display: inline-flex; align-items: center; white-space: nowrap; line-height: 1;" title="Modifier le montant">' + amountStr + '</span>' +
+            '</div>';
+            
+        if (statusRef.length > 0) {
+            let badge = statusRef.find('.badge, .status, .label');
+            if (badge.length > 0) {
+                $(statsHtml).insertBefore(badge.first());
+            } else {
+                statusRef.prepend(statsHtml);
+            }
+        } else if (titleBlock.length > 0) {
+            titleBlock.prepend(statsHtml);
+        }
+    }
+
+    // 3. Align Title and Contact blocks perfectly on the left, side-by-side if space permits
+    let titleWrapper = $('.reedcrm-header-title-wrapper');
+    let contactWrapper = $('.contact-inline-wrapper.reedcrm-header-contact-master');
+    if (titleWrapper.length > 0 && contactWrapper.length > 0) {
+        let alignWrapper = $('<div class="reedcrm-card-header-blocks" style="display: flex; flex-direction: column; gap: 8px; margin-top: 6px; margin-left: 0; padding-left: 0; align-items: flex-start; clear: both;"></div>');
+        titleWrapper.wrap(alignWrapper);
+        contactWrapper.appendTo(titleWrapper.parent());
+        
+        // Remove trailing or separating <br> tags within refidno to avoid random gaps
+        refidno.children('br').remove();
+        
+        // In case previously added margins persist, wipe them
+        titleWrapper.css({'margin-left': '0', 'margin-right': '0', 'margin-bottom': '0'});
+        contactWrapper.css({'margin-left': '0', 'margin-right': '0', 'margin-bottom': '0'});
+    }
+    
+    // 4. Third-Party Badge Styling & Interception
+    // Find the standard third-party link (usually an <a> tag that contains "socid=" inside refidno, avoiding tiny C/P/S badges)
+    let companyBadge = refidno.find('a[href*="socid="]').not('.customer-back').not('.vendor-back').first();
+    if (companyBadge.length > 0) {
+        let compHref = companyBadge.attr('href');
+        
+        // Remove native building icons from the text link
+        let buildingIcon = companyBadge.find('.fa-building, .fa-building-o, .fa-industry');
+        if (buildingIcon.length > 0) {
+            buildingIcon.remove();
+            // Also trim leading spaces left after icon removal
+            companyBadge.html(companyBadge.html().replace(/&nbsp;/g, '').trim());
+        }
+        
+        // Wrap it with our standard UI badge styling if not already done
+        if (!companyBadge.parent().hasClass('reedcrm-header-company-wrapper')) {
+            let compWrapperHtml = '<div class="reedcrm-header-company-wrapper" style="display: inline-flex; align-items: center; background: #f8fbff; border: 1px solid #e2e8f0; border-radius: 6px; padding: 4px 8px 4px 6px; vertical-align: middle; font-weight: 500; font-size: 0.9em; margin-bottom: 2px; color: #4a5568;"></div>';
+            companyBadge.wrap(compWrapperHtml);
+            companyBadge.before('<img src="' + logoPath + '" style="height: 18px; width: 18px; object-fit: contain; margin-right: 8px; border-right: 1px solid #cbd5e0; padding-right: 8px;" alt="ReedCRM" />');
+            
+            // Inject the dedicated _blank hyperlink using the building icon
+            companyBadge.before('<a href="' + compHref + '" target="_blank" style="color: #64748b; margin-right: 6px; display: inline-flex; align-items: center;" title="Ouvrir la fiche tiers"><i class="fas fa-building"></i></a>');
+        }
+        
+        // Ensure the text looks like editable fields
+        companyBadge.addClass('inline-edit-company-badge').css({
+            'cursor': 'pointer',
+            'transition': 'color 0.3s',
+            'color': '#0f172a'
+        }).attr('title', 'Modifier l\'entreprise rattachée');
+        
+        // Force the wrapper into the align flexbox if it exists
+        let companyWrapper = companyBadge.closest('.reedcrm-header-company-wrapper');
+        let alignWrapper = $('.reedcrm-card-header-blocks');
+        if (alignWrapper.length > 0 && companyWrapper.length > 0) {
+            companyWrapper.insertAfter($('.reedcrm-header-title-wrapper'));
+            companyWrapper.css({'margin-left': '0', 'margin-right': '0', 'margin-bottom': '0'});
+        }
+    } else {
+        // No company linked yet! Provide a UI to assign one.
+        let titleWrapper = $('.reedcrm-header-title-wrapper');
+        let alignWrapper = $('.reedcrm-card-header-blocks');
+        
+        if (titleWrapper.length > 0) {
+             let placeholderHtml = '<div class="reedcrm-header-company-wrapper" style="display: inline-flex; align-items: center; background: #f8fbff; border: 1px solid #e2e8f0; border-radius: 6px; padding: 4px 8px 4px 6px; vertical-align: middle; font-weight: 500; font-size: 0.9em; margin-bottom: 2px; color: #4a5568;">' +
+                 '<img src="' + logoPath + '" style="height: 18px; width: 18px; object-fit: contain; margin-right: 8px; border-right: 1px solid #cbd5e0; padding-right: 8px;" alt="ReedCRM" />' +
+                 '<a href="#" class="inline-edit-company-badge" style="cursor: pointer; transition: color 0.3s; color: #0f172a; border-bottom: 1px dashed #cbd5e0; line-height: 1; padding-bottom: 1px;" title="Affecter une entreprise"><i class="fas fa-building" style="margin-right:5px; color:#64748b;"></i>Affecter un tiers</a>' +
+                 '</div>';
+             
+             let newWrapper = $(placeholderHtml);
+             if (alignWrapper.length > 0) {
+                 newWrapper.insertAfter(titleWrapper);
+                 newWrapper.css({'margin-left': '0', 'margin-right': '0', 'margin-bottom': '0'});
+             } else {
+                 newWrapper.insertAfter(titleWrapper);
+             }
+        }
+    }
+}
+
+window.saturne.contact_inline.startCompanyEdit = function(e) {
+    if ($(e.target).hasClass('select2-selection__choice__remove') || $(e.target).closest('.select2-container').length > 0) return;
+    
+    e.preventDefault();
+    e.stopPropagation();
+    
+    let aTag = $(this);
+    let originalHtml = aTag.html();
+    
+    // Retrieve the hidden selector we injected in php
+    let hiddenSelectorWrap = $('#reedcrm-hidden-company-selector');
+    if (hiddenSelectorWrap.length === 0) return;
+    
+    // Check if we already injected it in place, avoiding duplicates
+    if (aTag.parent().find('#reedcrm-hidden-company-selector').length > 0) {
+        // Just show it
+        aTag.hide();
+        hiddenSelectorWrap.show();
+        let s2 = hiddenSelectorWrap.find('select');
+        if (s2.data('select2')) { s2.select2('open'); }
+        return;
+    }
+    
+    aTag.hide();
+    hiddenSelectorWrap.insertAfter(aTag).show();
+    
+    let select2Elem = $('#reedcrm_inline_socid');
+    if (select2Elem.data('select2')) {
+        select2Elem.select2('open');
+    }
+    
+    // Disable native change events from other listeners if any, then add ours
+    select2Elem.off('change.inlineedit').on('change.inlineedit', function() {
+        let newSocid = $(this).val();
+        let projId = $('#reedcrm-inline-data').data('project-id');
+        let token = $('input[name="token"]').val() || '';
+        
+        // Basic revert if no change or empty selected
+        if (!newSocid || newSocid == 0) {
+            hiddenSelectorWrap.hide();
+            aTag.show();
+            return;
+        }
+        
+        let url = 'undefined' != typeof dolibarr_main_url_root && dolibarr_main_url_root ? dolibarr_main_url_root : '';
+        if (!url) {
+            if (document.URL.indexOf('/projet/') > 0) url = document.URL.substring(0, document.URL.indexOf('/projet/'));
+            else if (document.URL.indexOf('/custom/') > 0) url = document.URL.substring(0, document.URL.indexOf('/custom/'));
+        }
+        
+        let ajaxUrl = url + '/custom/reedcrm/view/frontend/quickcreation.php?action=updateoppsocid&token=' + token;
+        
+        aTag.html('<i class="fas fa-spinner fa-spin" style="color: #9b59b6;"></i> Enregistrement...');
+        hiddenSelectorWrap.hide();
+        aTag.show();
+        
+        $.ajax({
+            url: ajaxUrl,
+            type: 'POST',
+            data: { projectid: projId, socid: newSocid },
+            dataType: 'json',
+            success: function(res) {
+                if (res.success) {
+                    if (res.new_company_url) {
+                        // The res.new_company_url is already the full HTML string for the third party (Dolibarr's native format)
+                        // It natively comes out as `<a href="..."> <span class="..."></span> Title </a>`
+                        // So we extract its inner HTML and href
+                        let tempDiv = $('<div>').html(res.new_company_url);
+                        let nativeA = tempDiv.find('a').first();
+                        
+                        if (nativeA.length > 0) {
+                            aTag.attr('href', nativeA.attr('href'));
+                            aTag.html(nativeA.html());
+                        } else {
+                            aTag.html(res.new_company_url);
+                        }
+                    } else {
+                        aTag.html(originalHtml);
+                    }
+                } else {
+                    alert("Erreur: " + (res.error || "Inconnue"));
+                    aTag.html(originalHtml);
+                }
+            },
+            error: function() {
+                alert("Impossible de joindre le serveur");
+                aTag.html(originalHtml);
+            }
+        });
+    });
+    
+    // Try to catch when Select2 is closed without change to revert UI
+    select2Elem.on('select2:close', function () {
+        setTimeout(function() {
+            if (hiddenSelectorWrap.is(':visible')) {
+                // Not selecting anything ? just revert
+                hiddenSelectorWrap.hide();
+                aTag.show();
+            }
+        }, 100);
+    });
+};
+
+window.saturne.contact_inline.startOriginEdit = function(e) {
+    if ($(e.target).hasClass('select2-selection__choice__remove') || $(e.target).closest('.select2-container').length > 0) return;
+    
+    e.preventDefault();
+    e.stopPropagation();
+    
+    let aTag = $(this);
+    let originalHtml = aTag.html();
+    
+    let hiddenSelectorWrap = aTag.parent().find('.reedcrm-hidden-origin-selector-wrap');
+    if (hiddenSelectorWrap.length === 0) return;
+    
+    aTag.hide();
+    hiddenSelectorWrap.show();
+    
+    let selectElem = hiddenSelectorWrap.find('select');
+    if (selectElem.length === 0) return;
+    
+    try {
+        // Ensure Select2 is instantiated
+        if (!selectElem.data('select2') && !selectElem.hasClass('select2-hidden-accessible')) {
+            selectElem.select2({ width: '180px' });
+        } else {
+            // Explicitly fix Select2 width if it was 0 px due to being initialized while display:none
+            let sc = selectElem.next('.select2-container');
+            if (sc.length > 0) {
+                sc.css('width', '180px');
+            }
+        }
+        
+        selectElem.select2('open');
+    } catch (err) {
+        console.error("SELECT2 ERROR: ", err);
+        return;
+    }
+    
+    selectElem.off('change.inlineedit').on('change.inlineedit', function() {
+        let newOrigin = $(this).val();
+        let newOriginText = $(this).find('option:selected').text();
+        let projId = $('#reedcrm-inline-data').data('project-id');
+        let token = $('input[name="token"]').val() || '';
+        
+        let url = 'undefined' != typeof dolibarr_main_url_root && dolibarr_main_url_root ? dolibarr_main_url_root : '';
+        if (!url) {
+            if (document.URL.indexOf('/projet/') > 0) url = document.URL.substring(0, document.URL.indexOf('/projet/'));
+            else if (document.URL.indexOf('/custom/') > 0) url = document.URL.substring(0, document.URL.indexOf('/custom/'));
+        }
+        let ajaxUrl = url + '/custom/reedcrm/view/frontend/quickcreation.php?action=updateopporigin';
+        
+        aTag.html('<i class="fas fa-spinner fa-spin" style="color: #9b59b6;"></i> Enregistrement...');
+        hiddenSelectorWrap.hide();
+        aTag.show();
+        
+        $.ajax({
+            url: ajaxUrl,
+            type: 'POST',
+            data: { projectid: projId, origin: newOrigin, token: token },
+            dataType: 'json',
+            success: function(res) {
+                if (res.success) {
+                    aTag.text(newOriginText);
+                    aTag.css('color', '#2ecc71');
+                    setTimeout(() => aTag.css('color', ''), 1500);
+                } else {
+                    alert("Erreur: " + (res.error || "Inconnue"));
+                    aTag.html(originalHtml);
+                }
+            },
+            error: function() {
+                alert("Impossible de joindre le serveur");
+                aTag.html(originalHtml);
+            }
+        });
+    });
+    
+    // Revert UI on close if no change happened
+    selectElem.off('select2:close').on('select2:close', function () {
+        setTimeout(function() {
+            if (hiddenSelectorWrap.is(':visible')) {
+                hiddenSelectorWrap.hide();
+                aTag.show();
+            }
+        }, 100);
+    });
+};
+
+window.saturne.contact_inline.startInlineEdit = function(e) {
+    if ($(this).find('input').length > 0) return;
+    e.stopPropagation();
+    
+    let span = $(this);
+    let isTitle = span.hasClass('inline-edit-proj-title');
+    let currentVal = span.data('val') || '';
+    let originalHtml = span.html();
+    
+    let isPhone = span.data('field') === 'phone';
+    let isWebsite = span.data('field') === 'website';
+    let isEmail = span.data('field') === 'email';
+    let isFlexChild = span.data('field') === 'firstname' || span.data('field') === 'lastname' || isEmail;
+    let inputType = isPhone ? 'tel' : (isWebsite ? 'url' : (isEmail ? 'email' : 'text'));
+    
+    let inputWidth = isTitle ? '250px' : (isFlexChild ? '100%' : (isPhone || isWebsite ? '180px' : '140px'));
+    
+    // Pour le téléphone avec le widget intlTelInput, forcer un padding à gauche pour éviter la superposition du drapeau
+    let extraPadding = isPhone ? 'padding-left: 52px !important; ' : '';
+    let input = $('<input type="' + inputType + '" style="width: ' + inputWidth + '; border: 1px solid #3b82f6; border-radius: 4px; padding: 2px 6px; ' + extraPadding + 'font-weight: inherit; font-size: inherit; color: #0f172a; outline: none; box-sizing: border-box; background: white; margin: 0; display: inline-block; line-height: normal; box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.2);" value="">');
+    input.val(currentVal);
+    
+    if (isWebsite) {
+        if (currentVal === '' || currentVal === 'http://') {
+            input.val('https://');
+        } else if (currentVal.startsWith('http://')) {
+            input.val('https://' + currentVal.substring(7));
+        }
+    }
+    
+    span.html('').append(input);
+    
+    if (isWebsite) {
+        input.on('input', function() {
+            let val = $(this).val().trim();
+            if (val.startsWith('www.')) {
+                val = 'https://' + val;
+                $(this).val(val);
+            }
+            const materialUrlRegex = /^(https?:\/\/)?([\w\-]+(\.[\w\-]+)+)([\/?#].*)?$/i;
+            if (val !== '' && val !== 'https://' && val !== 'http://' && !materialUrlRegex.test(val)) {
+                $(this).css({ 'border-color': '#e53935', 'color': '#e53935', 'box-shadow': '0 0 0 2px rgba(229, 57, 53, 0.2)' });
+            } else {
+                $(this).css({ 'border-color': '#3b82f6', 'color': '#0f172a', 'box-shadow': '0 0 0 2px rgba(59, 130, 246, 0.2)' });
+            }
+        });
+    }
+    
+    if (isPhone && typeof window.intlTelInput !== 'undefined') {
+        let baseRoot = (typeof dolibarr_main_url_root !== 'undefined' && dolibarr_main_url_root) ? dolibarr_main_url_root : '';
+        if (!baseRoot) {
+            if (document.URL.indexOf('/projet/') > 0) baseRoot = document.URL.substring(0, document.URL.indexOf('/projet/'));
+            else if (document.URL.indexOf('/custom/') > 0) baseRoot = document.URL.substring(0, document.URL.indexOf('/custom/'));
+        }
+        input[0].iti = window.intlTelInput(input[0], {
+            utilsScript: baseRoot + '/custom/reedcrm/js/intl-tel-input/js/utils.js',
+            initialCountry: "fr",
+            preferredCountries: ["fr", "be", "ch", "lu", "ca"],
+            nationalMode: false,
+            autoPlaceholder: "polite",
+            dropdownContainer: document.body
+        });
+        $('.iti__flag-container').css('z-index', 9999);
+        
+        input[0].addEventListener("open:countrydropdown", function() {
+            input[0].itiDropdownOpen = true;
+        });
+        input[0].addEventListener("close:countrydropdown", function() {
+            input[0].itiDropdownOpen = false;
+            setTimeout(() => input.focus(), 50);
+        });
+    }
+    
+    input.focus();
+    input.select();
+    
+    let submitFunction = isTitle ? window.saturne.contact_inline.submitTitleDetail : window.saturne.contact_inline.submitContactDetail;
+    
+    input.on('blur', function() { 
+        if (input[0] && input[0].itiDropdownOpen) return;
+        submitFunction(span, input, originalHtml, currentVal, false); 
+    });
+    input.on('keydown', function(ev) { 
+        ev.stopPropagation(); 
+        if (ev.which === 13) { ev.preventDefault(); input.off('blur'); submitFunction(span, input, originalHtml, currentVal, false); }
+        else if (ev.which === 9) { ev.preventDefault(); input.off('blur'); submitFunction(span, input, originalHtml, currentVal, true); }
+    });
+    input.on('click', function(ev) { ev.stopPropagation(); });
+};
+
+window.saturne.contact_inline.submitTitleDetail = function(span, input, originalHtml, currentVal, isTabbing) {
+    let focusNextSpan = function() {
+        let firstContactSpan = $('.contact-inline-wrapper .inline-edit-contact').first();
+        if (firstContactSpan.length > 0) {
+            firstContactSpan.click();
+        }
+    };
+
+    let newVal = input.val().trim();
+    if (newVal === currentVal) {
+        span.html(originalHtml);
+        if (isTabbing) {
+            focusNextSpan();
+        }
+        return;
+    }
+    
+    span.data('val', newVal);
+    var originalWidth = span.width();
+    span.html('<i class="fas fa-spinner fa-spin" style="color: #9b59b6;"></i>').css('min-width', originalWidth + 'px');
+    let projectId = span.data('project-id');
+    let token = $('input[name="token"]').val() || '';
+    
+    let baseRoot = (typeof dolibarr_main_url_root !== 'undefined' && dolibarr_main_url_root) ? dolibarr_main_url_root : '';
+    if (!baseRoot) {
+        if (document.URL.indexOf('/projet/') > 0) baseRoot = document.URL.substring(0, document.URL.indexOf('/projet/'));
+        else if (document.URL.indexOf('/custom/') > 0) baseRoot = document.URL.substring(0, document.URL.indexOf('/custom/'));
+    }
+    let targetUrl = baseRoot + '/custom/reedcrm/view/frontend/quickcreation.php?action=updateopptitle';
+    if (document.URL.indexOf('quickcreation.php') > 0) targetUrl = document.URL.split('?')[0] + '?action=updateopptitle';
+    
+    $.ajax({
+        url: targetUrl,
+        type: 'POST',
+        data: { token: token, projectid: projectId, title: newVal },
+        success: function(res) {
+            span.css({color: '#2ecc71', 'min-width': ''});
+            span.html(newVal ? newVal : '<span style="color:#cbd5e0; font-style:italic;">Sans titre</span>');
+            setTimeout(function() { span.css({color: ''}); }, 1500);
+            if (isTabbing) {
+                focusNextSpan();
+            }
+        },
+        error: function(jqXHR) {
+            alert("Erreur XHR Titre: " + jqXHR.status + "\n" + (jqXHR.responseText ? jqXHR.responseText.substring(0, 300) : 'Aucune reponse'));
+            span.html(originalHtml).css('min-width', '');
+            span.data('val', currentVal);
+            span.css({color: '#e74c3c'});
+            setTimeout(() => span.css({color: ''}), 1500);
+        }
+    });
+};
+
+window.saturne.contact_inline.submitContactDetail = function(span, input, originalHtml, currentVal, isTabbing) {
+    let newVal = input.val().trim();
+    if (span.data('field') === 'phone' && input[0].iti && window.intlTelInputUtils) {
+        if (input[0].iti.isValidNumber()) {
+            newVal = input[0].iti.getNumber();
+        }
+    }
+    let contactWrapper = span.closest('.contact-inline-wrapper');
+    
+    let focusNextSpan = function() {
+        let allSpans = contactWrapper.find('.inline-edit-contact:visible');
+        let currentIndex = allSpans.index(span);
+        if (currentIndex >= 0 && currentIndex < allSpans.length - 1) {
+            allSpans.eq(currentIndex + 1).click();
+        }
+    };
+    
+    let field = span.data('field');
+    
+    // Email Validation
+    if (field === 'email' && newVal !== '') {
+        const materialEmailRegex = /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$/;
+        if (!materialEmailRegex.test(newVal)) {
+            alert('Format de l\'adresse e-mail invalide.');
+            input.focus();
+            return;
+        }
+    }
+    
+    // Website Validation
+    if (field === 'website') {
+        if (newVal === 'https://' || newVal === 'http://') {
+            newVal = '';
+            input.val('');
+        }
+        if (newVal !== '') {
+            if (!newVal.startsWith('http://') && !newVal.startsWith('https://')) {
+                newVal = 'https://' + newVal;
+                input.val(newVal);
+            }
+            const materialUrlRegex = /^(https?:\/\/)?([\w\-]+(\.[\w\-]+)+)([\/?#].*)?$/i;
+            if (!materialUrlRegex.test(newVal)) {
+                alert('Format du site web invalide.');
+                input.focus();
+                return;
+            }
+        }
+    }
+
+    if (newVal === currentVal) {
+        span.html(originalHtml);
+        if (isTabbing) focusNextSpan();
+        return;
+    }
+    
+    span.data('val', newVal);
+    var originalWidth = span.width();
+    span.html('<i class="fas fa-spinner fa-spin" style="color: #9b59b6;"></i>').css('min-width', originalWidth + 'px');
+    
+    let contactProjectId = contactWrapper.data('project-id');
+    
+    let bFirst = contactWrapper.find('.inline-edit-contact[data-field="firstname"]').data('val');
+    let bLast = contactWrapper.find('.inline-edit-contact[data-field="lastname"]').data('val');
+    let bPhone = contactWrapper.find('.inline-edit-contact[data-field="phone"]').data('val');
+    let bEmail = contactWrapper.find('.inline-edit-contact[data-field="email"]').data('val');
+    let bWeb = contactWrapper.find('.inline-edit-contact[data-field="website"]').data('val');
+    
+    let token = $('input[name="token"]').val() || '';
+    
+    let baseRoot = (typeof dolibarr_main_url_root !== 'undefined' && dolibarr_main_url_root) ? dolibarr_main_url_root : '';
+    if (!baseRoot) {
+        if (document.URL.indexOf('/projet/') > 0) baseRoot = document.URL.substring(0, document.URL.indexOf('/projet/'));
+        else if (document.URL.indexOf('/custom/') > 0) baseRoot = document.URL.substring(0, document.URL.indexOf('/custom/'));
+    }
+    let targetUrl = baseRoot + '/custom/reedcrm/view/frontend/quickcreation.php?action=updateoppcontact';
+    if (document.URL.indexOf('quickcreation.php') > 0) targetUrl = document.URL.split('?')[0] + '?action=updateoppcontact';
+    
+    $.ajax({
+        url: targetUrl,
+        type: 'POST',
+        data: {
+            token: token,
+            projectid: contactProjectId,
+            firstname: bFirst,
+            lastname: bLast,
+            phone: bPhone,
+            email: bEmail,
+            website: bWeb
+        },
+        success: function(res) {
+            span.css({color: '#2ecc71', 'min-width': ''});
+            var pText = '';
+            if (field === 'firstname') pText = 'Prénom';
+            if (field === 'lastname') pText = 'Nom';
+            if (field === 'phone') pText = 'Téléphone';
+            if (field === 'email') pText = 'Email';
+            if (field === 'website') pText = 'Site Web';
+            span.html(newVal ? newVal : '<span style="color:#cbd5e0; font-style:italic;">' + pText + '</span>');
+            setTimeout(function() { span.css({color: ''}); }, 1500);
+            
+            if (isTabbing) {
+                focusNextSpan();
+            }
+        },
+        error: function(jqXHR) {
+            alert("Erreur XHR Titre: " + jqXHR.status + "\n" + (jqXHR.responseText ? jqXHR.responseText.substring(0, 300) : 'Aucune reponse'));
+            span.html(originalHtml).css('min-width', '');
+            span.data('val', currentVal);
+            span.css({color: '#e74c3c'});
+            setTimeout(() => span.css({color: ''}), 1500);
+        }
+    });
+    
+    if (span.data('field') === 'phone' && input[0].iti) {
+        input[0].iti.destroy();
+    }
+};
+
+window.saturne.contact_inline.editPercent = function(e) {
+    if ($(this).find('input').length > 0) return;
+    e.stopPropagation();
+    
+    let span = $(this);
+    let projId = span.data('project-id');
+    let currentVal = parseInt(span.data('val'));
+    let originalText = span.text();
+    
+    let input = $('<input type="number" min="0" max="100" class="percent-input" style="width: 35px; text-align: center; border: 1px solid #cbd5e1; border-radius: 4px; padding: 0; font-weight: 600; font-size: 1em; color: #0f172a; outline: none; box-sizing: border-box; background: transparent; margin: 0; display: inline-block; vertical-align: middle; line-height: normal; -moz-appearance: textfield;" value="'+currentVal+'">');
+    
+    if ($('#css-no-spinners').length === 0) {
+        $('head').append('<style id="css-no-spinners">input[type="number"].percent-input::-webkit-outer-spin-button, input[type="number"].percent-input::-webkit-inner-spin-button { -webkit-appearance: none; margin: 0; }</style>');
+    }
+    
+    span.html('').append(input).append('<span style="font-weight:normal; margin-left: 2px;">%</span>');
+    input.focus();
+    
+    let submitValuePercent = function() {
+        let newVal = parseInt(input.val());
+        if (isNaN(newVal) || newVal < 0) newVal = 0;
+        if (newVal > 100) newVal = 100;
+        
+        if (newVal === currentVal) {
+            span.html(originalText);
+            return;
+        }
+        
+        span.html('<i class="fas fa-spinner fa-spin" style="color: #9b59b6; line-height: 22px;"></i>');
+        let token = $('input[name="token"]').val() || '';
+        
+        let baseRoot = (typeof dolibarr_main_url_root !== 'undefined' && dolibarr_main_url_root) ? dolibarr_main_url_root : '';
+        if (!baseRoot) {
+            if (document.URL.indexOf('/projet/') > 0) baseRoot = document.URL.substring(0, document.URL.indexOf('/projet/'));
+            else if (document.URL.indexOf('/custom/') > 0) baseRoot = document.URL.substring(0, document.URL.indexOf('/custom/'));
+        }
+        let targetUrl = baseRoot + '/custom/reedcrm/view/frontend/quickcreation.php?action=updateopppercent';
+        if (document.URL.indexOf('quickcreation.php') > 0) targetUrl = document.URL.split('?')[0] + '?action=updateopppercent';
+        
+        $.ajax({
+            url: targetUrl,
+            type: 'POST',
+            data: { token: token, projectid: projId, percent: newVal },
+            success: function(res) {
+                if(res && res.success) {
+                    span.data('val', newVal);
+                    span.html(newVal + ' %');
+                    span.css({color: '#2ecc71'});
+                    setTimeout(() => span.css({color: '#0f172a'}), 1500);
+                } else {
+                    span.html(originalText).css({color: '#e74c3c'});
+                    setTimeout(() => span.css({color: '#0f172a'}), 1500);
+                }
+            },
+            error: function(jqXHR) {
+                alert("Erreur XHR Percent: " + jqXHR.status + "\n" + (jqXHR.responseText ? jqXHR.responseText.substring(0, 300) : 'Aucune reponse'));
+                span.html(originalText).css({color: '#e74c3c'});
+                setTimeout(() => span.css({color: originalColor}), 1500);
+            }
+        });
+    };
+    
+    input.on('blur', submitValuePercent);
+    input.on('keypress', function(ev) { ev.stopPropagation(); if (ev.which === 13) { ev.preventDefault(); input.off('blur'); submitValuePercent(); } });
+    input.on('keydown', function(ev) {
+        if (ev.which === 9) { // Tab
+            ev.preventDefault();
+            input.off('blur');
+            submitValuePercent();
+            let amountSpan = span.parent().find('.inline-edit-proj-amount');
+            if (amountSpan.length > 0) {
+                setTimeout(() => amountSpan.click(), 50);
+            }
+        }
+    });
+    input.on('click', function(ev) { ev.stopPropagation(); });
+};
+
+window.saturne.contact_inline.editAmount = function(e) {
+    if ($(this).find('input').length > 0) return;
+    e.stopPropagation();
+    
+    let span = $(this);
+    let projId = span.data('project-id');
+    let currentVal = parseFloat(span.data('val'));
+    let originalText = span.text();
+    
+    let inputWidth = originalText.length > 8 ? '80px' : '65px';
+    let input = $('<input type="text" class="amount-input" style="width: '+inputWidth+'; text-align: center; border: 1px solid #cbd5e1; border-radius: 4px; padding: 0 2px; font-weight: 600; font-size: 1em; color: #3b82f6; outline: none; box-sizing: border-box; background: transparent; margin: 0; display: inline-block; vertical-align: middle; line-height: normal; -moz-appearance: textfield;" value="'+currentVal+'">');
+    
+    span.html('').append(input).append('<span style="font-weight:normal; margin-left: 4px;">€</span>');
+    input.focus();
+    
+    let submitValueAmount = function() {
+        let userStr = input.val().replace(',', '.');
+        let newVal = parseFloat(userStr);
+        if (isNaN(newVal) || newVal < 0) newVal = 0;
+        
+        if (newVal === currentVal) {
+            span.html(originalText);
+            return;
+        }
+        
+        span.html('<i class="fas fa-spinner fa-spin" style="color: #9b59b6; line-height: 22px;"></i>');
+        let token = $('input[name="token"]').val() || '';
+        
+        let baseRoot = (typeof dolibarr_main_url_root !== 'undefined' && dolibarr_main_url_root) ? dolibarr_main_url_root : '';
+        if (!baseRoot) {
+            if (document.URL.indexOf('/projet/') > 0) baseRoot = document.URL.substring(0, document.URL.indexOf('/projet/'));
+            else if (document.URL.indexOf('/custom/') > 0) baseRoot = document.URL.substring(0, document.URL.indexOf('/custom/'));
+        }
+        let targetUrl = baseRoot + '/custom/reedcrm/view/frontend/quickcreation.php?action=updateoppamount';
+        if (document.URL.indexOf('quickcreation.php') > 0) targetUrl = document.URL.split('?')[0] + '?action=updateoppamount';
+        
+        $.ajax({
+            url: targetUrl,
+            type: 'POST',
+            data: { token: token, projectid: projId, amount: newVal },
+            success: function(res) {
+                if(res && res.success) {
+                    span.data('val', newVal);
+                    span.html(res.formatted_amount);
+                    span.css({color: '#2ecc71'});
+                    setTimeout(() => span.css({color: '#3b82f6'}), 1500);
+                } else {
+                    span.html(originalText).css({color: '#e74c3c'});
+                    setTimeout(() => span.css({color: '#3b82f6'}), 1500);
+                }
+            },
+            error: function(jqXHR) {
+                alert("Erreur XHR Percent: " + jqXHR.status + "\n" + (jqXHR.responseText ? jqXHR.responseText.substring(0, 300) : 'Aucune reponse'));
+                span.html(originalText).css({color: '#e74c3c'});
+                setTimeout(() => span.css({color: '#3b82f6'}), 1500);
+            }
+        });
+    };
+    
+    input.on('blur', submitValueAmount);
+    input.on('keypress', function(ev) { ev.stopPropagation(); if (ev.which === 13) { ev.preventDefault(); input.off('blur'); submitValueAmount(); } });
+    input.on('keydown', function(ev) {
+        if (ev.which === 9) { // Tab
+            ev.preventDefault();
+            input.off('blur');
+            submitValueAmount();
+        }
+    });
+    input.on('click', function(ev) { ev.stopPropagation(); });
+};
+
+// Initialize module on ready
+$(document).ready(function() {
+    if (typeof window.saturne !== 'undefined' && window.saturne.contact_inline) {
+        window.saturne.contact_inline.mountCardUi();
+        $(document).on('click', '.reedcrm-copy-text', window.saturne.contact_inline.copyToClipboard);
+    }
+
+    // --- Data-action event delegation (replaces all inline onclick attributes) ---
+    $(document).on('click', '[data-action="open-vcard-modal"]', function() {
+        var m = document.getElementById('vcard-modal');
+        if (m) m.style.display = 'flex';
+    });
+    $(document).on('click', '[data-action="close-vcard-modal"]', function() {
+        var m = document.getElementById('vcard-modal');
+        if (m) m.style.display = 'none';
+    });
+    $(document).on('click', '[data-action="toggle-geoloc-address"]', function() {
+        $('#current-address-block').toggleClass('is-visible');
+    });
+
+    // --- CSS hover for .reedcrm-hover-bg (replaces inline onmouseover/onmouseout) ---
+    $(document).on('mouseenter', '.reedcrm-hover-bg', function() {
+        $(this).css({ 'background': '#f1f5f9', 'border-color': '#e2e8f0' });
+    }).on('mouseleave', '.reedcrm-hover-bg', function() {
+        $(this).css({ 'background': 'transparent', 'border-color': 'transparent' });
+    });
+    // Close vcard modal on overlay click
+    $(document).on('click', '#vcard-modal', function(e) {
+        if ($(e.target).is('#vcard-modal')) { this.style.display = 'none'; }
+    });
+});
+
+/**
+ * PWA Project Card - Client & Contact Selector (inline, no modal)
+ * Opens a Select2 dropdown directly under each button.
+ */
+window.saturne.pwa_selectors = {};
+
+window.saturne.pwa_selectors.init = function() {
+    window.saturne.pwa_selectors.event();
+};
+
+window.saturne.pwa_selectors.getBaseUrl = function() {
+    var url = (typeof dolibarr_main_url_root !== 'undefined' && dolibarr_main_url_root) ? dolibarr_main_url_root : '';
+    if (!url) {
+        if (document.URL.indexOf('/custom/') > 0) url = document.URL.substring(0, document.URL.indexOf('/custom/'));
+    }
+    return url + '/custom/reedcrm/view/frontend/quickcreation.php';
+};
+
+window.saturne.pwa_selectors.event = function() {
+    // Close all inline selectors when clicking outside
+    $(document).on('click', function(e) {
+        if (!$(e.target).closest('.pwa-selector-wrap').length) {
+            $('.pwa-inline-select-wrap').hide();
+        }
+    });
+
+    // Client selector : open inline AJAX Select2
+    $(document).on('click', '.pwa-client-selector', function(e) {
+        e.stopPropagation();
+        var btn       = $(this);
+        var projectId = btn.data('project-id');
+        var wrap      = $('#pwa-client-wrap-' + projectId);
+        var $select   = $('#pwa-client-select-' + projectId);
+        var baseUrl   = window.saturne.pwa_selectors.getBaseUrl();
+        var token     = $('input[name="token"]').val() || '';
+
+        // Toggle: close if already open
+        if (wrap.is(':visible')) { wrap.hide(); return; }
+
+        // Hide all other open selectors
+        $('.pwa-inline-select-wrap').hide();
+        wrap.show();
+
+        // Init Select2 once (AJAX — shows 10 recent companies on open, search on typing)
+        if (!$select.data('select2')) {
+            $select.select2({
+                placeholder: 'Clients récents ou tapez pour chercher...',
+                minimumInputLength: 0,
+                language: {
+                    searching: function() { return 'Chargement...'; },
+                    noResults: function() { return 'Aucun résultat'; }
+                },
+                ajax: {
+                    url:      baseUrl,
+                    dataType: 'json',
+                    delay:    200,
+                    cache:    true,
+                    data:     function(p) { return { action: 'search_tiers_ajax', q: p.term || '' }; },
+                    processResults: function(d) { return { results: d.results || [] }; }
+                }
+            });
+
+            // On selection → save & update DOM (no page reload)
+            $select.on('select2:select', function(ev) {
+                var newSocid    = ev.params.data.id;
+                var newSocName  = ev.params.data.text;
+                wrap.hide();
+                var $btn       = $('.pwa-client-selector[data-project-id="' + projectId + '"]');
+                var origHtml   = $btn.html();
+                $btn.html('<i class="fas fa-spinner fa-spin" style="color:#9b59b6;"></i>');
+                $.post(baseUrl + '?action=updateoppsocid&token=' + token, { projectid: projectId, socid: newSocid }, function(res) {
+                    if (res && res.success) {
+                        var badge = (res.new_company_badge && res.new_company_badge.trim()) ? res.new_company_badge + ' ' : '<i class="far fa-building" style="color:#64748b;"></i> ';
+                        $btn.html(
+                            badge +
+                            '<span style="font-weight:500;">' + $('<span>').text(newSocName).html() + '</span>' +
+                            '<i class="fas fa-chevron-down" style="color:#94a3b8;font-size:0.8em;"></i>'
+                        );
+                        $btn.removeClass('empty').attr('title', 'Changer le tiers');
+
+                        // ── Inject / update the clickable building icon link (absent when project had no client) ──
+                        var cardUrl = res.new_company_card_url || '';
+                        if (cardUrl) {
+                            var $selectorWrap = $btn.closest('.pwa-selector-wrap');
+                            var $existingIcon = $selectorWrap.find('a[title="Voir la fiche client"]');
+                            if ($existingIcon.length) {
+                                // Update existing link
+                                $existingIcon.attr('href', cardUrl);
+                            } else {
+                                // Project had no client before → inject the icon link before the button
+                                $btn.before(
+                                    '<a href="' + cardUrl + '" class="prevent-edit-click" title="Voir la fiche client" ' +
+                                    'style="display:inline-flex;align-items:center;color:#64748b;font-size:1.15em;flex-shrink:0;">' +
+                                    '<i class="fas fa-building"></i></a>'
+                                );
+                            }
+                        }
+
+                        // Reset the client Select2 field (clear search term so next open is clean)
+                        $select.val(null).trigger('change');
+
+                        // Reset contact preload flag since company changed (old contact selector)
+                        var $cSelect = $('#pwa-contact-select-' + projectId);
+                        $cSelect.removeData('contacts-loaded').empty();
+                        if ($cSelect.data('select2')) { $cSelect.select2('destroy'); }
+
+                        // ── New chip system: update data-tiers-id on the contact tags wrap ──
+                        var $tagsWrap = $('.pwa-contact-tags-wrap[data-project-id="' + projectId + '"]');
+                        $tagsWrap.data('tiers-id', newSocid);
+                        $tagsWrap.attr('data-tiers-id', newSocid);
+
+                        // Update tiers-id on old contact button (legacy, harmless)
+                        $('.pwa-contact-selector[data-project-id="' + projectId + '"]').data('tiers-id', newSocid);
+                        $('#pwa-contact-wrap-' + projectId).hide();
+                    } else {
+                        $btn.html(origHtml);
+                        $btn.css({ border: '1px solid #e74c3c' });
+                        setTimeout(function() { $btn.css({ border: '' }); }, 2000);
+                    }
+                }, 'json').fail(function() {
+                    $btn.html(origHtml);
+                    $btn.css({ border: '1px solid #e74c3c' });
+                    setTimeout(function() { $btn.css({ border: '' }); }, 2000);
+                });
+            });
+
+            // Close on clear / close event
+            $select.on('select2:close', function() {
+                setTimeout(function() { wrap.hide(); }, 100);
+            });
+        }
+
+        $select.select2('open');
+    });
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Multi-contact tag system : [+] add button → native dropdown (no Select2)
+    // ─────────────────────────────────────────────────────────────────────────
+    $(document).on('click', '.pwa-add-contact-btn', function(e) {
+        e.stopPropagation();
+        var $btn      = $(this);
+        var $wrap     = $btn.closest('.pwa-contact-tags-wrap');
+        var $panel    = $wrap.find('.pwa-contact-add-panel');
+        var projectId = $wrap.data('project-id');
+        var tiersId   = $wrap.data('tiers-id') || 0;
+        var baseUrl   = window.saturne.pwa_selectors.getBaseUrl();
+
+        // Toggle
+        if ($panel.is(':visible')) { $panel.hide(); return; }
+
+        // Close other open panels
+        $('.pwa-contact-add-panel').hide();
+        $panel.show();
+
+        // No company → warn
+        if (tiersId <= 0) {
+            $panel.html('<div class="pwa-contact-loading-inline"><i class="fas fa-exclamation-triangle" style="color:#d97706;"></i> Associez d\'abord un client</div>');
+            return;
+        }
+
+        // Collect already linked contact IDs
+        var linkedIds = [];
+        $wrap.find('.pwa-contact-chip').each(function() {
+            linkedIds.push(parseInt($(this).data('contact-id'), 10));
+        });
+
+        // Show spinner while loading
+        $panel.html('<div class="pwa-contact-loading-inline"><i class="fas fa-spinner fa-spin"></i> Chargement...</div>');
+
+        // Fetch contacts and build native <ul> — no Select2, no "Searching...", list appears immediately
+        $.getJSON(baseUrl, { action: 'search_contact_ajax', socid: tiersId, q: '' }, function(data) {
+            var results = (data && data.results) ? data.results : [];
+            var $ul = $('<ul class="pwa-contact-list">');
+            if (results.length === 0) {
+                $ul.append('<li class="pwa-contact-list-empty">Aucun contact pour ce client</li>');
+            } else {
+                $.each(results, function(i, item) {
+                    var isLinked = linkedIds.indexOf(parseInt(item.id, 10)) !== -1;
+                    var $li = $('<li>').attr('data-contact-id', item.id).attr('data-contact-name', item.text);
+                    if (isLinked) {
+                        $li.addClass('pwa-contact-list-linked').html($('<span>').text(item.text).prop('outerHTML') + '<i class="fas fa-check pwa-linked-check"></i>');
+                    } else {
+                        $li.text(item.text);
+                    }
+                    $ul.append($li);
+                });
+            }
+            $panel.html($ul); // render immediately — no intermediate state
+        }).fail(function() {
+            $panel.html('<div class="pwa-contact-loading-inline" style="color:#e74c3c;"><i class="fas fa-exclamation-circle"></i> Impossible de charger les contacts</div>');
+        });
+    });
+
+    // Click on a contact row → addoppcontact
+    $(document).on('click', '.pwa-contact-list li:not(.pwa-contact-list-empty):not(.pwa-contact-list-linked)', function(e) {
+        e.stopPropagation();
+        var $li            = $(this);
+        var $panel         = $li.closest('.pwa-contact-add-panel');
+        var $wrap          = $panel.closest('.pwa-contact-tags-wrap');
+        var $btn           = $wrap.find('.pwa-add-contact-btn');
+        var newContactId   = parseInt($li.data('contact-id'), 10);
+        var newContactName = $li.data('contact-name') || $li.text().trim();
+        var projectId      = $wrap.data('project-id');
+        var baseUrl        = window.saturne.pwa_selectors.getBaseUrl();
+        var token          = $('input[name="token"]').val() || '';
+
+        if (!newContactId) return;
+        $panel.hide();
+        $btn.html('<i class="fas fa-spinner fa-spin"></i>');
+
+        $.post(baseUrl + '?action=addoppcontact&token=' + token,
+            { projectid: projectId, contactid: newContactId },
+            function(res) {
+                $btn.html('<i class="fas fa-plus"></i>');
+                if (res && res.success && res.link_id) {
+                    var chipHtml =
+                        '<span class="pwa-contact-chip" data-link-id="' + res.link_id + '" data-contact-id="' + newContactId + '">' +
+                            '<a href="' + res.contact_url + '" class="prevent-edit-click" title="Voir la fiche contact">' +
+                                $('<span>').text(newContactName).html() +
+                            '</a>' +
+                            '<span class="pwa-chip-role">- Intervenant</span>' +
+                            '<span class="pwa-chip-remove prevent-edit-click" data-link-id="' + res.link_id + '" title="Retirer ce contact"><i class="fas fa-unlink" style="font-size:0.75em;"></i></span>' +
+                        '</span>';
+                    $btn.before(chipHtml);
+                    $wrap.find('.pwa-contact-icon-nolink').replaceWith(
+                        '<a href="' + res.contact_url + '" class="pwa-contact-icon-link prevent-edit-click" title="Voir la fiche contact"><i class="fas fa-address-book"></i></a>'
+                    );
+                } else {
+                    var errMsg = (res && res.error) ? ' (' + res.error + ')' : '';
+                    $btn.attr('title', 'Erreur' + errMsg).css({ outline: '2px solid #e74c3c' });
+                    setTimeout(function() { $btn.css({ outline: '' }).removeAttr('title'); }, 3000);
+                }
+            }, 'json').fail(function() {
+                $btn.html('<i class="fas fa-plus"></i>');
+                $btn.css({ outline: '2px solid #e74c3c' });
+                setTimeout(function() { $btn.css({ outline: '' }); }, 2000);
+            });
+    });
+
+    // Close add-panel on click outside
+    $(document).on('click', function(e) {
+        if (!$(e.target).closest('.pwa-contact-tags-wrap').length) {
+            $('.pwa-contact-add-panel').hide();
+        }
+    });
+
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Remove a contact chip → unlink via removeoppcontact
+    // ─────────────────────────────────────────────────────────────────────────
+    $(document).on('click', '.pwa-chip-remove', function(e) {
+        e.stopPropagation();
+        var $removeBtn = $(this);
+        var linkId     = parseInt($removeBtn.data('link-id'), 10);
+        var $chip      = $removeBtn.closest('.pwa-contact-chip');
+        var $wrap      = $chip.closest('.pwa-contact-tags-wrap');
+        var baseUrl    = window.saturne.pwa_selectors.getBaseUrl();
+        var token      = $('input[name="token"]').val() || '';
+
+        $removeBtn.html('<i class="fas fa-spinner fa-spin" style="font-size:0.75em;"></i>');
+
+        $.post(baseUrl + '?action=removeoppcontact&token=' + token, { link_id: linkId }, function(res) {
+            if (res && res.success) {
+                // Green flash confirmation before fade-out
+                $chip.css({ outline: '2px solid #38a169', transition: 'outline 0.2s' });
+                setTimeout(function() {
+                    $chip.fadeOut(250, function() {
+                        $(this).remove();
+                        // If no chips left, revert icon to greyed-out
+                        if ($wrap.find('.pwa-contact-chip').length === 0) {
+                            $wrap.find('.pwa-contact-icon-link').replaceWith(
+                                '<i class="fas fa-address-book pwa-contact-icon-nolink" title="Ajouter un contact"></i>'
+                            );
+                        }
+                    });
+                }, 300);
+            } else {
+                $removeBtn.html('<i class="fas fa-unlink" style="font-size:0.75em;"></i>');
+                $chip.css({ outline: '2px solid #e74c3c' });
+                setTimeout(function() { $chip.css({ outline: '' }); }, 2000);
+            }
+        }, 'json').fail(function() {
+            $removeBtn.html('<i class="fas fa-unlink" style="font-size:0.75em;"></i>');
+        });
+    });
+};
+
+
+
+
+/**
+ * PWA Quickcreation Form — Geoloc, Phone, Email, URL, Slider, Contact Select
+ * Replaces the inline scripts removed from reedcrm_project_quickcreation_frontend.tpl.php
+ */
+window.saturne.quickcreation_form = {};
+
+window.saturne.quickcreation_form.init = function() {
+    if (!document.querySelector('.quickcreation-form') && !document.getElementById('geoloc-header-wrapper')) return;
+    window.saturne.quickcreation_form.moveGeolocIcon();
+    window.saturne.quickcreation_form.initPhoneValidation();
+    window.saturne.quickcreation_form.initEmailValidation();
+    window.saturne.quickcreation_form.initWebsiteValidation();
+    window.saturne.quickcreation_form.initFormSubmit();
+    window.saturne.quickcreation_form.initOppSlider();
+    window.saturne.quickcreation_form.initContactSelect();
+};
+
+window.saturne.quickcreation_form.moveGeolocIcon = function() {
+    setTimeout(function() {
+        var $pwaHeader = $('#id-top');
+        if ($pwaHeader.length) {
+            var $userWidget = $pwaHeader.find('.user-profile-widget');
+            if ($userWidget.length) {
+                $('#geoloc-header-wrapper').css('display', 'flex').insertBefore($userWidget);
+            } else {
+                $pwaHeader.append($('#geoloc-header-wrapper').css('display', 'flex'));
+            }
+            return;
+        }
+        var $headerRight = $('.login_block, .header-pwa-right, .saturne-header-right').first();
+        if ($headerRight.length) {
+            $('#geoloc-header-wrapper').css('display', 'flex').prependTo($headerRight);
+        } else {
+            $('#geoloc-header-wrapper').css({'display':'flex','position':'fixed','top':'12px','right':'80px','z-index':'9999','background':'rgba(255,255,255,0.9)','padding':'4px 8px','border-radius':'4px'}).appendTo('body');
+        }
+    }, 500);
+};
+
+window.saturne.quickcreation_form.initPhoneValidation = function() {
+    var dataDiv = document.getElementById('reedcrm-quickcreation-data');
+    if (!dataDiv) return;
+    var utilsPath = dataDiv.getAttribute('data-utils-path') || '';
+    var phoneInput = document.getElementById('projectphone');
+    if (!phoneInput || typeof window.intlTelInput === 'undefined') return;
+    var iti = window.intlTelInput(phoneInput, {initialCountry:'fr', utilsScript:utilsPath, formatOnDisplay:true, nationalMode:true, autoPlaceholder:'aggressive', preferredCountries:['fr','be','ch','lu','mc']});
+    phoneInput.addEventListener('input', function() {
+        var val = phoneInput.value;
+        var correctedVal = val.replace(/^(?:\+33|0033)[\s\-.]*0([1-9])/, '+33 $1');
+        if (correctedVal !== val) { phoneInput.value = val = correctedVal; }
+        if (window.intlTelInputUtils) {
+            var cp = phoneInput.selectionStart, isEnd = (cp === phoneInput.value.length);
+            var ft = val.startsWith('+') ? window.intlTelInputUtils.numberFormat.INTERNATIONAL : window.intlTelInputUtils.numberFormat.NATIONAL;
+            var formatted = window.intlTelInputUtils.formatNumber(val, iti.getSelectedCountryData().iso2, ft);
+            if (formatted && formatted !== val) { phoneInput.value = formatted; if (!isEnd && phoneInput.setSelectionRange) phoneInput.setSelectionRange(cp, cp); }
+        }
+        if (phoneInput.value.trim()) {
+            if (!iti.isValidNumber()) { phoneInput.classList.add('input-invalid-material'); phoneInput.setCustomValidity('Numéro de téléphone invalide.'); }
+            else { phoneInput.classList.remove('input-invalid-material'); phoneInput.setCustomValidity(''); }
+        } else { phoneInput.classList.remove('input-invalid-material'); phoneInput.setCustomValidity(''); }
+    });
+    var form = phoneInput.closest('form');
+    if (form) form.addEventListener('submit', function() { if (phoneInput.value.trim() && iti.isValidNumber()) phoneInput.value = iti.getNumber(); });
+};
+
+window.saturne.quickcreation_form.initEmailValidation = function() {
+    var re = /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$/;
+    document.querySelectorAll('input[type="email"]').forEach(function(el) {
+        el.addEventListener('input', function() {
+            var v = this.value.trim();
+            if (v && !re.test(v)) { this.classList.add('input-invalid-material'); this.setCustomValidity("Format de l'adresse e-mail invalide."); }
+            else { this.classList.remove('input-invalid-material'); this.setCustomValidity(''); }
+        });
+    });
+};
+
+window.saturne.quickcreation_form.initWebsiteValidation = function() {
+    var dr = /^([\w\-]+(\.[\w\-]+)+)([\/?#].*)?$/i;
+    document.querySelectorAll('.website-input-group').forEach(function(group) {
+        var ps = group.querySelector('.url-protocol'), di = group.querySelector('.url-domain'), hi = group.querySelector('.url-hidden');
+        function validate() {
+            var v = di.value.trim();
+            if (/^https?:\/\//i.test(v)) { if (v.toLowerCase().startsWith('http://')) { ps.value='http://'; v=v.substring(7); } else { ps.value='https://'; v=v.substring(8); } di.value=v; }
+            if (!v) { hi.value=''; group.classList.remove('input-invalid-material'); di.setCustomValidity(''); return; }
+            hi.value = ps.value + v;
+            if (!dr.test(v)) { group.classList.add('input-invalid-material'); di.setCustomValidity('Format du nom de domaine invalide.'); }
+            else { group.classList.remove('input-invalid-material'); di.setCustomValidity(''); }
+        }
+        ps.addEventListener('change', validate);
+        di.addEventListener('input', validate);
+    });
+};
+
+window.saturne.quickcreation_form.initFormSubmit = function() {
+    var er = /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$/;
+    var dr = /^([\w\-]+(\.[\w\-]+)+)([\/?#].*)?$/i;
+    var mainForm = document.querySelector('.quickcreation-form');
+    if (!mainForm) return;
+    mainForm.addEventListener('submit', function(e) {
+        if (!this.checkValidity()) return;
+        var hasError = false;
+        this.querySelectorAll('input[type="email"]').forEach(function(el) { if (el.value.trim() && !er.test(el.value.trim())) { hasError=true; el.classList.add('input-invalid-material'); el.reportValidity(); el.focus(); } });
+        this.querySelectorAll('.website-input-group').forEach(function(g) { var di=g.querySelector('.url-domain'); if (di.value.trim() && !dr.test(di.value.trim())) { hasError=true; g.classList.add('input-invalid-material'); di.reportValidity(); di.focus(); } });
+        if (hasError) { e.preventDefault(); return; }
+        e.preventDefault();
+        var btn = mainForm.querySelector('button[type="submit"]');
+        if (!btn) return;
+        var orig = btn.innerHTML;
+        btn.innerHTML='<i class="fas fa-spinner fa-spin" style="font-size:20px;color:#fff;"></i>'; btn.disabled=true;
+        var fd = new FormData(mainForm); fd.append('ajax_submission','1');
+        fetch(window.location.href,{method:'POST',body:fd})
+            .then(function(r) { var ct=r.headers.get('content-type'); return ct&&ct.indexOf('application/json')!==-1?r.json():r.text(); })
+            .then(function(data) {
+                if (typeof data==='object'&&data.success) { window.location.href=data.redirect_url||window.location.href; }
+                else if (typeof data==='string') {
+                    var doc=(new DOMParser()).parseFromString(data,'text/html');
+                    var errs=doc.querySelectorAll('.error,.theme-error,.jnotify-container,.alert-danger,.warning,.theme-warning');
+                    if (errs.length) { document.querySelectorAll('.error,.theme-error,.jnotify-container,.alert-danger,.warning,.theme-warning').forEach(function(n){n.remove();}); var cont=document.getElementById('id-container')||mainForm; errs.forEach(function(n){cont.insertBefore(n,cont.firstChild);}); window.scrollTo({top:0,behavior:'smooth'}); }
+                    else if (doc.querySelector('.ok,.theme-success,.theme-statut-ok')) { window.location.reload(); }
+                    else { document.open(); document.write(data); document.close(); }
+                }
+            })
+            .catch(function(err) { console.error('Erreur de soumission',err); alert("Une erreur technique s'est produite."); })
+            .finally(function() { btn.innerHTML=orig; btn.disabled=false; });
+    });
+};
+
+window.saturne.quickcreation_form.initOppSlider = function() {
+    var s=document.getElementById('opp_percent'), v=document.querySelector('.opp_percent-value');
+    if (!s||!v) return;
+    function upd() { var val=parseInt(s.value)||0; v.textContent=val+'%'; var p=val/100; v.style.left='calc('+(p*100)+'% - '+(p*45)+'px + 22.5px)'; }
+    upd(); s.addEventListener('input', upd);
+};
+
+window.saturne.quickcreation_form.initContactSelect = function() {
+    if (typeof jQuery === 'undefined') return;
+    var dataDiv = document.getElementById('reedcrm-quickcreation-data');
+    var lang = dataDiv ? (dataDiv.getAttribute('data-lang') || 'fr') : 'fr';
+    function initS2() { if (!jQuery.fn.select2) return; var s=$('#contactid'); if (s.hasClass('select2-hidden-accessible')) s.select2('destroy'); s.select2({width:'100%',language:lang,placeholder:'Contact/Adresse'}); }
+    function toggleCW() { var sid=$('#socid').val()||($('#search_socid').length?$('#search_socid').val():null); if (sid&&parseInt(sid)>0) $('#contact-wrapper').slideDown(200); else $('#contact-wrapper').slideUp(200); }
+    initS2(); toggleCW();
+    $(document).ajaxComplete(function(ev,xhr,s) { if (s.url&&s.url.indexOf('contacts.php')!==-1) { initS2(); toggleCW(); } });
+    $(document).on('change','#socid, #search_socid', toggleCW);
+    $(document).on('change','#contactid', function() {
+        var cid=$(this).val(); if (!cid||cid<=0) return;
+        var fd=new FormData(); fd.append('action','get_contact_details'); fd.append('contactid',cid);
+        fetch(window.location.href,{method:'POST',body:fd}).then(function(r){return r.json();}).then(function(c) {
+            if (!c||!c.id) return;
+            var pi=document.getElementById('projectphone'); if (pi&&c.phone) { pi.value=c.phone; pi.dispatchEvent(new Event('input',{bubbles:true})); }
+            document.querySelectorAll('input[type="email"]').forEach(function(i) { if (i.name==='options_reedcrm_email'&&c.email) { i.value=c.email; i.dispatchEvent(new Event('input',{bubbles:true})); } });
+            var fi=document.getElementById('reedcrm_firstname'); if (fi&&c.firstname) { fi.value=c.firstname; fi.dispatchEvent(new Event('input')); }
+            var li=document.getElementById('reedcrm_lastname'); if (li&&c.lastname) { li.value=c.lastname; li.dispatchEvent(new Event('input')); }
+        }).catch(function(err){console.error('Error fetching contact details',err);});
+    });
+};
+
+window.reedcrm.call_list_widget = {};
+
+window.reedcrm.call_list_widget.init = function() {
+    window.reedcrm.call_list_widget.event();
+    window.reedcrm.call_list_widget.initSelect2();
+};
+
+window.reedcrm.call_list_widget.initSelect2 = function() {
+    if (typeof jQuery === 'undefined' || !jQuery.fn.select2) return;
+    $('.reedcrm-call-list-select').each(function() {
+        if (!$(this).hasClass('select2-hidden-accessible')) {
+            $(this).select2({ width: '200px', minimumResultsForSearch: Infinity });
+            // Prevent Dolibarr's select2:open handler from throwing a SyntaxError
+            // when id and name are both empty (querySelector receives invalid selector)
+            $(this).on('select2:open', function(e) { e.stopPropagation(); });
+        }
+    });
+};
+
+window.reedcrm.call_list_widget.event = function() {
+    $(document).off('click', '.reedcrm-call-list-add-btn', window.reedcrm.call_list_widget.handleAdd)
+               .on('click', '.reedcrm-call-list-add-btn', window.reedcrm.call_list_widget.handleAdd);
+    $(document).off('change', '.reedcrm-call-list-select', window.reedcrm.call_list_widget.onSelectChange)
+               .on('change', '.reedcrm-call-list-select', window.reedcrm.call_list_widget.onSelectChange);
+    $(document).off('click', '.reedcrm-call-list-default-btn', window.reedcrm.call_list_widget.handleAddDefault)
+               .on('click', '.reedcrm-call-list-default-btn', window.reedcrm.call_list_widget.handleAddDefault);
+};
+
+window.reedcrm.call_list_widget.onSelectChange = function() {
+    var btn = $(this).closest('.reedcrm-add-to-call-list-wrapper').find('.reedcrm-call-list-add-btn');
+    btn.prop('disabled', !$(this).val());
+};
+
+window.reedcrm.call_list_widget.handleAdd = function() {
+    if ($(this).prop('disabled')) return;
+
+    var wrapper     = $(this).closest('.reedcrm-add-to-call-list-wrapper');
+    var elementType = wrapper.data('element-type');
+    var elementId   = wrapper.data('element-id');
+    var ajaxUrl     = wrapper.data('ajax-url');
+    var callListId  = wrapper.find('.reedcrm-call-list-select').val();
+    var token       = $('input[name="token"]').val() || '';
+
+    if (!callListId) return;
+
+    var fd = new FormData();
+    fd.append('element_type', elementType);
+    fd.append('element_id', elementId);
+    fd.append('call_list_id', callListId);
+    fd.append('token', token);
+
+    fetch(ajaxUrl, { method: 'POST', body: fd })
+        .then(function(r) { return r.json(); })
+        .then(function(res) {
+            if (res.success) {
+                $.jnotify(res.message);
+            } else {
+                $.jnotify(res.message, 'error');
+            }
+        })
+        .catch(function() {
+            $.jnotify('Erreur réseau', 'error');
+        });
+};
+
+window.reedcrm.call_list_widget.handleAddDefault = function() {
+    var star        = $(this);
+    var wrapper     = star.closest('.reedcrm-add-to-call-list-wrapper');
+    var elementType = wrapper.data('element-type');
+    var elementId   = wrapper.data('element-id');
+    var ajaxUrl     = wrapper.data('default-ajax-url');
+    var token       = $('input[name="token"]').val() || '';
+
+    var fd = new FormData();
+    fd.append('element_type', elementType);
+    fd.append('element_id', elementId);
+    fd.append('token', token);
+
+    fetch(ajaxUrl, { method: 'POST', body: fd })
+        .then(function(r) { return r.json(); })
+        .then(function(res) {
+            if (res.success) {
+                star.addClass('is-active');
+                $.jnotify(res.message);
+            } else {
+                $.jnotify(res.message, 'error');
+            }
+        })
+        .catch(function() {
+            $.jnotify('Erreur réseau', 'error');
+        });
+};
+/* --- Source: address.js --- */
+/* Copyright (C) 2021-2025 EVARISK <technique@evarisk.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Library javascript to enable Browser notifications
+ */
+
+/**
+ * \file    js/reedcrm.js
+ * \ingroup reedcrm
+ * \brief   JavaScript address file for module ReedCRM.
+ */
+
+/**
+ * Init address JS.
+ *
+ * @memberof ReedCRM_Task
+ *
+ * @since   1.1.0
+ * @version 1.1.0
+ *
+ * @type {Object}
+ */
+window.reedcrm.address = {};
+
+/**
+ * Task init.
+ *
+ * @memberof ReedCRM_Task
+ *
+ * @since   1.1.0
+ * @version 1.1.0
+ *
+ * @returns {void}
+ */
+window.reedcrm.address.init = function() {
+  window.reedcrm.address.event();
+};
+
+/**
+ * Task event.
+ *
+ * @memberof ReedCRM_Task
+ *
+ * @since   1.1.0
+ * @version 1.1.0
+ *
+ * @returns {void}
+ */
+window.reedcrm.address.event = function() {
+  $(document).on('click', '[name="favorite_address"]', window.reedcrm.address.toggleAddressFavorite);
+};
+
+
+/**
+ * Toggle favorite address.
+ *
+ * @memberof ReedCRM_Address
+ *
+ * @since   1.1.0
+ * @version 1.1.0
+ *
+ * @return {void}
+ */
+window.reedcrm.address.toggleAddressFavorite = function() {
+  let contactID = $(this).attr('value');
+  let addressContainer = $(this);
+  let token = window.saturne.toolbox.getToken();
+  let querySeparator = '?';
+
+  document.URL.match(/\?/) ? querySeparator = '&' : 1;
+
+  $.ajax({
+    url: document.URL + querySeparator + 'action=toggle_favorite&contact_id=' + contactID + '&token=' + token,
+    type: "POST",
+    processData: false,
+    contentType: false,
+    success: function() {
+      let elements = $(".fas.fa-star");
+
+      if (addressContainer.hasClass('far')) {
+        addressContainer.removeClass('far');
+        addressContainer.addClass('fas');
+      }
+      elements.removeClass('fas').addClass('far');
+    },
+    error: function() {}
+  });
+};
+
+/* --- Source: call_list.js --- */
+window.saturne = window.saturne || {};
+window.saturne.call_list = {};
+
+window.saturne.call_list.init = function() {
+    window.saturne.call_list.event();
+};
+
+window.saturne.call_list.event = function() {
+    $(document).on('change', '#call_line_element_type', window.saturne.call_list.onTypeChange);
+    $(document).on('change', '#propal_id', window.saturne.call_list.onElementChange);
+    $(document).on('change', '#project_id', window.saturne.call_list.onElementChange);
+    $(document).on('submit', '#add-call-line-form', window.saturne.call_list.onSubmit);
+};
+
+window.saturne.call_list.onTypeChange = function() {
+    var type = $(this).val();
+    if (type === 'project') {
+        $('#call-line-propal-wrap').addClass('hidden');
+        $('#call-line-project-wrap').removeClass('hidden');
+        if ($.fn.select2) {
+            $('#project_id').select2({ width: '300px' });
+        }
+    } else {
+        $('#call-line-project-wrap').addClass('hidden');
+        $('#call-line-propal-wrap').removeClass('hidden');
+        if ($.fn.select2) {
+            $('#propal_id').select2({ width: '300px' });
+        }
+    }
+    window.saturne.call_list.resetContact();
+};
+
+window.saturne.call_list.onElementChange = function() {
+    var elementId   = $(this).val();
+    var elementType = $('#call_line_element_type').val();
+    var $data       = $('#call-list-data');
+
+    if (!elementId) {
+        window.saturne.call_list.resetContact();
+        return;
+    }
+
+    $.ajax({
+        url: $data.data('ajaxUrl'),
+        dataType: 'json',
+        data: { element_type: elementType, element_id: elementId },
+        success: function(res) {
+            if (res && res.success && res.contact_id) {
+                var html = '<b>' + res.lastname + ' ' + res.firstname + '</b>';
+                if (res.phone) {
+                    html += ' — ' + res.phone;
+                } else {
+                    html += ' <span class="opacitymedium badge badge-status1">⚠ ' + $data.data('labelNoPhone') + '</span>';
+                }
+                $('#call_line_contact_info').html(html);
+                $('#fk_contact_hidden').val(res.contact_id);
+            } else {
+                $('#call_line_contact_info').html('<span class="opacitymedium">' + $data.data('labelNoContact') + '</span>');
+                $('#fk_contact_hidden').val('');
+            }
+        },
+        error: function() {
+            window.saturne.call_list.resetContact();
+        }
+    });
+};
+
+window.saturne.call_list.resetContact = function() {
+    var $data = $('#call-list-data');
+    $('#call_line_contact_info').html('<span class="opacitymedium">' + $data.data('labelContact') + ' : —</span>');
+    $('#fk_contact_hidden').val('');
+};
+
+window.saturne.call_list.onSubmit = function(e) {
+    var type      = $('#call_line_element_type').val();
+    var elementId = type === 'project' ? $('#project_id').val() : $('#propal_id').val();
+    if (!elementId) {
+        e.preventDefault();
+        return false;
+    }
+};
+
+$(document).ready(function() {
+    window.saturne.call_list.init();
+});
+
+/* --- Source: call_notifications.js --- */
+/* Copyright (C) 2025 EVARISK <technique@evarisk.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+"use strict";
+
+/**
+ * \file    js/modules/call_notifications.js
+ * \ingroup reedcrm
+ * \brief   JavaScript call notifications file for module ReedCRM - Uses native Dolibarr jnotify
+ */
+
+// Create namespace if not exists
+if (!window.reedcrm) {
+  window.reedcrm = {};
+}
+
+/**
+ * Init call_notifications JS
+ *
+ * @memberof ReedCRM_CallNotifications
+ *
+ * @since   1.0.0
+ * @version 1.0.0
+ *
+ * @type {Object}
+ */
+window.reedcrm.callnotifications = {};
+
+/**
+ * Call notifications init
+ *
+ * @memberof ReedCRM_CallNotifications
+ *
+ * @since   1.0.0
+ * @version 1.0.0
+ *
+ * @returns {void}
+ */
+window.reedcrm.callnotifications.init = function() {
+  console.log('ReedCRM Call Notifications initialized');
+  window.reedcrm.callnotifications.config();
+  window.reedcrm.callnotifications.start();
+};
+
+/**
+ * Configure call notifications
+ *
+ * @memberof ReedCRM_CallNotifications
+ *
+ * @since   1.0.0
+ * @version 1.0.0
+ *
+ * @returns {void}
+ */
+window.reedcrm.callnotifications.config = function() {
+  // Get config from data attributes or defaults
+  var configEl = document.getElementById('reedcrm-call-config');
+
+  if (configEl) {
+    window.reedcrm.callnotifications.frequency = parseInt(configEl.dataset.frequency) || 60;
+    window.reedcrm.callnotifications.autoOpen = parseInt(configEl.dataset.autoOpen) || 0;
+    window.reedcrm.callnotifications.openNewTab = parseInt(configEl.dataset.openNewTab) || 1;
+    window.reedcrm.callnotifications.checkUrl = configEl.dataset.checkUrl || '';
+
+    // Get translations
+    window.reedcrm.callnotifications.trans = {
+      incomingCall: configEl.dataset.transIncomingCall || 'Incoming Call',
+      from: configEl.dataset.transFrom || 'From',
+      phone: configEl.dataset.transPhone || 'Phone',
+      email: configEl.dataset.transEmail || 'Email',
+      viewContact: configEl.dataset.transViewContact || 'View Contact'
+    };
+  } else {
+    // Fallback defaults
+    window.reedcrm.callnotifications.frequency = 60;
+    window.reedcrm.callnotifications.autoOpen = 0;
+    window.reedcrm.callnotifications.openNewTab = 1;
+    window.reedcrm.callnotifications.checkUrl = '';
+    window.reedcrm.callnotifications.trans = {
+      incomingCall: 'Incoming Call',
+      from: 'From',
+      phone: 'Phone',
+      email: 'Email',
+      viewContact: 'View Contact'
+    };
+  }
+
+  window.reedcrm.callnotifications.enabled = true;
+  window.reedcrm.callnotifications.interval = null;
+};
+
+/**
+ * Start checking for call events
+ *
+ * @memberof ReedCRM_CallNotifications
+ *
+ * @since   1.0.0
+ * @version 1.0.0
+ *
+ * @returns {void}
+ */
+window.reedcrm.callnotifications.start = function() {
+  if (!window.reedcrm.callnotifications.checkUrl) {
+    console.error('ReedCRM: No check URL configured for call notifications');
+    return;
+  }
+
+  // Start checking after a small delay
+  setTimeout(function() {
+    console.log('Starting ReedCRM call check with frequency: ' + window.reedcrm.callnotifications.frequency + 's');
+    window.reedcrm.callnotifications.check();
+    window.reedcrm.callnotifications.interval = setInterval(
+      window.reedcrm.callnotifications.check,
+      window.reedcrm.callnotifications.frequency * 1000
+    );
+  }, 3000);
+};
+
+/**
+ * Check for new call events
+ *
+ * @memberof ReedCRM_CallNotifications
+ *
+ * @since   1.0.0
+ * @version 1.0.0
+ *
+ * @returns {void}
+ */
+window.reedcrm.callnotifications.check = function() {
+  if (!window.reedcrm.callnotifications.enabled) return;
+
+  jQuery.ajax({
+    url: window.reedcrm.callnotifications.checkUrl,
+    type: 'GET',
+    dataType: 'json',
+    success: function(data) {
+      if (data && data.length > 0) {
+        console.log('Found ' + data.length + ' new call events');
+        jQuery.each(data, function(index, event) {
+          window.reedcrm.callnotifications.show(event);
+        });
+      }
+    },
+    error: function(xhr, status, error) {
+      console.error('Error checking call events:', error);
+    }
+  });
+};
+
+/**
+ * Show call notification using native jnotify
+ *
+ * @memberof ReedCRM_CallNotifications
+ *
+ * @since   1.0.0
+ * @version 1.0.0
+ *
+ * @param   {Object} event Event data
+ * @returns {void}
+ */
+window.reedcrm.callnotifications.show = function(event) {
+  console.log('Showing call notification:', event);
+
+  var trans = window.reedcrm.callnotifications.trans;
+  var body = '<strong>' + trans.incomingCall + '</strong> : ' + event.contact_name;
+
+  if (event.caller) {
+    body += '<br>' + trans.from + ': ' + event.caller;
+  }
+  if (event.contact_phone) {
+    body += '<br>' + trans.phone + ': ' + event.contact_phone;
+  }
+  if (event.contact_email) {
+    body += '<br>' + trans.email + ': ' + event.contact_email;
+  }
+
+  body += '<br><br><button type="button" class="button" onclick="window.open(\'' + event.url + '\', \'_blank\')">';
+  body += trans.viewContact + '</button>';
+
+  // Use native Dolibarr jnotify
+  jQuery.jnotify(body, 'success', true, {
+    sticky: true,
+    timeout: 30000
+  });
+
+  // Auto-open if configured
+  if (window.reedcrm.callnotifications.autoOpen) {
+    setTimeout(function() {
+      var target = window.reedcrm.callnotifications.openNewTab ? '_blank' : '_self';
+      window.open(event.url, target);
+    }, 1000);
+  }
+};
+
+/**
+ * Enable call notifications
+ *
+ * @memberof ReedCRM_CallNotifications
+ *
+ * @since   1.0.0
+ * @version 1.0.0
+ *
+ * @returns {void}
+ */
+window.reedcrm.callnotifications.enable = function() {
+  window.reedcrm.callnotifications.enabled = true;
+  window.reedcrm.callnotifications.check();
+  window.reedcrm.callnotifications.interval = setInterval(
+    window.reedcrm.callnotifications.check,
+    window.reedcrm.callnotifications.frequency * 1000
+  );
+  console.log('ReedCRM call notifications enabled');
+};
+
+/**
+ * Disable call notifications
+ *
+ * @memberof ReedCRM_CallNotifications
+ *
+ * @since   1.0.0
+ * @version 1.0.0
+ *
+ * @returns {void}
+ */
+window.reedcrm.callnotifications.disable = function() {
+  window.reedcrm.callnotifications.enabled = false;
+  if (window.reedcrm.callnotifications.interval) {
+    clearInterval(window.reedcrm.callnotifications.interval);
+  }
+  console.log('ReedCRM call notifications disabled');
+};
+
+// Auto-initialize on document ready
+jQuery(document).ready(function() {
+  window.reedcrm.callnotifications.init();
+});
+
+
+/* --- Source: contact_inline.js --- */
+window.saturne.contact_inline = {};
+
+window.saturne.contact_inline.init = function() {
+    window.saturne.contact_inline.mountCardUi();
+    window.saturne.contact_inline.event();
+};
+
+window.saturne.contact_inline.event = function() {
+    // Liste: copy icons, cancel buttons inside standard contacts (if any left)
+    $(document).on('click', '.copy-action-icon', window.saturne.contact_inline.copyToClipboard);
+    
+    // Inline quick-edit click delegator logic (Handles Title, Contact spans, Percent, Amount, Company)
+    $(document).on('click', '.inline-edit-proj-title, .inline-edit-contact', window.saturne.contact_inline.startInlineEdit);
+    $(document).on('click', '.inline-edit-proj-percent', window.saturne.contact_inline.editPercent);
+    $(document).on('click', '.inline-edit-proj-amount', window.saturne.contact_inline.editAmount);
+    $(document).on('click', '.inline-edit-company-badge', window.saturne.contact_inline.startCompanyEdit);
+    $(document).on('click', '.inline-edit-origin-badge', window.saturne.contact_inline.startOriginEdit);
+    $(document).on('click', '.inline-edit-salesrep-badge', window.saturne.contact_inline.startSalesRepEdit);
+};
+
+window.saturne.contact_inline.copyToClipboard = function(e) {
+    e.preventDefault();
+    e.stopPropagation();
+    let textToCopy = $(this).data('copy');
+    let icon = $(this);
+    let originalClass = icon.attr('class');
+    let originalColor = icon.css('color');
+    
+    if (navigator.clipboard) {
+        navigator.clipboard.writeText(textToCopy).then(() => {
+            icon.attr('class', 'fas fa-check').css('color', '#38a169');
+            setTimeout(() => { icon.attr('class', originalClass).css('color', originalColor); }, 1500);
+        }).catch(err => console.error('Erreur Copie:', err));
+    }
+};
+
+window.saturne.contact_inline.mountCardUi = function() {
+    let contextData = $('#reedcrm-inline-data');
+    if (contextData.length === 0) return;
+    if ($('.reedcrm-card-header-blocks').length > 0) return; // UI already mounted, prevent duplicates
+    
+    let projId = contextData.data('project-id');
+    let rawAmount = parseFloat(contextData.data('amount') || 0);
+    let percentStr = contextData.data('percent-str');
+    let amountStr = contextData.data('amount-str');
+    let logoPath = contextData.data('logo-path');
+    let percentVal = contextData.data('percent-val');
+    
+    // 1. Title Modification
+    let refidno = $('div.refidno');
+    if (refidno.length > 0) {
+        let editval = refidno.find('.editval');
+        if (editval.length === 0) {
+            let firstNode = refidno.contents().filter(function() {
+                return this.nodeType === 3 && $.trim(this.nodeValue) !== ''; 
+            }).first();
+            
+            if (firstNode.length > 0) {
+                let originalTitle = $.trim(firstNode.text());
+                
+                let wrapperHtml = '<div class="reedcrm-header-title-wrapper" style="display: inline-flex; align-items: center; background: #f8fbff; border: 1px solid #e2e8f0; border-radius: 6px; padding: 4px 8px 4px 6px; vertical-align: middle; font-weight: 600; font-size: 0.95em; margin-bottom: 2px;">' +
+                    '<img src="' + logoPath + '" style="height: 18px; width: 18px; object-fit: contain; margin-right: 8px; border-right: 1px solid #cbd5e0; padding-right: 8px;" alt="ReedCRM" title="Géré par ReedCRM" />' +
+                    '</div>';
+                
+                let wrapper = $(wrapperHtml);
+                firstNode.replaceWith(wrapper);
+                
+                let prefixSpan = $('<span class="dynamic-libelle-prefix" style="color: #4a5568; cursor: pointer; font-weight: bold; margin-right: 6px; padding-bottom: 1px;" title="Modifier le titre">Libellé :</span>');
+                let editableSpan = $('<span class="inline-edit-proj-title" data-project-id="' + projId + '" data-val="" style="color: #0f172a; cursor: pointer; border-bottom: 1px dashed #cbd5e0; line-height: 1; padding-bottom: 1px; transition: color 0.3s; display: inline-flex; min-width: 100px;" title="Modifier le titre"></span>');
+                editableSpan.text(originalTitle).attr('data-val', originalTitle);
+                
+                wrapper.append(prefixSpan).append(editableSpan);
+                prefixSpan.on('click', function(e) { e.stopPropagation(); editableSpan.click(); });
+            }
+        } else {
+             let wrapperHtml = '<div class="reedcrm-header-title-wrapper" style="display: inline-flex; align-items: center; background: #f8fbff; border: 1px solid #e2e8f0; border-radius: 6px; padding: 4px 8px 4px 6px; vertical-align: middle; font-weight: 600; font-size: 0.95em; margin-bottom: 2px; margin-right: 6px;">' +
+                 '<img src="' + logoPath + '" style="height: 18px; width: 18px; object-fit: contain; margin-right: 8px; border-right: 1px solid #cbd5e0; padding-right: 8px;" alt="ReedCRM" title="Géré par ReedCRM" />' +
+                 '<span style="color: #4a5568; font-weight: bold; margin-right: 4px;">Libellé :</span>' +
+                 '</div>';
+             $(wrapperHtml).insertBefore(editval);
+        }
+    }
+    
+    // 2. Probability and Amount
+    let statusRef = $('.statusref');
+    let titleBlock = $('.arearef > div').first();
+    if ($('.reedcrm-header-stats').length === 0) {
+        let statsHtml = '<div class="reedcrm-header-stats" style="' + (statusRef.length > 0 ? '' : 'float: right; ') + 'display: inline-flex; align-items: center; background: #f8fbff; border: 1px solid #e2e8f0; border-radius: 6px; padding: 4px 8px 4px 6px; margin-right: 15px; vertical-align: middle; font-weight: 600; font-size: 0.95em;">' +
+            '<img src="' + logoPath + '" style="height: 18px; width: 18px; object-fit: contain; margin-right: 8px; border-right: 1px solid #cbd5e0; padding-right: 8px;" alt="ReedCRM" title="Géré par ReedCRM" />' +
+            '<span class="inline-edit-proj-percent" data-project-id="'+projId+'" data-val="'+percentVal+'" style="color: #0f172a; cursor: pointer; border-bottom: 1px dashed #cbd5e0; padding-bottom: 1px; transition: color 0.3s; display: inline-flex; align-items: center; white-space: nowrap; line-height: 1;" title="Modifier la probabilité">' + percentStr + '</span>' +
+            '<span style="color: #cbd5e0; margin: 0 6px;">-</span>' +
+            '<span class="inline-edit-proj-amount" data-project-id="'+projId+'" data-val="'+rawAmount+'" style="color: #3b82f6; cursor: pointer; border-bottom: 1px dashed #cbd5e0; padding-bottom: 1px; transition: color 0.3s; display: inline-flex; align-items: center; white-space: nowrap; line-height: 1;" title="Modifier le montant">' + amountStr + '</span>' +
+            '</div>';
+            
+        if (statusRef.length > 0) {
+            let badge = statusRef.find('.badge, .status, .label');
+            if (badge.length > 0) {
+                $(statsHtml).insertBefore(badge.first());
+            } else {
+                statusRef.prepend(statsHtml);
+            }
+        } else if (titleBlock.length > 0) {
+            titleBlock.prepend(statsHtml);
+        }
+    }
+
+    // 3. Align Title and Contact blocks perfectly on the left, side-by-side if space permits
+    let titleWrapper = $('.reedcrm-header-title-wrapper');
+    let contactWrapper = $('.contact-inline-wrapper.reedcrm-header-contact-master');
+    if (titleWrapper.length > 0 && contactWrapper.length > 0) {
+        let alignWrapper = $('<div class="reedcrm-card-header-blocks" style="display: flex; flex-direction: column; gap: 8px; margin-top: 6px; margin-left: 0; padding-left: 0; align-items: flex-start; clear: both;"></div>');
+        titleWrapper.wrap(alignWrapper);
+        contactWrapper.appendTo(titleWrapper.parent());
+        
+        // Remove trailing or separating <br> tags within refidno to avoid random gaps
+        refidno.children('br').remove();
+        
+        // In case previously added margins persist, wipe them
+        titleWrapper.css({'margin-left': '0', 'margin-right': '0', 'margin-bottom': '0'});
+        contactWrapper.css({'margin-left': '0', 'margin-right': '0', 'margin-bottom': '0'});
+    }
+    
+    // 4. Third-Party Badge Styling & Interception
+    // Find the standard third-party link (usually an <a> tag that contains "socid=" inside refidno, avoiding tiny C/P/S badges)
+    let companyBadge = refidno.find('a[href*="socid="]').not('.customer-back').not('.vendor-back').first();
+    if (companyBadge.length > 0) {
+        let compHref = companyBadge.attr('href');
+        
+        // Remove native building icons from the text link
+        let buildingIcon = companyBadge.find('.fa-building, .fa-building-o, .fa-industry');
+        if (buildingIcon.length > 0) {
+            buildingIcon.remove();
+            // Also trim leading spaces left after icon removal
+            companyBadge.html(companyBadge.html().replace(/&nbsp;/g, '').trim());
+        }
+        
+        // Wrap it with our standard UI badge styling if not already done
+        if (!companyBadge.parent().hasClass('reedcrm-header-company-wrapper')) {
+            let compWrapperHtml = '<div class="reedcrm-header-company-wrapper" style="display: inline-flex; align-items: center; background: #f8fbff; border: 1px solid #e2e8f0; border-radius: 6px; padding: 4px 8px 4px 6px; vertical-align: middle; font-weight: 500; font-size: 0.9em; margin-bottom: 2px; color: #4a5568;"></div>';
+            companyBadge.wrap(compWrapperHtml);
+            companyBadge.before('<img src="' + logoPath + '" style="height: 18px; width: 18px; object-fit: contain; margin-right: 8px; border-right: 1px solid #cbd5e0; padding-right: 8px;" alt="ReedCRM" />');
+            
+            // Inject the dedicated _blank hyperlink using the building icon
+            companyBadge.before('<a href="' + compHref + '" target="_blank" style="color: #64748b; margin-right: 6px; display: inline-flex; align-items: center;" title="Ouvrir la fiche tiers"><i class="fas fa-building"></i></a>');
+        }
+        
+        // Ensure the text looks like editable fields
+        companyBadge.addClass('inline-edit-company-badge').css({
+            'cursor': 'pointer',
+            'transition': 'color 0.3s',
+            'color': '#0f172a'
+        }).attr('title', 'Modifier l\'entreprise rattachée');
+        
+        // Force the wrapper into the align flexbox if it exists
+        let companyWrapper = companyBadge.closest('.reedcrm-header-company-wrapper');
+        let alignWrapper = $('.reedcrm-card-header-blocks');
+        if (alignWrapper.length > 0 && companyWrapper.length > 0) {
+            companyWrapper.insertAfter($('.reedcrm-header-title-wrapper'));
+            companyWrapper.css({'margin-left': '0', 'margin-right': '0', 'margin-bottom': '0'});
+        }
+    } else {
+        // No company linked yet! Provide a UI to assign one.
+        let titleWrapper = $('.reedcrm-header-title-wrapper');
+        let alignWrapper = $('.reedcrm-card-header-blocks');
+        
+        if (titleWrapper.length > 0) {
+             let placeholderHtml = '<div class="reedcrm-header-company-wrapper" style="display: inline-flex; align-items: center; background: #f8fbff; border: 1px solid #e2e8f0; border-radius: 6px; padding: 4px 8px 4px 6px; vertical-align: middle; font-weight: 500; font-size: 0.9em; margin-bottom: 2px; color: #4a5568;">' +
+                 '<img src="' + logoPath + '" style="height: 18px; width: 18px; object-fit: contain; margin-right: 8px; border-right: 1px solid #cbd5e0; padding-right: 8px;" alt="ReedCRM" />' +
+                 '<a href="#" class="inline-edit-company-badge" style="cursor: pointer; transition: color 0.3s; color: #0f172a; border-bottom: 1px dashed #cbd5e0; line-height: 1; padding-bottom: 1px;" title="Affecter une entreprise"><i class="fas fa-building" style="margin-right:5px; color:#64748b;"></i>Affecter un tiers</a>' +
+                 '</div>';
+             
+             let newWrapper = $(placeholderHtml);
+             if (alignWrapper.length > 0) {
+                 newWrapper.insertAfter(titleWrapper);
+                 newWrapper.css({'margin-left': '0', 'margin-right': '0', 'margin-bottom': '0'});
+             } else {
+                 newWrapper.insertAfter(titleWrapper);
+             }
+        }
+    }
+}
+
+window.saturne.contact_inline.startCompanyEdit = function(e) {
+    if ($(e.target).hasClass('select2-selection__choice__remove') || $(e.target).closest('.select2-container').length > 0) return;
+    
+    e.preventDefault();
+    e.stopPropagation();
+    
+    let aTag = $(this);
+    let originalHtml = aTag.html();
+    
+    // Retrieve the hidden selector we injected in php
+    let hiddenSelectorWrap = $('#reedcrm-hidden-company-selector');
+    if (hiddenSelectorWrap.length === 0) return;
+    
+    // Check if we already injected it in place, avoiding duplicates
+    if (aTag.parent().find('#reedcrm-hidden-company-selector').length > 0) {
+        // Just show it
+        aTag.hide();
+        hiddenSelectorWrap.show();
+        let s2 = hiddenSelectorWrap.find('select');
+        if (s2.data('select2')) { s2.select2('open'); }
+        return;
+    }
+    
+    aTag.hide();
+    hiddenSelectorWrap.insertAfter(aTag).show();
+    
+    let select2Elem = $('#reedcrm_inline_socid');
+    if (select2Elem.data('select2')) {
+        select2Elem.select2('open');
+    }
+    
+    // Disable native change events from other listeners if any, then add ours
+    select2Elem.off('change.inlineedit').on('change.inlineedit', function() {
+        let newSocid = $(this).val();
+        let projId = $('#reedcrm-inline-data').data('project-id');
+        let token = $('input[name="token"]').val() || '';
+        
+        // Basic revert if no change or empty selected
+        if (!newSocid || newSocid == 0) {
+            hiddenSelectorWrap.hide();
+            aTag.show();
+            return;
+        }
+        
+        let url = 'undefined' != typeof dolibarr_main_url_root && dolibarr_main_url_root ? dolibarr_main_url_root : '';
+        if (!url) {
+            if (document.URL.indexOf('/projet/') > 0) url = document.URL.substring(0, document.URL.indexOf('/projet/'));
+            else if (document.URL.indexOf('/custom/') > 0) url = document.URL.substring(0, document.URL.indexOf('/custom/'));
+        }
+        
+        let ajaxUrl = url + '/custom/reedcrm/view/frontend/quickcreation.php?action=updateoppsocid&token=' + token;
+        
+        aTag.html('<i class="fas fa-spinner fa-spin" style="color: #9b59b6;"></i> Enregistrement...');
+        hiddenSelectorWrap.hide();
+        aTag.show();
+        
+        $.ajax({
+            url: ajaxUrl,
+            type: 'POST',
+            data: { projectid: projId, socid: newSocid },
+            dataType: 'json',
+            success: function(res) {
+                if (res.success) {
+                    if (res.new_company_url) {
+                        // The res.new_company_url is already the full HTML string for the third party (Dolibarr's native format)
+                        // It natively comes out as `<a href="..."> <span class="..."></span> Title </a>`
+                        // So we extract its inner HTML and href
+                        let tempDiv = $('<div>').html(res.new_company_url);
+                        let nativeA = tempDiv.find('a').first();
+                        
+                        if (nativeA.length > 0) {
+                            aTag.attr('href', nativeA.attr('href'));
+                            aTag.html(nativeA.html());
+                        } else {
+                            aTag.html(res.new_company_url);
+                        }
+                    } else {
+                        aTag.html(originalHtml);
+                    }
+                } else {
+                    alert("Erreur: " + (res.error || "Inconnue"));
+                    aTag.html(originalHtml);
+                }
+            },
+            error: function() {
+                alert("Impossible de joindre le serveur");
+                aTag.html(originalHtml);
+            }
+        });
+    });
+    
+    // Try to catch when Select2 is closed without change to revert UI
+    select2Elem.on('select2:close', function () {
+        setTimeout(function() {
+            if (hiddenSelectorWrap.is(':visible')) {
+                // Not selecting anything ? just revert
+                hiddenSelectorWrap.hide();
+                aTag.show();
+            }
+        }, 100);
+    });
+};
+
+window.saturne.contact_inline.startOriginEdit = function(e) {
+    if ($(e.target).hasClass('select2-selection__choice__remove') || $(e.target).closest('.select2-container').length > 0) return;
+    
+    e.preventDefault();
+    e.stopPropagation();
+    
+    let aTag = $(this);
+    let originalHtml = aTag.html();
+    
+    let hiddenSelectorWrap = aTag.parent().find('.reedcrm-hidden-origin-selector-wrap');
+    if (hiddenSelectorWrap.length === 0) return;
+    
+    aTag.hide();
+    hiddenSelectorWrap.show();
+    
+    let selectElem = hiddenSelectorWrap.find('select');
+    if (selectElem.length === 0) return;
+    
+    try {
+        // Ensure Select2 is instantiated
+        if (!selectElem.data('select2') && !selectElem.hasClass('select2-hidden-accessible')) {
+            selectElem.select2({ width: '180px' });
+        } else {
+            // Explicitly fix Select2 width if it was 0 px due to being initialized while display:none
+            let sc = selectElem.next('.select2-container');
+            if (sc.length > 0) {
+                sc.css('width', '180px');
+            }
+        }
+        
+        selectElem.select2('open');
+    } catch (err) {
+        console.error("SELECT2 ERROR: ", err);
+        return;
+    }
+    
+    selectElem.off('change.inlineedit').on('change.inlineedit', function() {
+        let newOrigin = $(this).val();
+        let newOriginText = $(this).find('option:selected').text();
+        let projId = $('#reedcrm-inline-data').data('project-id');
+        let token = $('input[name="token"]').val() || '';
+        
+        let url = 'undefined' != typeof dolibarr_main_url_root && dolibarr_main_url_root ? dolibarr_main_url_root : '';
+        if (!url) {
+            if (document.URL.indexOf('/projet/') > 0) url = document.URL.substring(0, document.URL.indexOf('/projet/'));
+            else if (document.URL.indexOf('/custom/') > 0) url = document.URL.substring(0, document.URL.indexOf('/custom/'));
+        }
+        let ajaxUrl = url + '/custom/reedcrm/view/frontend/quickcreation.php?action=updateopporigin';
+        
+        aTag.html('<i class="fas fa-spinner fa-spin" style="color: #9b59b6;"></i> Enregistrement...');
+        hiddenSelectorWrap.hide();
+        aTag.show();
+        
+        $.ajax({
+            url: ajaxUrl,
+            type: 'POST',
+            data: { projectid: projId, origin: newOrigin, token: token },
+            dataType: 'json',
+            success: function(res) {
+                if (res.success) {
+                    aTag.text(newOriginText);
+                    aTag.css('color', '#2ecc71');
+                    setTimeout(() => aTag.css('color', ''), 1500);
+                } else {
+                    alert("Erreur: " + (res.error || "Inconnue"));
+                    aTag.html(originalHtml);
+                }
+            },
+            error: function() {
+                alert("Impossible de joindre le serveur");
+                aTag.html(originalHtml);
+            }
+        });
+    });
+    
+    // Revert UI on close if no change happened
+    selectElem.off('select2:close').on('select2:close', function () {
+        setTimeout(function() {
+            if (hiddenSelectorWrap.is(':visible')) {
+                hiddenSelectorWrap.hide();
+                aTag.show();
+            }
+        }, 100);
+  // Apply the material look (blue base / red invalid) on an inline editor input. Uses inline
+// !important so it beats the backend list theme's stronger global input border rule.
+window.saturne.contact_inline.applyInputMaterial = function(el, invalid) {
+    if (!el) return;
+    let border = invalid ? '#e53935' : '#3b82f6';
+    let color  = invalid ? '#e53935' : '#0f172a';
+    let shadow = invalid ? '0 0 0 2px rgba(229, 57, 53, 0.2)' : '0 0 0 2px rgba(59, 130, 246, 0.2)';
+    el.style.setProperty('border', '1px solid ' + border, 'important');
+    el.style.setProperty('color', color, 'important');
+    el.style.setProperty('box-shadow', shadow, 'important');
+};
+
+// Cancel an inline edit: tear down the phone widget if any and restore the original markup.
+window.saturne.contact_inline.cancelInlineEdit = function(span, input, originalHtml) {
+    if (input && input[0] && input[0].iti) {
+        input[0].iti.destroy();
+    }
+    span.html(originalHtml);
+};
+
+window.saturne.contact_inline.startSalesRepEdit = function(e) {
+    if ($(e.target).hasClass('select2-selection__choice__remove') || $(e.target).closest('.select2-container').length > 0) return;
+    
+    e.preventDefault();
+    e.stopPropagation();
+    
+    let aTag = $(this);
+    let originalHtml = aTag.html();
+    
+    let hiddenSelectorWrap = aTag.parent().find('.reedcrm-hidden-salesrep-selector-wrap');
+    if (hiddenSelectorWrap.length === 0) return;
+    
+    aTag.hide();
+    hiddenSelectorWrap.show();
+    
+    let selectElem = hiddenSelectorWrap.find('select');
+    if (selectElem.length === 0) return;
+    
+    try {
+        // Ensure Select2 is instantiated
+        if (!selectElem.data('select2') && !selectElem.hasClass('select2-hidden-accessible')) {
+            selectElem.select2({ width: '180px' });
+        } else {
+            let sc = selectElem.next('.select2-container');
+            if (sc.length > 0) {
+                sc.css('width', '180px');
+            }
+        }
+        
+        selectElem.select2('open');
+    } catch (err) {
+        console.error("SELECT2 ERROR: ", err);
+        return;
+    }
+    
+    selectElem.off('change.inlineedit').on('change.inlineedit', function() {
+        let newSalesrep = $(this).val();
+        let newSalesrepText = $(this).find('option:selected').text();
+        let projId = $('#reedcrm-inline-data').data('project-id');
+        let token = $('input[name="token"]').val() || '';
+        
+        let url = 'undefined' != typeof dolibarr_main_url_root && dolibarr_main_url_root ? dolibarr_main_url_root : '';
+        if (!url) {
+            if (document.URL.indexOf('/projet/') > 0) url = document.URL.substring(0, document.URL.indexOf('/projet/'));
+            else if (document.URL.indexOf('/custom/') > 0) url = document.URL.substring(0, document.URL.indexOf('/custom/'));
+        }
+        let ajaxUrl = url + '/custom/reedcrm/view/frontend/quickcreation.php?action=updateoppsalesrep';
+        
+        aTag.html('<i class="fas fa-spinner fa-spin" style="color: #9b59b6;"></i> Enregistrement...');
+        hiddenSelectorWrap.hide();
+        aTag.show();
+        
+        $.ajax({
+            url: ajaxUrl,
+            type: 'POST',
+            data: { projectid: projId, salesrepid: newSalesrep, token: token },
+            dataType: 'json',
+            success: function(res) {
+                if (res.success) {
+                    if (res.new_salesrep_name) {
+                        aTag.text(res.new_salesrep_name);
+                    } else {
+                        aTag.html('<span style="color:#cbd5e0; font-style:italic;">Commercial</span>');
+                    }
+                    aTag.css('color', '#2ecc71');
+                    setTimeout(() => aTag.css('color', ''), 1500);
+                } else {
+                    alert("Erreur: " + (res.error || "Inconnue"));
+                    aTag.html(originalHtml);
+                }
+            },
+            error: function() {
+                alert("Impossible de joindre le serveur");
+                aTag.html(originalHtml);
+            }
+        });
+    });
+    
+    selectElem.off('select2:close').on('select2:close', function () {
+        setTimeout(function() {
+            if (hiddenSelectorWrap.is(':visible')) {
+                hiddenSelectorWrap.hide();
+                aTag.show();
+            }
+        }, 100);
+    });
+};
+
+window.saturne.contact_inline.startInlineEdit = function(e) {
+    if ($(this).find('input').length > 0) return;
+    e.stopPropagation();
+
+    let span = $(this);
+    let isTitle = span.hasClass('inline-edit-proj-title');
+    let currentVal = span.data('val') || '';
+    let originalHtml = span.html();
+    
+    let isPhone = span.data('field') === 'phone';
+    let isWebsite = span.data('field') === 'website';
+    let isEmail = span.data('field') === 'email';
+    let isFlexChild = span.data('field') === 'firstname' || span.data('field') === 'lastname' || isEmail;
+    let inputType = isPhone ? 'tel' : (isWebsite ? 'url' : (isEmail ? 'email' : 'text'));
+    
+    let inputWidth = isTitle ? '250px' : (isFlexChild ? '100%' : (isPhone || isWebsite ? '180px' : '140px'));
+    
+    // Pour le téléphone avec le widget intlTelInput, forcer un padding à gauche pour éviter la superposition du drapeau
+    let extraPadding = isPhone ? 'padding-left: 52px !important; ' : '';
+    let input = $('<input type="' + inputType + '" style="width: ' + inputWidth + '; border: 1px solid #3b82f6; border-radius: 4px; padding: 2px 6px; ' + extraPadding + 'font-weight: inherit; font-size: inherit; color: #0f172a; outline: none; box-sizing: border-box; background: white; margin: 0; display: inline-block; line-height: normal; box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.2);" value="">');
+    input.val(currentVal);
+    
+    if (isWebsite) {
+        if (currentVal === '' || currentVal === 'http://') {
+            input.val('https://');
+        } else if (currentVal.startsWith('http://')) {
+            input.val('https://' + currentVal.substring(7));
+        }
+    }
+    
+    span.html('').append(input);
+    window.saturne.contact_inline.applyInputMaterial(input[0], false);
+
+    if (isWebsite) {
+        input.on('input', function() {
+            let val = $(this).val().trim();
+            if (val.startsWith('www.')) {
+                val = 'https://' + val;
+                $(this).val(val);
+            }
+            const materialUrlRegex = /^(https?:\/\/)?([\w\-]+(\.[\w\-]+)+)([\/?#].*)?$/i;
+            const invalid = val !== '' && val !== 'https://' && val !== 'http://' && !materialUrlRegex.test(val);
+            window.saturne.contact_inline.applyInputMaterial(this, invalid);
+        });
+    }
+    
+    if (isEmail) {
+        input.on('input', function() {
+            let val = $(this).val().trim();
+            const materialEmailRegex = /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$/;
+            window.saturne.contact_inline.applyInputMaterial(this, val !== '' && !materialEmailRegex.test(val));
+        });
+    }
+
+    if (isPhone && typeof window.intlTelInput !== 'undefined') {
+        let baseRoot = (typeof dolibarr_main_url_root !== 'undefined' && dolibarr_main_url_root) ? dolibarr_main_url_root : '';
+        if (!baseRoot) {
+            if (document.URL.indexOf('/projet/') > 0) baseRoot = document.URL.substring(0, document.URL.indexOf('/projet/'));
+            else if (document.URL.indexOf('/custom/') > 0) baseRoot = document.URL.substring(0, document.URL.indexOf('/custom/'));
+        }
+        input[0].iti = window.intlTelInput(input[0], {
+            utilsScript: baseRoot + '/custom/reedcrm/js/intl-tel-input/js/utils.js',
+            initialCountry: "fr",
+            preferredCountries: ["fr", "be", "ch", "lu", "ca"],
+            nationalMode: false,
+            autoPlaceholder: "polite",
+            dropdownContainer: document.body
+        });
+        $('.iti__flag-container').css('z-index', 9999);
+        
+        input[0].addEventListener("open:countrydropdown", function() {
+            input[0].itiDropdownOpen = true;
+        });
+        input[0].addEventListener("close:countrydropdown", function() {
+            input[0].itiDropdownOpen = false;
+            setTimeout(() => input.focus(), 50);
+        });
+        // The flag's mousedown fires before the input's blur; mark the dropdown as open right
+        // away so the blur handler doesn't tear the editor down before the open event arrives.
+        // Letting focus leave the input also lets intlTelInput's type-ahead country search
+        // receive keystrokes (otherwise typed letters would land in the phone number field).
+        $(input).closest('.iti').on('mousedown', '.iti__selected-flag, .iti__flag-container', function() {
+            input[0].itiDropdownOpen = true;
+        });
+    }
+    
+    input.focus();
+    input.select();
+    
+    let submitFunction = isTitle ? window.saturne.contact_inline.submitTitleDetail : window.saturne.contact_inline.submitContactDetail;
+    
+    input.on('blur', function() {
+        if (input[0] && input[0].itiDropdownOpen) return;
+        submitFunction(span, input, originalHtml, currentVal, false, 'blur');
+    });
+    input.on('keydown', function(ev) {
+        ev.stopPropagation();
+        if (ev.which === 13) { ev.preventDefault(); input.off('blur'); submitFunction(span, input, originalHtml, currentVal, false, 'enter'); }
+        else if (ev.which === 9) { ev.preventDefault(); input.off('blur'); submitFunction(span, input, originalHtml, currentVal, true, 'tab'); }
+        else if (ev.which === 27) { ev.preventDefault(); input.off('blur'); window.saturne.contact_inline.cancelInlineEdit(span, input, originalHtml); }
+    });
+    input.on('click', function(ev) { ev.stopPropagation(); });
+};
+
+window.saturne.contact_inline.submitTitleDetail = function(span, input, originalHtml, currentVal, isTabbing) {
+    let focusNextSpan = function() {
+        let firstContactSpan = $('.contact-inline-wrapper .inline-edit-contact').first();
+        if (firstContactSpan.length > 0) {
+            firstContactSpan.click();
+        }
+    };
+
+    let newVal = input.val().trim();
+    if (newVal === currentVal) {
+        span.html(originalHtml);
+        if (isTabbing) {
+            focusNextSpan();
+        }
+        return;
+    }
+    
+    span.data('val', newVal);
+    var originalWidth = span.width();
+    span.html('<i class="fas fa-spinner fa-spin" style="color: #9b59b6;"></i>').css('min-width', originalWidth + 'px');
+    let projectId = span.data('project-id');
+    let token = $('input[name="token"]').val() || '';
+    
+    let baseRoot = (typeof dolibarr_main_url_root !== 'undefined' && dolibarr_main_url_root) ? dolibarr_main_url_root : '';
+    if (!baseRoot) {
+        if (document.URL.indexOf('/projet/') > 0) baseRoot = document.URL.substring(0, document.URL.indexOf('/projet/'));
+        else if (document.URL.indexOf('/custom/') > 0) baseRoot = document.URL.substring(0, document.URL.indexOf('/custom/'));
+    }
+    let targetUrl = baseRoot + '/custom/reedcrm/view/frontend/quickcreation.php?action=updateopptitle';
+    if (document.URL.indexOf('quickcreation.php') > 0) targetUrl = document.URL.split('?')[0] + '?action=updateopptitle';
+    
+    $.ajax({
+        url: targetUrl,
+        type: 'POST',
+        data: { token: token, projectid: projectId, title: newVal },
+        success: function(res) {
+            span.css({color: '#2ecc71', 'min-width': ''});
+            span.html(newVal ? newVal : '<span style="color:#cbd5e0; font-style:italic;">Sans titre</span>');
+            setTimeout(function() { span.css({color: ''}); }, 1500);
+            if (isTabbing) {
+                focusNextSpan();
+            }
+        },
+        error: function(jqXHR) {
+            alert("Erreur XHR Titre: " + jqXHR.status + "\n" + (jqXHR.responseText ? jqXHR.responseText.substring(0, 300) : 'Aucune reponse'));
+            span.html(originalHtml).css('min-width', '');
+            span.data('val', currentVal);
+            span.css({color: '#e74c3c'});
+            setTimeout(() => span.css({color: ''}), 1500);
+        }
+    });
+};
+
+window.saturne.contact_inline.submitContactDetail = function(span, input, originalHtml, currentVal, isTabbing, trigger) {
+    let newVal = input.val().trim();
+    if (span.data('field') === 'phone' && input[0].iti && window.intlTelInputUtils) {
+        if (input[0].iti.isValidNumber()) {
+            newVal = input[0].iti.getNumber();
+        }
+    }
+    let contactWrapper = span.closest('.contact-inline-wrapper');
+    
+    let focusNextSpan = function() {
+        let allSpans = contactWrapper.find('.inline-edit-contact:visible');
+        let currentIndex = allSpans.index(span);
+        if (currentIndex >= 0 && currentIndex < allSpans.length - 1) {
+            allSpans.eq(currentIndex + 1).click();
+        }
+    };
+    
+    let field = span.data('field');
+    let invalid = false;
+
+    // Email validation
+    if (field === 'email' && newVal !== '') {
+        const materialEmailRegex = /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$/;
+        invalid = !materialEmailRegex.test(newVal);
+    }
+
+    // Website validation (normalize the protocol first)
+    if (field === 'website') {
+        if (newVal === 'https://' || newVal === 'http://') {
+            newVal = '';
+            input.val('');
+        }
+        if (newVal !== '') {
+            if (!newVal.startsWith('http://') && !newVal.startsWith('https://')) {
+                newVal = 'https://' + newVal;
+                input.val(newVal);
+            }
+            const materialUrlRegex = /^(https?:\/\/)?([\w\-]+(\.[\w\-]+)+)([\/?#].*)?$/i;
+            invalid = !materialUrlRegex.test(newVal);
+        }
+    }
+
+    // No blocking alert (it previously trapped the user, with no way to cancel the edit).
+    if (invalid) {
+        if (trigger === 'blur') {
+            // Clicked away from an invalid value: cancel and restore the original.
+            window.saturne.contact_inline.cancelInlineEdit(span, input, originalHtml);
+            span.data('val', currentVal);
+        } else {
+            // Active submit (Enter/Tab): keep editing and flag the field in red.
+            window.saturne.contact_inline.applyInputMaterial(input[0], true);
+            input.focus();
+        }
+        return;
+    }
+
+    if (newVal === currentVal) {
+        span.html(originalHtml);
+        if (isTabbing) focusNextSpan();
+        return;
+    }
+    
+    span.data('val', newVal);
+    var originalWidth = span.width();
+    span.html('<i class="fas fa-spinner fa-spin" style="color: #9b59b6;"></i>').css('min-width', originalWidth + 'px');
+    
+    let contactProjectId = contactWrapper.data('project-id');
+    
+    let bFirst = contactWrapper.find('.inline-edit-contact[data-field="firstname"]').data('val');
+    let bLast = contactWrapper.find('.inline-edit-contact[data-field="lastname"]').data('val');
+    let bPhone = contactWrapper.find('.inline-edit-contact[data-field="phone"]').data('val');
+    let bEmail = contactWrapper.find('.inline-edit-contact[data-field="email"]').data('val');
+    let bWeb = contactWrapper.find('.inline-edit-contact[data-field="website"]').data('val');
+    
+    let token = $('input[name="token"]').val() || '';
+    
+    let baseRoot = (typeof dolibarr_main_url_root !== 'undefined' && dolibarr_main_url_root) ? dolibarr_main_url_root : '';
+    if (!baseRoot) {
+        if (document.URL.indexOf('/projet/') > 0) baseRoot = document.URL.substring(0, document.URL.indexOf('/projet/'));
+        else if (document.URL.indexOf('/custom/') > 0) baseRoot = document.URL.substring(0, document.URL.indexOf('/custom/'));
+    }
+    let targetUrl = baseRoot + '/custom/reedcrm/view/frontend/quickcreation.php?action=updateoppcontact';
+    if (document.URL.indexOf('quickcreation.php') > 0) targetUrl = document.URL.split('?')[0] + '?action=updateoppcontact';
+    
+    $.ajax({
+        url: targetUrl,
+        type: 'POST',
+        data: {
+            token: token,
+            projectid: contactProjectId,
+            firstname: bFirst,
+            lastname: bLast,
+            phone: bPhone,
+            email: bEmail,
+            website: bWeb
+        },
+        success: function(res) {
+            span.css({color: '#2ecc71', 'min-width': ''});
+            var pText = '';
+            if (field === 'firstname') pText = 'Prénom';
+            if (field === 'lastname') pText = 'Nom';
+            if (field === 'phone') pText = 'Téléphone';
+            if (field === 'email') pText = 'Email';
+            if (field === 'website') pText = 'Site Web';
+            span.html(newVal ? newVal : '<span style="color:#cbd5e0; font-style:italic;">' + pText + '</span>');
+            setTimeout(function() { span.css({color: ''}); }, 1500);
+            
+            if (isTabbing) {
+                focusNextSpan();
+            }
+        },
+        error: function(jqXHR) {
+            alert("Erreur XHR Titre: " + jqXHR.status + "\n" + (jqXHR.responseText ? jqXHR.responseText.substring(0, 300) : 'Aucune reponse'));
+            span.html(originalHtml).css('min-width', '');
+            span.data('val', currentVal);
+            span.css({color: '#e74c3c'});
+            setTimeout(() => span.css({color: ''}), 1500);
+        }
+    });
+    
+    if (span.data('field') === 'phone' && input[0].iti) {
+        input[0].iti.destroy();
+    }
+};
+
+window.saturne.contact_inline.editPercent = function(e) {
+    if ($(this).find('input').length > 0) return;
+    e.stopPropagation();
+    
+    let span = $(this);
+    let projId = span.data('project-id');
+    let currentVal = parseInt(span.data('val'));
+    let originalText = span.text();
+    
+    let input = $('<input type="number" min="0" max="100" class="percent-input" style="width: 35px; text-align: center; border: 1px solid #cbd5e1; border-radius: 4px; padding: 0; font-weight: 600; font-size: 1em; color: #0f172a; outline: none; box-sizing: border-box; background: transparent; margin: 0; display: inline-block; vertical-align: middle; line-height: normal; -moz-appearance: textfield;" value="'+currentVal+'">');
+    
+    if ($('#css-no-spinners').length === 0) {
+        $('head').append('<style id="css-no-spinners">input[type="number"].percent-input::-webkit-outer-spin-button, input[type="number"].percent-input::-webkit-inner-spin-button { -webkit-appearance: none; margin: 0; }</style>');
+    }
+    
+    span.html('').append(input).append('<span style="font-weight:normal; margin-left: 2px;">%</span>');
+    input.focus();
+    
+    let submitValuePercent = function() {
+        let newVal = parseInt(input.val());
+        if (isNaN(newVal) || newVal < 0) newVal = 0;
+        if (newVal > 100) newVal = 100;
+        
+        if (newVal === currentVal) {
+            span.html(originalText);
+            return;
+        }
+        
+        span.html('<i class="fas fa-spinner fa-spin" style="color: #9b59b6; line-height: 22px;"></i>');
+        let token = $('input[name="token"]').val() || '';
+        
+        let baseRoot = (typeof dolibarr_main_url_root !== 'undefined' && dolibarr_main_url_root) ? dolibarr_main_url_root : '';
+        if (!baseRoot) {
+            if (document.URL.indexOf('/projet/') > 0) baseRoot = document.URL.substring(0, document.URL.indexOf('/projet/'));
+            else if (document.URL.indexOf('/custom/') > 0) baseRoot = document.URL.substring(0, document.URL.indexOf('/custom/'));
+        }
+        let targetUrl = baseRoot + '/custom/reedcrm/view/frontend/quickcreation.php?action=updateopppercent';
+        if (document.URL.indexOf('quickcreation.php') > 0) targetUrl = document.URL.split('?')[0] + '?action=updateopppercent';
+        
+        $.ajax({
+            url: targetUrl,
+            type: 'POST',
+            data: { token: token, projectid: projId, percent: newVal },
+            success: function(res) {
+                if(res && res.success) {
+                    span.data('val', newVal);
+                    span.html(newVal + ' %');
+                    span.css({color: '#2ecc71'});
+                    setTimeout(() => span.css({color: '#0f172a'}), 1500);
+                } else {
+                    span.html(originalText).css({color: '#e74c3c'});
+                    setTimeout(() => span.css({color: '#0f172a'}), 1500);
+                }
+            },
+            error: function(jqXHR) {
+                alert("Erreur XHR Percent: " + jqXHR.status + "\n" + (jqXHR.responseText ? jqXHR.responseText.substring(0, 300) : 'Aucune reponse'));
+                span.html(originalText).css({color: '#e74c3c'});
+                setTimeout(() => span.css({color: originalColor}), 1500);
+            }
+        });
+    };
+    
+    input.on('blur', submitValuePercent);
+    input.on('keypress', function(ev) { ev.stopPropagation(); if (ev.which === 13) { ev.preventDefault(); input.off('blur'); submitValuePercent(); } });
+    input.on('keydown', function(ev) {
+        if (ev.which === 9) { // Tab
+            ev.preventDefault();
+            input.off('blur');
+            submitValuePercent();
+            let amountSpan = span.parent().find('.inline-edit-proj-amount');
+            if (amountSpan.length > 0) {
+                setTimeout(() => amountSpan.click(), 50);
+            }
+        }
+    });
+    input.on('click', function(ev) { ev.stopPropagation(); });
+};
+
+window.saturne.contact_inline.editAmount = function(e) {
+    if ($(this).find('input').length > 0) return;
+    e.stopPropagation();
+    
+    let span = $(this);
+    let projId = span.data('project-id');
+    let currentVal = parseFloat(span.data('val'));
+    let originalText = span.text();
+    
+    let inputWidth = originalText.length > 8 ? '80px' : '65px';
+    let input = $('<input type="text" class="amount-input" style="width: '+inputWidth+'; text-align: center; border: 1px solid #cbd5e1; border-radius: 4px; padding: 0 2px; font-weight: 600; font-size: 1em; color: #3b82f6; outline: none; box-sizing: border-box; background: transparent; margin: 0; display: inline-block; vertical-align: middle; line-height: normal; -moz-appearance: textfield;" value="'+currentVal+'">');
+    
+    span.html('').append(input).append('<span style="font-weight:normal; margin-left: 4px;">€</span>');
+    input.focus();
+    
+    let submitValueAmount = function() {
+        let userStr = input.val().replace(',', '.');
+        let newVal = parseFloat(userStr);
+        if (isNaN(newVal) || newVal < 0) newVal = 0;
+        
+        if (newVal === currentVal) {
+            span.html(originalText);
+            return;
+        }
+        
+        span.html('<i class="fas fa-spinner fa-spin" style="color: #9b59b6; line-height: 22px;"></i>');
+        let token = $('input[name="token"]').val() || '';
+        
+        let baseRoot = (typeof dolibarr_main_url_root !== 'undefined' && dolibarr_main_url_root) ? dolibarr_main_url_root : '';
+        if (!baseRoot) {
+            if (document.URL.indexOf('/projet/') > 0) baseRoot = document.URL.substring(0, document.URL.indexOf('/projet/'));
+            else if (document.URL.indexOf('/custom/') > 0) baseRoot = document.URL.substring(0, document.URL.indexOf('/custom/'));
+        }
+        let targetUrl = baseRoot + '/custom/reedcrm/view/frontend/quickcreation.php?action=updateoppamount';
+        if (document.URL.indexOf('quickcreation.php') > 0) targetUrl = document.URL.split('?')[0] + '?action=updateoppamount';
+        
+        $.ajax({
+            url: targetUrl,
+            type: 'POST',
+            data: { token: token, projectid: projId, amount: newVal },
+            success: function(res) {
+                if(res && res.success) {
+                    span.data('val', newVal);
+                    span.html(res.formatted_amount);
+                    span.css({color: '#2ecc71'});
+                    setTimeout(() => span.css({color: '#3b82f6'}), 1500);
+                } else {
+                    span.html(originalText).css({color: '#e74c3c'});
+                    setTimeout(() => span.css({color: '#3b82f6'}), 1500);
+                }
+            },
+            error: function(jqXHR) {
+                alert("Erreur XHR Percent: " + jqXHR.status + "\n" + (jqXHR.responseText ? jqXHR.responseText.substring(0, 300) : 'Aucune reponse'));
+                span.html(originalText).css({color: '#e74c3c'});
+                setTimeout(() => span.css({color: '#3b82f6'}), 1500);
+            }
+        });
+    };
+    
+    input.on('blur', submitValueAmount);
+    input.on('keypress', function(ev) { ev.stopPropagation(); if (ev.which === 13) { ev.preventDefault(); input.off('blur'); submitValueAmount(); } });
+    input.on('keydown', function(ev) {
+        if (ev.which === 9) { // Tab
+            ev.preventDefault();
+            input.off('blur');
+            submitValueAmount();
+        }
+    });
+    input.on('click', function(ev) { ev.stopPropagation(); });
+};
+
+// Initialize module on ready
+$(document).ready(function() {
+    if (typeof window.saturne !== 'undefined' && window.saturne.contact_inline) {
+        // Mount the UI elements into the banner (Title, Percentage, Amount)
+        window.saturne.contact_inline.mountCardUi();
+        
+        // Bind all click delegates
+        // (Delegates are mostly handled in init -> event(), keeping document bounds clean)
+        $(document).on('click', '.reedcrm-copy-text', window.saturne.contact_inline.copyToClipboard);
+    }
+});
+
+/* --- Source: eventpro.js --- */
+/* Copyright (C) 2025 EVARISK <technique@evarisk.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+"use strict";
+
+/**
+ * \file    js/modules/eventpro.js
+ * \ingroup reedcrm
+ * \brief   JavaScript eventpro modal file for module ReedCRM
+ */
+
+if (!window.reedcrm) {
+  window.reedcrm = {};
+}
+
+/**
+ * Init eventpro JS
+ *
+ * @memberof ReedCRM_EventPro
+ *
+ * @since   1.0.0
+ * @version 1.0.0
+ *
+ * @type {Object}
+ */
+window.reedcrm.eventpro = {};
+
+/**
+ * Eventpro modal ID
+ *
+ * @memberof ReedCRM_EventPro
+ *
+ * @since   1.0.0
+ * @version 1.0.0
+ *
+ * @type {String}
+ */
+window.reedcrm.eventpro.modalId = 'eventproCardModal';
+
+/**
+ * Track if refresh was already triggered to avoid double refresh
+ *
+ * @memberof ReedCRM_EventPro
+ *
+ * @since   1.0.0
+ * @version 1.0.0
+ *
+ * @type {Boolean}
+ */
+window.reedcrm.eventpro.refreshTriggered = false;
+
+/**
+ * Eventpro init
+ *
+ * @memberof ReedCRM_EventPro
+ *
+ * @since   1.0.0
+ * @version 1.0.0
+ *
+ * @returns {void}
+ */
+window.reedcrm.eventpro.init = function () {
+  window.reedcrm.eventpro.event();
+  window.reedcrm.eventpro.modalCloseWatcher();
+  window.reedcrm.eventpro.initAddContact();
+  window.reedcrm.eventpro.initRelaunchTooltips();
+};
+
+/**
+ * Load content into modal via AJAX
+ *
+ * @memberof ReedCRM_EventPro
+ *
+ * @since   1.1.0
+ * @version 1.1.0
+ *
+ * @param {String} url The URL to load
+ * @returns {void}
+ */
+window.reedcrm.eventpro.loadModalContent = function (url) {
+  var $content = $('#' + window.reedcrm.eventpro.modalId + '-content');
+  var $loader = $('#' + window.reedcrm.eventpro.modalId + '-loader');
+
+  $loader.show().addClass('wpeo-loader');
+  if (typeof window.saturne !== 'undefined' && window.saturne.loader) {
+    window.saturne.loader.display($loader);
+  }
+  $content.hide().empty();
+
+  var separator = url.indexOf('?') !== -1 ? '&' : '?';
+  var ajaxUrl = url + separator + 'modal=1';
+
+  $.ajax({
+    url: ajaxUrl,
+    type: 'GET',
+    success: function (html) {
+      $content.html(html);
+      $content.show();
+
+      if (typeof window.saturne !== 'undefined' && window.saturne.loader) {
+        window.saturne.loader.remove($loader);
+      } else {
+        $loader.hide();
+      }
+
+      window.reedcrm.eventpro.bindModalContentEvents();
+    },
+    error: function () {
+      if (typeof window.saturne !== 'undefined' && window.saturne.loader) {
+        window.saturne.loader.remove($loader);
+      } else {
+        $loader.hide();
+      }
+      $content.html('<div class="error" style="padding: 20px;">Erreur lors du chargement</div>');
+      $content.show();
+    }
+  });
+};
+
+/**
+ * Bind events on AJAX-loaded modal content (form submit, tab clicks)
+ *
+ * @memberof ReedCRM_EventPro
+ *
+ * @since   1.1.0
+ * @version 1.1.0
+ *
+ * @returns {void}
+ */
+window.reedcrm.eventpro.bindModalContentEvents = function () {
+  var $content = $('#' + window.reedcrm.eventpro.modalId + '-content');
+
+  $content.find('form').off('submit.reedcrm').on('submit.reedcrm', function (e) {
+    e.preventDefault();
+    var $form = $(this);
+    var formAction = $form.attr('action');
+    var separator = formAction.indexOf('?') !== -1 ? '&' : '?';
+
+    $.ajax({
+      url: formAction + separator + 'modal=1',
+      type: 'POST',
+      data: $form.serialize(),
+      dataType: 'json',
+      success: function (response) {
+        if (response && response.success) {
+          var projectId = $('#' + window.reedcrm.eventpro.modalId).attr('data-project-id');
+          $('#' + window.reedcrm.eventpro.modalId).removeClass('modal-active');
+          $('#' + window.reedcrm.eventpro.modalId + '-content').empty();
+          window.reedcrm.eventpro.refreshProjectRow(projectId);
+
+          if (response.message && typeof window.saturne !== 'undefined' && window.saturne.notification) {
+            window.saturne.notification.success(response.message);
+          }
+        } else {
+          var errorMsg = (response && response.error) ? response.error : 'Erreur';
+          if (typeof window.saturne !== 'undefined' && window.saturne.notification) {
+            window.saturne.notification.error(errorMsg);
+          } else {
+            alert(errorMsg);
+          }
+        }
+      },
+      error: function () {
+        if (typeof window.saturne !== 'undefined' && window.saturne.notification) {
+          window.saturne.notification.error('Erreur lors de la soumission');
+        } else {
+          alert('Erreur lors de la soumission');
+        }
+      }
+    });
+  });
+
+  $content.find('a[href*="tab="]').on('click', function (e) {
+    e.preventDefault();
+    var url = $(this).attr('href');
+    window.reedcrm.eventpro.loadModalContent(url);
+  });
+};
+
+/**
+ * Refresh the project row
+ *
+ * @memberof ReedCRM_EventPro
+ *
+ * @since   1.0.0
+ * @version 1.0.0
+ *
+ * @param {String|Number} projectId The project ID
+ * @returns {void}
+ */
+window.reedcrm.eventpro.refreshProjectRow = function (projectId) {
+  if (!projectId) {
+    window.location.reload();
+    return;
+  }
+
+  var baseUrl = window.location.href.split('&action=')[0].split('#')[0];
+  var curTr = $('tr[data-rowid="' + projectId + '"]');
+
+  if (!curTr.length) {
+    window.location.reload();
+    return;
+  }
+
+  curTr.css('opacity', '0.5');
+
+  $.ajax({
+    url: baseUrl,
+    type: 'GET',
+    success: function (resp) {
+      var $resp = $(resp);
+      var newTr = $resp.find('tr[data-rowid="' + projectId + '"]');
+      if (newTr.length && curTr.length) {
+        curTr.fadeOut(200, function () {
+          curTr.html(newTr.html());
+          curTr.css('opacity', '1');
+          curTr.fadeIn(200);
+        });
+      } else {
+        curTr.css('opacity', '1');
+      }
+    },
+    error: function () {
+      curTr.css('opacity', '1');
+    }
+  });
+};
+
+/**
+ * Handle modal close watcher - don't refresh on close, only on form submission
+ *
+ * @memberof ReedCRM_EventPro
+ *
+ * @since   1.0.0
+ * @version 1.0.0
+ *
+ * @returns {void}
+ */
+window.reedcrm.eventpro.modalCloseWatcher = function () {
+  var previousModalState = false;
+  setInterval(function () {
+    var isModalActive = $('#' + window.reedcrm.eventpro.modalId).hasClass('modal-active');
+    if (previousModalState && !isModalActive) {
+      window.reedcrm.eventpro.refreshTriggered = false;
+    }
+    previousModalState = isModalActive;
+  }, 200);
+};
+
+/**
+ * Eventpro events
+ *
+ * @memberof ReedCRM_EventPro
+ *
+ * @since   1.0.0
+ * @version 1.1.0
+ *
+ * @returns {void}
+ */
+window.reedcrm.eventpro.event = function () {
+  var modalSelector = '#' + window.reedcrm.eventpro.modalId;
+
+  $(document).on('click', modalSelector + ' .modal-close, ' + modalSelector + ' .modal-close i', function (e) {
+    e.preventDefault();
+    var $modal = $(modalSelector);
+    $modal.removeClass('modal-active');
+    $modal.find('#' + window.reedcrm.eventpro.modalId + '-content').empty();
+  });
+
+  var mousedownOnBackdrop = false;
+  $(document).on('mousedown', modalSelector, function (e) {
+    mousedownOnBackdrop = $(e.target).is(modalSelector);
+  });
+
+  $(document).on('click', modalSelector, function (e) {
+    if ($(e.target).is(modalSelector) && mousedownOnBackdrop) {
+      $(this).removeClass('modal-active');
+      $(this).find('#' + window.reedcrm.eventpro.modalId + '-content').empty();
+    }
+  });
+
+  $(document).on('click', '.reedcrm-modal-open, .reedcrm-card-modal-open', function (e) {
+    var $button = $(this);
+    var modalUrl = $button.attr('data-modal-url');
+    var projectId = $button.attr('data-project-id');
+
+    if (modalUrl) {
+      var $modal = $('#' + window.reedcrm.eventpro.modalId);
+
+      $modal.addClass('modal-active');
+      $modal.attr('data-project-id', projectId);
+
+      window.reedcrm.eventpro.loadModalContent(modalUrl);
+    }
+  });
+};
+
+/**
+ * Initialize add contact functionality
+ *
+ * @memberof ReedCRM_EventPro
+ *
+ * @since   1.0.0
+ * @version 1.0.0
+ */
+window.reedcrm.eventpro.initAddContact = function () {
+  $(document).on('click', '.reedcrm-add-contact-btn', function (e) {
+    e.preventDefault();
+    var $form = $(this).closest('.reedcrm-contact-field-wrapper').parent().find('.reedcrm-add-contact-form');
+    $form.slideDown();
+  });
+
+  $(document).on('click', '.reedcrm-add-contact-cancel', function (e) {
+    e.preventDefault();
+    var $form = $(this).closest('.reedcrm-add-contact-form');
+    $form.slideUp();
+    $form.find('input').val('');
+  });
+
+  $(document).on('click', '.reedcrm-add-contact-submit', function (e) {
+    e.preventDefault();
+    window.reedcrm.eventpro.submitAddContact($(this));
+  });
+};
+
+/**
+ * Submit add contact form
+ *
+ * @memberof ReedCRM_EventPro
+ *
+ * @since   1.0.0
+ * @version 1.1.0
+ *
+ * @param {jQuery} $button The submit button element
+ */
+window.reedcrm.eventpro.submitAddContact = function ($button) {
+  var $form = $button.closest('.reedcrm-add-contact-form');
+  var $mainForm = $form.closest('form');
+  var $contactSelect = $mainForm.find('select[name="contactid"]');
+  var socid = $mainForm.find('select[name="socid"]').val();
+
+  var lastname = $form.find('#new_contact_lastname').val().trim();
+  if (!lastname) {
+    if (typeof window.saturne !== 'undefined' && window.saturne.notification) {
+      window.saturne.notification.error('Le nom est obligatoire');
+    }
+    return;
+  }
+
+  if (!socid) {
+    if (typeof window.saturne !== 'undefined' && window.saturne.notification) {
+      window.saturne.notification.error('Veuillez sélectionner un tiers');
+    }
+    return;
+  }
+
+  var formData = {
+    action: 'create_contact',
+    token: $mainForm.find('input[name="token"]').val(),
+    from_id: $mainForm.find('input[name="from_id"]').val(),
+    from_type: $mainForm.find('input[name="from_type"]').val(),
+    socid: socid,
+    new_contact_lastname: lastname,
+    new_contact_firstname: $form.find('#new_contact_firstname').val().trim(),
+    new_contact_phone_pro: $form.find('#new_contact_phone_pro').val().trim(),
+    new_contact_email: $form.find('#new_contact_email').val().trim()
+  };
+
+  $button.prop('disabled', true);
+
+  var baseUrl = $mainForm.attr('action');
+  if (baseUrl) {
+    baseUrl = baseUrl.split('?')[0];
+  } else {
+    baseUrl = window.location.href.split('?')[0];
+  }
+
+  $.ajax({
+    url: baseUrl,
+    type: 'POST',
+    data: formData,
+    dataType: 'json',
+    success: function (response) {
+      if (response && response.success) {
+        var newOption = new Option(response.contact_label, response.contact_id, true, true);
+        $contactSelect.append(newOption).trigger('change');
+
+        $form.slideUp();
+        $form.find('input').val('');
+
+        if (typeof window.saturne !== 'undefined' && window.saturne.notification) {
+          window.saturne.notification.success('Contact créé avec succès');
+        }
+      } else {
+        var errorMsg = (response && response.error) ? response.error : 'Erreur lors de la création du contact';
+        if (typeof window.saturne !== 'undefined' && window.saturne.notification) {
+          window.saturne.notification.error(errorMsg);
+        }
+      }
+    },
+    error: function (xhr, status, error) {
+      console.error('AJAX Error:', xhr, status, error);
+      var errorMsg = 'Erreur lors de la création du contact';
+      try {
+        if (xhr.responseText) {
+          var errorResponse = JSON.parse(xhr.responseText);
+          if (errorResponse.error) {
+            errorMsg = errorResponse.error;
+          }
+        }
+      } catch (e) {
+        console.error('Error parsing response:', e);
+      }
+
+      if (typeof window.saturne !== 'undefined' && window.saturne.notification) {
+        window.saturne.notification.error(errorMsg);
+      }
+    },
+    complete: function () {
+      $button.prop('disabled', false);
+    }
+  });
+};
+
+/**
+ * Initialize tooltips for relaunch buttons
+ *
+ * @memberof ReedCRM_EventPro
+ *
+ * @since   1.0.0
+ * @version 1.0.0
+ */
+window.reedcrm.eventpro.initRelaunchTooltips = function () {
+  var tooltipTimeout;
+  var $currentTooltip = null;
+  var tooltipHovered = false;
+  var loadingTooltip = false;
+
+  $(document).on('mouseenter', '.reedcrm-relaunch-button', function () {
+    var $button = $(this);
+    var type = $button.data('relaunch-type');
+    var $wrapper = $button.closest('.reedcrm-relaunch-buttons');
+    var projectId = $wrapper.find('.reedcrm-modal-open').first().data('project-id');
+    var socid = $wrapper.data('socid') || '';
+
+    if ((!projectId && !socid) || !type) {
+      return;
+    }
+
+    clearTimeout(tooltipTimeout);
+
+    if ($currentTooltip) {
+      $currentTooltip.remove();
+      $currentTooltip = null;
+    }
+    tooltipHovered = false;
+    loadingTooltip = true;
+
+    var actionTypeMap = {
+      'call': 'AC_TEL',
+      'email': 'AC_EMAIL',
+      'rdv': 'AC_RDV',
+      'other': 'AC_OTH',
+      'all': 'all'
+    };
+    var actionType = actionTypeMap[type] || 'AC_OTH';
+
+    var tooltipContent = '<div class="reedcrm-relaunch-tooltip">';
+    tooltipContent += '<div class="reedcrm-relaunch-tooltip-header">';
+
+    var typeLabels = {
+      'call': 'Appels',
+      'email': 'Emails',
+      'rdv': 'RDV',
+      'other': 'Autres',
+      'all': 'Relances commerciales'
+    };
+
+    tooltipContent += '<strong>' + (typeLabels[type] || type) + '</strong>';
+    tooltipContent += '</div>';
+    tooltipContent += '<div class="reedcrm-relaunch-tooltip-content">';
+    tooltipContent += '<div class="reedcrm-relaunch-tooltip-loading">' + (typeof window.saturne !== 'undefined' && window.saturne.loader ? '' : 'Chargement...') + '</div>';
+    tooltipContent += '</div>';
+    tooltipContent += '</div>';
+
+    $currentTooltip = $(tooltipContent);
+    $currentTooltip.css({
+      position: 'absolute',
+      zIndex: 10000,
+      display: 'none'
+    });
+    $('body').append($currentTooltip);
+
+    var buttonOffset = $button.offset();
+    var buttonHeight = $button.outerHeight();
+
+    $currentTooltip.css({ visibility: 'hidden', display: 'block' });
+    var tooltipWidth = $currentTooltip.outerWidth();
+    var tooltipHeight = $currentTooltip.outerHeight();
+    $currentTooltip.css({ visibility: 'visible', display: 'none' });
+
+    var left = buttonOffset.left;
+    var top = buttonOffset.top + buttonHeight + 5;
+
+    if (left + tooltipWidth > $(window).width()) {
+      left = $(window).width() - tooltipWidth - 10;
+    }
+    if (left < 10) {
+      left = 10;
+    }
+    if (top + tooltipHeight > $(window).height()) {
+      top = buttonOffset.top - tooltipHeight - 5;
+    }
+    if (top < 10) {
+      top = 10;
+    }
+
+    $currentTooltip.css({
+      left: left + 'px',
+      top: top + 'px'
+    });
+
+    tooltipTimeout = setTimeout(function () {
+      $currentTooltip.fadeIn(200);
+      const ajaxUrl = $wrapper.find('.reedcrm-modal-open').first().data('ajax-url') || '/custom/reedcrm/ajax/get_relaunches_list.php';
+
+      $.ajax({
+        url: ajaxUrl,
+        type: 'GET',
+        data: {
+          project_id: projectId || '',
+          socid: socid,
+          action_type: actionType,
+          limit: $button.data('limit') || 0,
+          token: $('meta[name=anti-csrf-currenttoken]').attr('content') || ''
+        },
+        dataType: 'json',
+        success: function (response) {
+          loadingTooltip = false;
+          if (response && response.success && response.html) {
+            $currentTooltip.find('.reedcrm-relaunch-tooltip-content').html(response.html);
+          } else {
+            var errorMsg = (response && response.error) ? response.error : 'Erreur lors du chargement';
+            $currentTooltip.find('.reedcrm-relaunch-tooltip-content').html('<div class="reedcrm-relaunch-tooltip-empty">' + errorMsg + '</div>');
+          }
+        },
+        error: function (xhr, status, error) {
+          loadingTooltip = false;
+          var errorMsg = 'Erreur lors du chargement';
+          if (xhr.responseJSON && xhr.responseJSON.error) {
+            errorMsg = xhr.responseJSON.error;
+          } else if (xhr.status === 0) {
+            errorMsg = 'Erreur de connexion';
+          } else if (xhr.status === 404) {
+            errorMsg = 'Fichier non trouvé';
+          } else if (xhr.status === 500) {
+            errorMsg = 'Erreur serveur';
+          }
+          $currentTooltip.find('.reedcrm-relaunch-tooltip-content').html('<div class="reedcrm-relaunch-tooltip-empty">' + errorMsg + '</div>');
+          console.error('AJAX Error:', status, error, xhr);
+        }
+      });
+    }, 300);
+
+    $currentTooltip.on('mouseenter', function () {
+      tooltipHovered = true;
+      clearTimeout(tooltipTimeout);
+    });
+
+    $currentTooltip.on('mouseleave', function () {
+      tooltipHovered = false;
+      if (!loadingTooltip) {
+        $currentTooltip.fadeOut(150, function () {
+          $(this).remove();
+          $currentTooltip = null;
+        });
+      }
+    });
+  });
+
+  $(document).on('mouseleave', '.reedcrm-relaunch-button', function () {
+    clearTimeout(tooltipTimeout);
+    tooltipTimeout = setTimeout(function () {
+      if ($currentTooltip && !tooltipHovered && !loadingTooltip) {
+        $currentTooltip.fadeOut(150, function () {
+          $(this).remove();
+          $currentTooltip = null;
+        });
+      }
+    }, 150);
+  });
+};
+
+/* --- Source: kpiCustomize.js --- */
+/* Copyright (C) 2026 EVARISK <technique@evarisk.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+"use strict";
+
+/**
+ * \file    js/modules/kpiCustomize.js
+ * \ingroup reedcrm
+ * \brief   Customize mode for the opportunity KPI banner (drag reorder, hide/show, per-user persistence)
+ */
+
+if (!window.reedcrm) {
+  window.reedcrm = {};
+}
+
+window.reedcrm.kpiCustomize = {};
+window.reedcrm.kpiCustomize.dragSrc = null;
+
+/**
+ * Init
+ *
+ * @returns {void}
+ */
+window.reedcrm.kpiCustomize.init = function () {
+  window.reedcrm.kpiCustomize.event();
+};
+
+/**
+ * Bind events
+ *
+ * @returns {void}
+ */
+window.reedcrm.kpiCustomize.event = function () {
+  $(document).on('click', '.reedcrm-kpi-customize-toggle', window.reedcrm.kpiCustomize.toggle);
+  $(document).on('click', '.reedcrm-kpi-customize-reset', window.reedcrm.kpiCustomize.reset);
+  $(document).on('click', '.reedcrm-status-display-toggle', window.reedcrm.kpiCustomize.toggleStatusDisplay);
+  $(document).on('click', '.reedcrm-list-density-toggle', window.reedcrm.kpiCustomize.toggleListDensity);
+  $(document).on('click', '.kpi-hide-btn', window.reedcrm.kpiCustomize.toggleHide);
+  $(document).on('dragstart', '.saturne-kpi-card', window.reedcrm.kpiCustomize.onDragStart);
+  $(document).on('dragover', '.saturne-kpi-card', window.reedcrm.kpiCustomize.onDragOver);
+  $(document).on('dragend', '.saturne-kpi-card', window.reedcrm.kpiCustomize.onDragEnd);
+};
+
+/**
+ * Endpoint URL
+ *
+ * @returns {String} The AJAX endpoint URL
+ */
+window.reedcrm.kpiCustomize.url = function () {
+  var root = (window.saturne && window.saturne.config && window.saturne.config.urlRoot) ? window.saturne.config.urlRoot : '';
+  return root + '/custom/reedcrm/ajax/save_kpi_layout.php';
+};
+
+/**
+ * Toggle edit mode on the KPI cards bar.
+ *
+ * @param  {Event} e Click event
+ * @returns {void}
+ */
+window.reedcrm.kpiCustomize.toggle = function (e) {
+  e.preventDefault();
+  var $cards = $('.saturne-kpi-cards');
+  if (!$cards.length) {
+    return;
+  }
+
+  var entering = !$cards.hasClass('saturne-kpi-customizing');
+  $cards.toggleClass('saturne-kpi-customizing', entering);
+  $('.reedcrm-kpi-customize-toggle').toggleClass('active', entering);
+  $('.reedcrm-kpi-customize-bar').toggleClass('customizing', entering);
+
+  if (entering) {
+    $cards.find('.saturne-kpi-card').attr('draggable', 'true').each(function () {
+      if (!$(this).find('.kpi-hide-btn').length) {
+        $(this).append('<span class="kpi-hide-btn" title="Masquer / afficher"><i class="fas fa-eye-slash"></i></span>');
+      }
+    });
+  } else {
+    $cards.find('.saturne-kpi-card').removeAttr('draggable');
+    window.reedcrm.kpiCustomize.save();
+  }
+};
+
+/**
+ * Hide / show a card.
+ *
+ * @param  {Event} e Click event
+ * @returns {void}
+ */
+window.reedcrm.kpiCustomize.toggleHide = function (e) {
+  e.preventDefault();
+  e.stopPropagation();
+  $(this).closest('.saturne-kpi-card').toggleClass('saturne-kpi-card--hidden');
+  window.reedcrm.kpiCustomize.save();
+};
+
+/**
+ * Drag start
+ *
+ * @param  {Event} e Drag event
+ * @returns {void}
+ */
+window.reedcrm.kpiCustomize.onDragStart = function (e) {
+  if (!$(this).closest('.saturne-kpi-cards').hasClass('saturne-kpi-customizing')) {
+    return;
+  }
+  window.reedcrm.kpiCustomize.dragSrc = this;
+  $(this).addClass('kpi-dragging');
+  if (e.originalEvent.dataTransfer) {
+    e.originalEvent.dataTransfer.effectAllowed = 'move';
+    try { e.originalEvent.dataTransfer.setData('text/plain', ''); } catch (err) { /* IE guard */ }
+  }
+};
+
+/**
+ * Drag over: reorder live based on cursor position.
+ *
+ * @param  {Event} e Drag event
+ * @returns {void}
+ */
+window.reedcrm.kpiCustomize.onDragOver = function (e) {
+  var src = window.reedcrm.kpiCustomize.dragSrc;
+  if (!src || src === this) {
+    return;
+  }
+  e.preventDefault();
+  var rect  = this.getBoundingClientRect();
+  var after = (e.originalEvent.clientX - rect.left) > (rect.width / 2);
+  if (after) {
+    this.parentNode.insertBefore(src, this.nextSibling);
+  } else {
+    this.parentNode.insertBefore(src, this);
+  }
+};
+
+/**
+ * Drag end: persist the new order.
+ *
+ * @returns {void}
+ */
+window.reedcrm.kpiCustomize.onDragEnd = function () {
+  $(this).removeClass('kpi-dragging');
+  window.reedcrm.kpiCustomize.dragSrc = null;
+  window.reedcrm.kpiCustomize.save();
+};
+
+/**
+ * Serialize the current order + hidden cards and persist them.
+ *
+ * @returns {void}
+ */
+window.reedcrm.kpiCustomize.save = function () {
+  var order  = [];
+  var hidden = [];
+  $('.saturne-kpi-cards .saturne-kpi-card').each(function () {
+    var id = $(this).attr('data-kpi-id');
+    if (!id) {
+      return;
+    }
+    order.push(id);
+    if ($(this).hasClass('saturne-kpi-card--hidden')) {
+      hidden.push(id);
+    }
+  });
+
+  $.ajax({
+    url: window.reedcrm.kpiCustomize.url(),
+    method: 'POST',
+    dataType: 'json',
+    data: {
+      action: 'save',
+      token: window.saturne.toolbox.getToken(),
+      layout: JSON.stringify({ order: order, hidden: hidden })
+    }
+  });
+};
+
+/**
+ * Toggle the status column display (full badge vs colored dot), persisted per user.
+ *
+ * @param  {Event} e Click event
+ * @returns {void}
+ */
+window.reedcrm.kpiCustomize.toggleStatusDisplay = function (e) {
+  e.preventDefault();
+  var mode = $(this).data('mode');
+  $.ajax({
+    url: window.reedcrm.kpiCustomize.url(),
+    method: 'POST',
+    dataType: 'json',
+    data: { action: 'set_status_display', token: window.saturne.toolbox.getToken(), mode: mode },
+    success: function () { window.location.reload(); },
+    error: function () { window.location.reload(); }
+  });
+};
+
+/**
+ * Toggle the list row density (compact / comfortable), saved per user.
+ *
+ * @param  {Event} e Click event
+ * @returns {void}
+ */
+window.reedcrm.kpiCustomize.toggleListDensity = function (e) {
+  e.preventDefault();
+  var mode = $(this).data('mode');
+  $.ajax({
+    url: window.reedcrm.kpiCustomize.url(),
+    method: 'POST',
+    dataType: 'json',
+    data: { action: 'set_list_density', token: window.saturne.toolbox.getToken(), mode: mode },
+    success: function () { window.location.reload(); },
+    error: function () { window.location.reload(); }
+  });
+};
+
+/**
+ * Reset the layout to defaults.
+ *
+ * @param  {Event} e Click event
+ * @returns {void}
+ */
+window.reedcrm.kpiCustomize.reset = function (e) {
+  e.preventDefault();
+  $.ajax({
+    url: window.reedcrm.kpiCustomize.url(),
+    method: 'POST',
+    dataType: 'json',
+    data: { action: 'reset', token: window.saturne.toolbox.getToken() },
+    success: function () { window.location.reload(); },
+    error: function () { window.location.reload(); }
+  });
+};
+
+/* --- Source: projectPresets.js --- */
+/* Copyright (C) 2026 EVARISK <technique@evarisk.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+"use strict";
+
+/**
+ * \file    js/modules/projectPresets.js
+ * \ingroup reedcrm
+ * \brief   Save/delete per-user saved views in the project list presets bar
+ */
+
+if (!window.reedcrm) {
+  window.reedcrm = {};
+}
+
+window.reedcrm.projectPresets = {};
+
+/**
+ * Init
+ *
+ * @returns {void}
+ */
+window.reedcrm.projectPresets.init = function () {
+  window.reedcrm.projectPresets.event();
+};
+
+/**
+ * Bind events
+ *
+ * @returns {void}
+ */
+window.reedcrm.projectPresets.event = function () {
+  $(document).on('click', '.reedcrm-save-view', window.reedcrm.projectPresets.saveView);
+  $(document).on('click', '.saturne-list-preset-remove', window.reedcrm.projectPresets.deleteView);
+};
+
+/**
+ * Endpoint URL
+ *
+ * @returns {String} The AJAX endpoint URL
+ */
+window.reedcrm.projectPresets.url = function () {
+  var root = (window.saturne && window.saturne.config && window.saturne.config.urlRoot) ? window.saturne.config.urlRoot : '';
+  return root + '/custom/reedcrm/ajax/save_project_view.php';
+};
+
+/**
+ * Save the current filters as a named view
+ *
+ * @param  {Event} e Click event
+ * @returns {void}
+ */
+window.reedcrm.projectPresets.saveView = function (e) {
+  e.preventDefault();
+
+  var label = window.prompt('Nom de la vue ?');
+  if (!label) {
+    return;
+  }
+
+  // The list form is POST, so current filters live in #searchFormList, not in the URL.
+  var keep = new URLSearchParams();
+  var seen = {};
+  var $form = $('#searchFormList');
+  if ($form.length) {
+    $form.serializeArray().forEach(function (f) {
+      var name = f.name;
+      if (name.indexOf('search_') !== 0) {
+        return;
+      }
+      if (f.value === '' || f.value === '-1') {
+        return; // empty or "all"
+      }
+      if (/_mode$/.test(name) && f.value === 'inc') {
+        return; // default include mode, not a real filter
+      }
+      var isArray = /\[\]$/.test(name);
+      if (!isArray) {
+        if (seen[name]) {
+          return; // dedupe scalar fields (panel + column row can both be present)
+        }
+        seen[name] = true;
+      }
+      keep.append(name, f.value);
+    });
+  }
+
+  // The active preset lives in the URL, not the form
+  var urlPreset = new URLSearchParams(window.location.search).get('search_preset');
+  if (urlPreset && !keep.has('search_preset')) {
+    keep.append('search_preset', urlPreset);
+  }
+
+  $.ajax({
+    url: window.reedcrm.projectPresets.url(),
+    method: 'POST',
+    dataType: 'json',
+    data: {
+      action: 'save',
+      token: window.saturne.toolbox.getToken(),
+      label: label,
+      query: keep.toString()
+    },
+    success: function (response) {
+      if (response && response.success) {
+        window.location.reload();
+      } else {
+        window.alert((response && response.error) || 'Erreur');
+      }
+    },
+    error: function () {
+      window.alert('Erreur');
+    }
+  });
+};
+
+/**
+ * Delete a saved view
+ *
+ * @param  {Event} e Click event
+ * @returns {void}
+ */
+window.reedcrm.projectPresets.deleteView = function (e) {
+  e.preventDefault();
+  e.stopPropagation();
+
+  var key = $(this).data('remove-key');
+  if (!key) {
+    return;
+  }
+  if (!window.confirm('Supprimer cette vue ?')) {
+    return;
+  }
+
+  $.ajax({
+    url: window.reedcrm.projectPresets.url(),
+    method: 'POST',
+    dataType: 'json',
+    data: {
+      action: 'delete',
+      token: window.saturne.toolbox.getToken(),
+      key: key
+    },
+    success: function (response) {
+      if (response && response.success) {
+        window.location.reload();
+      } else {
+        window.alert((response && response.error) || 'Erreur');
+      }
+    },
+    error: function () {
+      window.alert('Erreur');
+    }
+  });
+};
+
+/* --- Source: quickcreation.js --- */
+/* Copyright (C) 2021-2025 EVARISK <technique@evarisk.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Library javascript to enable Browser notifications
+ */
+
+/**
+ * \file    js/quickcreation.js
+ * \ingroup reedcrm
+ * \brief   JavaScript quickcreation file for module ReedCRM
+ */
+
+'use strict';
+
+/**
+ * Init quickcreation JS
+ *
+ * @since   1.3.0
+ * @version 1.3.0
+ *
+ * @type {Object}
+ */
+window.reedcrm.quickcreation = {};
+
+/**
+ * Init latitude GPS
+ *
+ * @since   1.3.0
+ * @version 22.0.0
+ */
+window.reedcrm.quickcreation.latitude = null;
+
+/**
+ * Init longitude GPS
+ *
+ * @since   1.3.0
+ * @version 22.0.0
+ */
+window.reedcrm.quickcreation.longitude = null;
+
+/**
+ * QuickCreation init
+ *
+ * @since   1.3.0
+ * @version 22.0.0
+ *
+ * @returns {void}
+ */
+window.reedcrm.quickcreation.init = function() {
+  window.reedcrm.quickcreation.setAddressBlockState('searching', 'Détection de la position en cours...');
+  window.reedcrm.quickcreation.event();
+};
+
+/**
+ * QuickCreation event
+ *
+ * @since   1.3.0
+ * @version 22.0.0
+ *
+ * @returns {void}
+ */
+window.reedcrm.quickcreation.event = function() {
+
+  // Get current GPS position of navigator user
+  window.reedcrm.quickcreation.getCurrentPosition();
+
+  // Vibrate phone on submit form
+  $(document).on('submit', '.quickcreation-form', window.reedcrm.quickcreation.vibratePhone);
+
+  // Show opp percent value on range input
+  $(document).on('input', '#opp_percent', window.reedcrm.quickcreation.showOppPercentValue);
+};
+
+
+/**
+ * Get current GPS position of navigator user
+ *
+ * @since   1.3.0
+ * @version 1.3.0
+ *
+ * @return {void}
+ */
+window.reedcrm.quickcreation.getCurrentPosition = function() {
+  if (!navigator.geolocation) {
+    $('#id-container #geolocation-error').val('Geolocation is not supported by this browser.');
+    window.reedcrm.quickcreation.setAddressBlockState('error', 'Géolocalisation non supportée.');
+    return;
+  }
+
+  // Safety fallback: if browser silently ignores permission (no popup shown),
+  // the native timeout may never fire. Force error state after 12s.
+  var _geolocResolved = false;
+  var _safetyTimer = setTimeout(function() {
+    if (!_geolocResolved) {
+      _geolocResolved = true;
+      $('#id-container #geolocation-error').val('Timeout');
+      window.reedcrm.quickcreation.setAddressBlockState('error', 'Délai dépassé. Autorisez la localisation dans votre navigateur.');
+    }
+  }, 12000);
+
+  navigator.geolocation.getCurrentPosition(
+    function (position) {
+      _geolocResolved = true;
+      clearTimeout(_safetyTimer);
+      $('#id-container #geolocation-error').val('');
+      window.reedcrm.quickcreation.latitude  = position.coords.latitude;
+      window.reedcrm.quickcreation.longitude = position.coords.longitude;
+      $('#id-container #latitude').val(window.reedcrm.quickcreation.latitude);
+      $('#id-container #longitude').val(window.reedcrm.quickcreation.longitude);
+      window.reedcrm.quickcreation.resolveCurrentAddress(
+        window.reedcrm.quickcreation.latitude,
+        window.reedcrm.quickcreation.longitude
+      );
+    },
+    function (error) {
+      if (_geolocResolved) return; // safety timer already fired
+      _geolocResolved = true;
+      clearTimeout(_safetyTimer);
+      var messages = {
+        1: 'Accès à la position refusé.',
+        2: 'Position indisponible.',
+        3: 'Délai de géolocalisation dépassé.'
+      };
+      $('#id-container #geolocation-error').val(error.message || '');
+      window.reedcrm.quickcreation.setAddressBlockState('error', messages[error.code] || 'Erreur de géolocalisation.');
+    },
+    { timeout: 10000, maximumAge: 300000 }
+  );
+};
+
+/**
+ * Reverse geocode lat/lon via OSM Nominatim and display the resolved address
+ *
+ * @since   1.4.0
+ * @version 1.4.0
+ *
+ * @param {number} lat Latitude
+ * @param {number} lon Longitude
+ *
+ * @return {void}
+ */
+window.reedcrm.quickcreation.resolveCurrentAddress = function(lat, lon) {
+  $('#current-address-coords').text(lat.toFixed(6) + ' / ' + lon.toFixed(6));
+  $('#current-address-block').attr('href', 'https://www.google.com/maps/search/?api=1&query=' + lat + ',' + lon).attr('target', '_blank');
+
+  $.getJSON(
+    'https://nominatim.openstreetmap.org/reverse?lat=' + lat + '&lon=' + lon + '&format=json&addressdetails=1',
+    function (data) {
+      if (!data || !data.address) {
+        window.reedcrm.quickcreation.setAddressBlockState('error', 'Adresse introuvable.');
+        return;
+      }
+
+      var a        = data.address;
+      var road     = a.road || a.pedestrian || a.footway || '';
+      var house    = a.house_number || '';
+      var postcode = a.postcode || '';
+      var city     = a.city || a.town || a.village || '';
+      var street   = house ? house + ' ' + road : road;
+      var parts    = $.grep([street, postcode, city], function(v) { return v !== ''; });
+      var label    = parts.length > 0 ? parts.join(', ') : data.display_name;
+
+      window.reedcrm.quickcreation.setAddressBlockState('success', label);
+    }
+  ).fail(function() {
+    window.reedcrm.quickcreation.setAddressBlockState('error', 'Impossible de récupérer l\'adresse.');
+  });
+};
+
+/**
+ * Update the address block visual state
+ *
+ * @since   1.4.0
+ * @version 1.4.0
+ *
+ * @param {string} state   'loading' | 'success' | 'error'
+ * @param {string} message Text to display
+ *
+ * @return {void}
+ */
+window.reedcrm.quickcreation.setAddressBlockState = function(state, message) {
+  var $icon = $('#current-address-icon');
+  var $text = $('#current-address-text');
+  var $ko   = $('#current-address-ko');
+
+  $icon.removeClass('fa-circle-notch fa-spin fa-map-marker-alt fa-exclamation-triangle');
+  $ko.hide();
+
+  var $block = $('#current-address-block');
+
+  if (state === 'success') {
+    $icon.addClass('fa-map-marker-alt').css('color', '#2ecc71');
+    $text.css('color', '#34495e');
+    $block.addClass('is-visible');
+  } else if (state === 'error') {
+    $icon.addClass('fa-map-marker-alt').css('color', '#e74c3c');
+    $ko.show();
+    $text.css('color', '#e74c3c');
+    $block.addClass('is-visible');
+  } else {
+    $icon.addClass('fa-circle-notch fa-spin').css('color', '#3498db');
+    $text.css('color', '#94a3b8');
+    $block.removeClass('is-visible');
+  }
+
+  $text.text(message);
+};
+
+/**
+ * Do vibrate phone after submit quick creation
+ *
+ * @since   1.3.0
+ * @version 1.3.0
+ *
+ * @return {void}
+ */
+window.reedcrm.quickcreation.vibratePhone = function() {
+  if ('vibrate' in navigator) {
+    // Trigger a vibration in the form of a pattern
+    // Vibrate for 1 second, pause for 0.5 seconds,
+    // Vibrate for 0.2 seconds, pause for 0.2 seconds,
+    // Vibrate for 0.5 seconds, pause for 1 second
+    navigator.vibrate([1000, 500, 200, 200, 500, 1000]);
+  }
+  
+  var $btn = $('.btn-submit-purple');
+  if ($btn.length === 0) {
+      $btn = $('.page-footer button');
+  }
+  
+  window.saturne.loader.display($btn);
+  
+  // Disable button after a tiny delay to ensure form still submits
+  setTimeout(function() {
+      $btn.prop('disabled', true);
+  }, 10);
+  
+  // Re-enable after 5 seconds just in case the page didn't reload
+  setTimeout(function() {
+      $btn.prop('disabled', false);
+      if (window.saturne && window.saturne.loader) {
+          window.saturne.loader.remove($btn);
+      }
+  }, 5000);
+};
+
+/**
+ * Show opp percent value on range input
+ *
+ * @since   1.3.0
+ * @version 1.3.0
+ *
+ * @return {void}
+ */
+window.reedcrm.quickcreation.showOppPercentValue = function() {
+  var val = $('#opp_percent').val();
+  $('.opp_percent-value').text(val + '%');
+  $('#opp_percent').parent().get(0).style.setProperty('--val', val);
+};
+
+// Initialisation assurée par reedcrm.load_list_script() dans reedcrm.min.js
+// qui itère window.reedcrm et appelle .init() sur chaque module au document.ready.
+
+/* --- Source: quickevent.js --- */
+/* Copyright (C) 2021-2023 EVARISK <technique@evarisk.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Library javascript to enable Browser notifications
+ */
+
+"use strict";
+
+/**
+ * \file    js/quickevent.js
+ * \ingroup reedcrm
+ * \brief   JavaScript quickevent file for module ReedCRM
+ */
+
+/**
+ * Init quickevent JS
+ *
+ * @memberof ReedCRM_QuickEvent
+ *
+ * @since   1.5.0
+ * @version 1.5.0
+ *
+ * @type {Object}
+ */
+window.reedcrm.quickevent = {};
+
+/**
+ * QuickEvent init
+ *
+ * @memberof ReedCRM_QuickEvent
+ *
+ * @since   1.5.0
+ * @version 1.5.0
+ *
+ * @returns {void}
+ */
+window.reedcrm.quickevent.init = function() {
+  window.reedcrm.quickevent.event();
+};
+
+/**
+ * QuickEvent event
+ *
+ * @memberof ReedCRM_QuickEvent
+ *
+ * @since   1.5.0
+ * @version 1.5.0
+ *
+ * @returns {void}
+ */
+window.reedcrm.quickevent.event = function() {
+  $(document).on('keyup', '#label', window.reedcrm.quickevent.labelKeyUp);
+};
+
+/**
+ * QuickEvent labelkeyup
+ *
+ * @memberof ReedCRM_QuickEvent
+ *
+ * @since   1.5.0
+ * @version 1.5.0
+ *
+ * @returns {void}
+ */
+window.reedcrm.quickevent.labelKeyUp = function() {
+  if ($("#label").val().length >= (parseInt($("#label").attr("maxlength")) * 0.7)) {
+    $(".quickevent-label-warning-notice").removeClass("hidden");
+  } else {
+    $(".quickevent-label-warning-notice").addClass("hidden");
+  }
+};
+
+/* --- Source: topMenu.js --- */
+/* Copyright (C) 2026 EVARISK <technique@evarisk.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+"use strict";
+
+/**
+ * \file    js/modules/topMenu.js
+ * \ingroup reedcrm
+ * \brief   Gather the decluttered (non-CRM) top-menu entries into a "Plus" dropdown (CRM context only)
+ */
+
+if (!window.reedcrm) {
+  window.reedcrm = {};
+}
+
+window.reedcrm.topMenu = {};
+
+// Top-menu entries kept visible in the CRM context (must mirror _top-menu.scss)
+window.reedcrm.topMenu.keep = [
+  'mainmenutd_companylogo', 'mainmenutd_menu', 'mainmenutd_home', 'mainmenutd_companies',
+  'mainmenutd_commercial', 'mainmenutd_project', 'mainmenutd_agenda', 'mainmenutd_reedcrm', 'mainmenutd_'
+];
+
+/**
+ * Init
+ *
+ * @returns {void}
+ */
+window.reedcrm.topMenu.init = function () {
+  window.reedcrm.topMenu.build();
+  window.reedcrm.topMenu.event();
+};
+
+/**
+ * Events: toggle the dropdown, close on outside click.
+ *
+ * @returns {void}
+ */
+window.reedcrm.topMenu.event = function () {
+  $(document).on('click', '.reedcrm-topmenu-more-toggle', function (e) {
+    e.preventDefault();
+    $(this).closest('.reedcrm-topmenu-more').toggleClass('open');
+  });
+  $(document).on('click', function (e) {
+    if (!$(e.target).closest('.reedcrm-topmenu-more').length) {
+      $('.reedcrm-topmenu-more').removeClass('open');
+    }
+  });
+};
+
+/**
+ * Build the "Plus" dropdown from the hidden (non-kept) top-menu entries.
+ *
+ * @returns {void}
+ */
+window.reedcrm.topMenu.build = function () {
+  var $first = $('#id-top li[id^="mainmenutd_"]').first();
+  if (!$first.length || $('.reedcrm-topmenu-more').length) {
+    return;
+  }
+  var $menu = $first.parent();
+
+  var items = [];
+  $menu.children('li[id^="mainmenutd_"]').each(function () {
+    if (window.reedcrm.topMenu.keep.indexOf(this.id) !== -1) {
+      return;
+    }
+    var $a = $(this).find('a').first();
+    var href = $a.attr('href');
+    if ($a.length && href && href !== '#') {
+      // Core modules use a Font Awesome span inside .topmenuimage; external modules use
+      // a PNG set as background-image on the .topmenuimage div itself.
+      var $img = $(this).find('.topmenuimage');
+      var bg   = $img.length ? $img.css('background-image') : 'none';
+      var icon;
+      if (bg && bg.indexOf('url(') !== -1) {
+        icon = '<span class="reedcrm-topmenu-more-img" style="background-image:' + bg.replace(/"/g, '') + '"></span>';
+      } else {
+        icon = $img.html() || '<span class="fas fa-puzzle-piece"></span>';
+      }
+      items.push({ href: href, label: $a.attr('title') || $.trim($a.text()), icon: icon });
+    }
+  });
+  if (!items.length) {
+    return;
+  }
+
+  var html = '<li class="tmenu reedcrm-topmenu-more">'
+    + '<a href="#" class="tmenuimage tmenu reedcrm-topmenu-more-toggle" title="Plus">'
+    + '<div class="mainmenu topmenuimage"><span class="fas fa-ellipsis-h fa-fw pictofixedwidth"></span></div>'
+    + '<span class="mainmenuaspan">Plus</span>'
+    + '</a>'
+    + '<ul class="reedcrm-topmenu-more-panel">';
+  items.forEach(function (it) {
+    html += '<li><a href="' + it.href + '">'
+      + '<span class="reedcrm-topmenu-more-icon">' + it.icon + '</span>'
+      + '<span class="reedcrm-topmenu-more-label">' + $('<div>').text(it.label).html() + '</span>'
+      + '</a></li>';
+  });
+  html += '</ul></li>';
+
+  $menu.append(html);
+};
+
+/* --- Source: vocal-player.js --- */
+/* Copyright (C) 2021-2025 EVARISK <technique@evarisk.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * \file    js/modules/vocal-player.js
+ * \ingroup reedcrm
+ * \brief   JavaScript vocal player for module ReedCRM
+ */
+
+'use strict';
+
+if (!window.reedcrm) {
+  window.reedcrm = {};
+}
+
+window.reedcrm.vocalPlayer = {
+
+  formatTime: function(seconds) {
+    var s = Math.floor(seconds) || 0;
+    var m = Math.floor(s / 60);
+    s = s % 60;
+    return m + ':' + (s < 10 ? '0' : '') + s;
+  },
+
+  stop: function($btn) {
+    var audio    = $btn.data('rc-audio');
+    var interval = $btn.data('rc-interval');
+    if (audio && !audio.paused) { audio.pause(); }
+    if (interval) { clearInterval(interval); $btn.removeData('rc-interval'); }
+    $btn.find('i').removeClass('fa-pause').addClass('fa-play');
+    $btn.removeClass('playing');
+  },
+
+  init: function() {
+    $(document).on('click', '.reedcrm-vocal-player', function() {
+      var $btn     = $(this);
+      var url      = $btn.data('audio-url');
+      var audioObj = $btn.data('rc-audio');
+      var $time    = $btn.find('.reedcrm-vocal-time');
+
+      // Stop all other active players
+      $('.reedcrm-vocal-player').not($btn).each(function() {
+        window.reedcrm.vocalPlayer.stop($(this));
+      });
+
+      // Create audio object on first click
+      if (!audioObj) {
+        audioObj = new Audio(url);
+        $btn.data('rc-audio', audioObj);
+        audioObj.addEventListener('ended', function() {
+          window.reedcrm.vocalPlayer.stop($btn);
+        });
+      }
+
+      if (audioObj.paused) {
+        audioObj.play();
+        $btn.find('i').removeClass('fa-play').addClass('fa-pause');
+        $btn.addClass('playing');
+        var interval = setInterval(function() {
+          var cur = window.reedcrm.vocalPlayer.formatTime(audioObj.currentTime);
+          var dur = isNaN(audioObj.duration) ? '--:--' : window.reedcrm.vocalPlayer.formatTime(audioObj.duration);
+          $time.text(cur + ' / ' + dur);
+        }, 500);
+        $btn.data('rc-interval', interval);
+      } else {
+        window.reedcrm.vocalPlayer.stop($btn);
+      }
+    });
+  }
+
+};
+
+window.reedcrm.vocalPlayer.init();
+


### PR DESCRIPTION
This PR implements the inline edit and quick selection of the project's internal sales representative (`SALESREPINTERNAL`) directly in the project card banner header, next to the Origin/Provenance widget.

### Features
1. **PHP selector rendering**:
   - Fetches the currently assigned project commercial (`SALESREPINTERNAL` internal contact type).
   - Queries active Dolibarr users (`llx_user`) and constructs the `<select>` selector.
   - Injects the badge and selector side-by-side with other widgets inside the header flex container `.rcrm-co-org-row` using a JS teleport script block.
2. **JavaScript Inline Edit**:
   - In `js/modules/contact_inline.js`, registered the click event on `.inline-edit-salesrep-badge` and added `startSalesRepEdit` to open/handle the Select2 dropdown.
3. **PHP AJAX Action**:
   - In `reedcrm_quickcreation_actions_frontend.tpl.php`, added the AJAX controller logic for `updateoppsalesrep` action, which deletes the old commercial link and inserts the new one in the database.

Closes #710
