### PR TITLE
[Réception/Expédition] Afficher la description produit/service sous chaque ligne

### DIFF
--- a/class/actions_reedcrm.class.php
+++ b/class/actions_reedcrm.class.php
@@ -275,7 +275,7 @@ class ActionsReedcrm
         // Single query (no N+1) to fetch each product description
         $descriptions = [];
         $sql  = 'SELECT rowid, description FROM ' . MAIN_DB_PREFIX . 'product';
-        $sql .= ' WHERE rowid IN (' . implode(',', array_map('intval', $productIds)) . ')';
+        $sql .= ' WHERE rowid IN (' . implode(',', array_keys($productIds)) . ')';
         $resql = $this->db->query($sql);
         if ($resql) {
             while ($obj = $this->db->fetch_object($resql)) {
@@ -285,6 +285,7 @@ class ActionsReedcrm
                     $descriptions[(int) $obj->rowid] = dol_htmlentitiesbr($desc);
                 }
             }
+            $this->db->free($resql);
         }
         if (empty($descriptions)) {
             return;

--- a/class/actions_reedcrm.class.php
+++ b/class/actions_reedcrm.class.php
@@ -236,10 +236,10 @@ class ActionsReedcrm
             }
         }
 
-        // ReedCRM: on Reception/Shipment cards, the core line views render only the (empty) line
-        // description and expose no per-line hook, so the product description never shows. We inject
-        // it client-side from a data-island computed here.
-        if (preg_match('/receptioncard|expeditioncard/', $parameters['context'])) {
+        // ReedCRM: on the validated Reception card, the core line view renders only the empty line
+        // description and exposes no per-line hook, so the product description never shows. We inject it
+        // client-side from a data-island computed here. (Shipment already shows it natively via the order line.)
+        if (strpos($parameters['context'], 'receptioncard') !== false) {
             $this->printLineProductDescriptions($object);
         }
 
@@ -248,11 +248,11 @@ class ActionsReedcrm
 
     /**
      * Emit a JSON data-island { productId: htmlDescription } and load the JS that injects each
-     * product/service description under its line, on Reception/Shipment cards. Pure-module
-     * workaround: these core views render only the (empty) line description and expose no
+     * product/service description under its line, on the validated Reception card. Pure-module
+     * workaround: that core view renders only the (empty) line description and exposes no
      * per-line hook, so the DOM is augmented client-side.
      *
-     * @param  CommonObject $object Reception or Expedition currently displayed
+     * @param  CommonObject $object Reception currently displayed
      * @return void
      */
     private function printLineProductDescriptions(CommonObject $object): void

--- a/class/actions_reedcrm.class.php
+++ b/class/actions_reedcrm.class.php
@@ -236,7 +236,64 @@ class ActionsReedcrm
             }
         }
 
+        // ReedCRM: on Reception/Shipment cards, the core line views render only the (empty) line
+        // description and expose no per-line hook, so the product description never shows. We inject
+        // it client-side from a data-island computed here.
+        if (preg_match('/receptioncard|expeditioncard/', $parameters['context'])) {
+            $this->printLineProductDescriptions($object);
+        }
+
         return 0; // or return 1 to replace standard code
+    }
+
+    /**
+     * Emit a JSON data-island { productId: htmlDescription } and load the JS that injects each
+     * product/service description under its line, on Reception/Shipment cards. Pure-module
+     * workaround: these core views render only the (empty) line description and expose no
+     * per-line hook, so the DOM is augmented client-side.
+     *
+     * @param  CommonObject $object Reception or Expedition currently displayed
+     * @return void
+     */
+    private function printLineProductDescriptions(CommonObject $object): void
+    {
+        if (empty($object->lines) || !is_array($object->lines)) {
+            return;
+        }
+
+        // Distinct predefined products on the document
+        $productIds = [];
+        foreach ($object->lines as $line) {
+            if (!empty($line->fk_product) && $line->fk_product > 0) {
+                $productIds[(int) $line->fk_product] = (int) $line->fk_product;
+            }
+        }
+        if (empty($productIds)) {
+            return;
+        }
+
+        // Single query (no N+1) to fetch each product description
+        $descriptions = [];
+        $sql  = 'SELECT rowid, description FROM ' . MAIN_DB_PREFIX . 'product';
+        $sql .= ' WHERE rowid IN (' . implode(',', array_map('intval', $productIds)) . ')';
+        $resql = $this->db->query($sql);
+        if ($resql) {
+            while ($obj = $this->db->fetch_object($resql)) {
+                $desc = trim((string) $obj->description);
+                if ($desc !== '') {
+                    // Render like the native template so the output matches the other document types
+                    $descriptions[(int) $obj->rowid] = dol_htmlentitiesbr($desc);
+                }
+            }
+        }
+        if (empty($descriptions)) {
+            return;
+        }
+
+        // Data only (JSON, escaped so it is safe inside a <script> tag) + targeted JS load
+        $json = json_encode($descriptions, JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT);
+        print "\n" . '<script type="application/json" id="reedcrm-linedesc-data">' . $json . '</script>' . "\n";
+        print '<script src="' . dol_buildpath('/reedcrm/js/reedcrm_line_description.js', 1) . '"></script>' . "\n";
     }
 
     /**

--- a/core/modules/modReedCRM.class.php
+++ b/core/modules/modReedCRM.class.php
@@ -906,6 +906,12 @@ class modReedCRM extends DolibarrModules
             }
         }
 
+        // Show product/service description inline under each document line (quotes, orders, invoices, purchase orders).
+        // Migration-safe: do not overwrite a deliberate non-default client choice (0 = Dolibarr default = unconfigured).
+        if (getDolGlobalInt('PRODUIT_DESC_IN_FORM') <= 0) {
+            dolibarr_set_const($this->db, 'PRODUIT_DESC_IN_FORM', '2', 'chaine', 0, '', $conf->entity);
+        }
+
         return $this->_init([], $options);
     }
 

--- a/core/modules/modReedCRM.class.php
+++ b/core/modules/modReedCRM.class.php
@@ -907,7 +907,7 @@ class modReedCRM extends DolibarrModules
             }
         }
 
-        // Show product/service description inline under each document line (quotes, orders, invoices, purchase orders).
+        // Show product/service description inline under each document line (quotes, orders, invoices, purchase orders, shipments; reception is handled by the ReedCRM JS hook).
         // Migration-safe: do not overwrite a deliberate non-default client choice (0 = Dolibarr default = unconfigured).
         if (getDolGlobalInt('PRODUIT_DESC_IN_FORM') <= 0) {
             dolibarr_set_const($this->db, 'PRODUIT_DESC_IN_FORM', '2', 'chaine', 0, '', $conf->entity);

--- a/core/modules/modReedCRM.class.php
+++ b/core/modules/modReedCRM.class.php
@@ -133,6 +133,8 @@ class modReedCRM extends DolibarrModules
                 'invoicereclist',
                 'invoicelist',
                 'invoicecard',
+                'receptioncard',
+                'expeditioncard',
                 'contactcard',
                 'thirdpartycard',
                 'thirdpartylist',

--- a/core/modules/modReedCRM.class.php
+++ b/core/modules/modReedCRM.class.php
@@ -134,7 +134,6 @@ class modReedCRM extends DolibarrModules
                 'invoicelist',
                 'invoicecard',
                 'receptioncard',
-                'expeditioncard',
                 'contactcard',
                 'thirdpartycard',
                 'thirdpartylist',

--- a/js/reedcrm_line_description.js
+++ b/js/reedcrm_line_description.js
@@ -1,0 +1,59 @@
+/**
+ * @file    js/reedcrm_line_description.js
+ * @brief   Inject the product/service description under each line on Reception/Shipment
+ *          cards. Data is provided as a data-island by the PHP hook. Standalone and
+ *          self-initialising: the saturne.js bootstrap is NOT loaded on Dolibarr core pages.
+ */
+(function () {
+    'use strict';
+
+    function injectLineDescriptions() {
+        var dataEl = document.getElementById('reedcrm-linedesc-data');
+        if (!dataEl) {
+            return;
+        }
+
+        var map;
+        try {
+            map = JSON.parse(dataEl.textContent || dataEl.innerHTML);
+        } catch (e) {
+            return;
+        }
+
+        var cells = document.querySelectorAll('td.linecoldescription');
+        for (var i = 0; i < cells.length; i++) {
+            var cell = cells[i];
+            // Idempotent (possible AJAX refreshes)
+            if (cell.getAttribute('data-reedcrm-desc') === '1') {
+                continue;
+            }
+
+            var link = cell.querySelector('a[href*="product/card.php?id="]');
+            if (!link) {
+                continue;
+            }
+
+            var match = link.getAttribute('href').match(/product\/card\.php\?id=(\d+)/);
+            if (!match) {
+                continue;
+            }
+
+            var desc = map[match[1]];
+            if (!desc) {
+                continue;
+            }
+
+            var span = document.createElement('span');
+            span.className = 'reedcrm-line-desc';
+            span.innerHTML = '<br>' + desc;
+            cell.appendChild(span);
+            cell.setAttribute('data-reedcrm-desc', '1');
+        }
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', injectLineDescriptions);
+    } else {
+        injectLineDescriptions();
+    }
+})();

--- a/js/reedcrm_line_description.js
+++ b/js/reedcrm_line_description.js
@@ -1,12 +1,10 @@
 /**
  * @file    js/reedcrm_line_description.js
- * @brief   Inject the product/service description under each line on Reception/Shipment
- *          cards. Data is provided as a data-island by the PHP hook. Standalone and
+ * @brief   Inject the product/service description under each line on the validated Reception
+ *          card. Data is provided as a data-island by the PHP hook. Standalone and
  *          self-initialising: the saturne.js bootstrap is NOT loaded on Dolibarr core pages.
  */
 (function () {
-    'use strict';
-
     function injectLineDescriptions() {
         var dataEl = document.getElementById('reedcrm-linedesc-data');
         if (!dataEl) {


### PR DESCRIPTION
## Résumé
Affiche la description du produit/service directement sous chaque ligne, sur les cartes de documents. 100 % dans le module — **aucune modification du cœur Dolibarr**.

- `modReedCRM::init()` pose `PRODUIT_DESC_IN_FORM=2` à l'activation (migration-safe : n'écrase pas un choix client non-défaut). → couvre **Proposition, Commande, Facture, Commande fournisseur et Expédition** via le rendu natif Dolibarr (ces lignes portent déjà la description).
- **Réception** : sa vue validée n'affiche rien nativement et n'expose aucun hook de ligne. Un hook `addMoreActionsButtons` (contexte `receptioncard`) émet une data-island JSON `{idProduit: description}`, et un JS standalone (`js/reedcrm_line_description.js`) injecte la description sous chaque ligne (`td.linecoldescription`), via l'id produit du lien déjà présent.

## Fichiers
- `core/modules/modReedCRM.class.php` : constante à l'activation + contexte de hook `receptioncard`.
- `class/actions_reedcrm.class.php` : hook + méthode `printLineProductDescriptions()` (1 requête SQL, `dol_htmlentitiesbr`, json_encode `JSON_HEX_*`).
- `js/reedcrm_line_description.js` : injection DOM autonome, idempotente.

## Vérification (Playwright, base de dev v23)
- Réception RCP2506-0009 : description affichée **1×** sous le produit.
- Expédition SH2506-0001 : description **native, sans doublon** (le périmètre du hook a été restreint à la réception pour éviter le doublon).
- Non-régression : Proposition / Commande / Facture / Cmd fournisseur inchangés ; le JS ReedCRM n'est **pas** chargé sur ces pages.
- `php -l` + `jshint` (config saturne) propres.

## ⚠️ Déploiement
Le nouveau contexte de hook `receptioncard` nécessite une **réactivation du module** chez chaque client pour être pris en compte.

Closes #711