### PR TITLE
fix: resolve contact_inline.js syntax error from PR merge conflict

### DIFF
--- a/js/modules/contact_inline.js
+++ b/js/modules/contact_inline.js
@@ -366,7 +366,10 @@ window.saturne.contact_inline.startOriginEdit = function(e) {
                 aTag.show();
             }
         }, 100);
-  // Apply the material look (blue base / red invalid) on an inline editor input. Uses inline
+    });
+};
+
+// Apply the material look (blue base / red invalid) on an inline editor input. Uses inline
 // !important so it beats the backend list theme's stronger global input border rule.
 window.saturne.contact_inline.applyInputMaterial = function(el, invalid) {
     if (!el) return;

--- a/js/reedcrm.min.js
+++ b/js/reedcrm.min.js
@@ -2289,7 +2289,10 @@ window.saturne.contact_inline.startOriginEdit = function(e) {
                 aTag.show();
             }
         }, 100);
-  // Apply the material look (blue base / red invalid) on an inline editor input. Uses inline
+    });
+};
+
+// Apply the material look (blue base / red invalid) on an inline editor input. Uses inline
 // !important so it beats the backend list theme's stronger global input border rule.
 window.saturne.contact_inline.applyInputMaterial = function(el, invalid) {
     if (!el) return;


### PR DESCRIPTION
This PR fixes a JavaScript syntax error (missing closing brackets for the `startOriginEdit` function) in `contact_inline.js` and rebuilds the minified JS file, fixing the project header inline edit components rendering.

Relates to #710 and the merge of #712.
