### PR TITLE
[Vue d'ensemble projet] Barre de chaîne opportunité→encaissement (onglet Overview + procard)

### DIFF
--- a/class/actions_reedcrm.class.php
+++ b/class/actions_reedcrm.class.php
@@ -247,6 +247,38 @@ class ActionsReedcrm
     }
 
     /**
+     * Print the opportunity chain bar once at the top of the standard project Overview tab
+     * (projet/element.php). The core hook fires once per referent type in a loop, so a static
+     * guard emits the bar only once. Returns 0 (we add output, never replace the default rendering).
+     *
+     * @param  array        $parameters Hook metadata (context, ...)
+     * @param  CommonObject $object     The project currently displayed
+     * @return int
+     */
+    public function printOverviewProfit(array $parameters, CommonObject $object): int
+    {
+        global $conf, $langs;
+
+        static $done = false;
+        if ($done || strpos($parameters['context'], 'projectOverview') === false) {
+            return 0;
+        }
+        if (empty($object->id)) {
+            return 0;
+        }
+        $done = true;
+
+        require_once __DIR__ . '/../lib/reedcrm.lib.php';
+        $reedcrmChainDocs = reedcrm_get_pwa_projects_documents([$object->id]);
+        $chainBarDocs     = $reedcrmChainDocs[$object->id] ?? [];
+
+        print reedcrm_chain_bar_styles();
+        include __DIR__ . '/../core/tpl/frontend/reedcrm_opportunity_chain_bar.tpl.php';
+
+        return 0;
+    }
+
+    /**
      * Emit a JSON data-island { productId: htmlDescription } and load the JS that injects each
      * product/service description under its line, on the validated Reception card. Pure-module
      * workaround: that core view renders only the (empty) line description and exposes no

--- a/core/modules/modReedCRM.class.php
+++ b/core/modules/modReedCRM.class.php
@@ -124,6 +124,7 @@ class modReedCRM extends DolibarrModules
             'hooks' => [
                 'thirdpartycomm',
                 'projectcard',
+                'projectOverview',
                 'projectlist',
                 'projectdao',
                 'propalcard',

--- a/core/tpl/frontend/reedcrm_opportunities_list_frontend.tpl.php
+++ b/core/tpl/frontend/reedcrm_opportunities_list_frontend.tpl.php
@@ -123,24 +123,6 @@ $pwaDocs = reedcrm_get_pwa_projects_documents($pwaProjectIds);
     .pwa-linked-check { color:#38a169; margin-left:8px; font-size:0.8em; }
     .pwa-contact-loading-inline { padding:8px 12px; color:#64748b; font-size:0.83em; display:flex; align-items:center; gap:6px; }
 
-    /* PWA Documents progress-bar style */
-    .pwa-doc-bar { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; background: #f8fafc; padding: 8px 10px; border-radius: 8px; border: 1px solid #e2e8f0; margin-top: 10px; width: 100%; box-sizing: border-box; }
-    .pwa-doc-item { display: inline-flex; align-items: center; gap: 6px; font-size: 0.85em; background: #fff; padding: 4px 10px; border-radius: 6px; border: 1px solid #cbd5e0; color: #475569; box-shadow: 0 1px 2px rgba(0,0,0,0.05); }
-    .pwa-doc-item.na { border-style: dashed; color: #94a3b8; background: #fdfdfd; box-shadow: none; }
-    .pwa-doc-item a { color: #1d4ed8; font-weight: 600; text-decoration: none; border-bottom: 1px dashed #cbd5e0; }
-    .pwa-doc-item a:hover { color: #2563eb; }
-    .pwa-doc-item { position: relative; }
-    .pwa-doc-item.is-done { background:#e7f5ea; border-color:#bfe3c7; color:#1f8a3b; }
-    .pwa-doc-item.is-current { background:#e8f0fe; border-color:#3b76e8; box-shadow:0 0 0 2px rgba(59,118,232,.25); color:#1f57c3; }
-    .pwa-doc-item.is-todo { background:#fafbfc; border-style:dashed; color:#94a3b8; box-shadow:none; }
-    .pwa-doc-item.has-warn { border-color:#e8923b !important; box-shadow:0 0 0 2px rgba(232,146,59,.25); }
-    .pwa-doc-item.has-err { border-color:#d34a4a !important; box-shadow:0 0 0 2px rgba(211,74,74,.25); }
-    .pwa-doc-badge { position:absolute; top:-7px; right:-7px; width:16px; height:16px; border-radius:50%; color:#fff; font-size:10px; line-height:16px; text-align:center; background:#e8923b; }
-    .pwa-doc-badge.err { background:#d34a4a; }
-    .pwa-doc-curtag { position:absolute; top:-8px; left:50%; transform:translateX(-50%); background:#3b76e8; color:#fff; font-size:8px; padding:1px 6px; border-radius:8px; font-weight:700; white-space:nowrap; }
-    .pwa-doc-bar.icons-only .pwa-doc-item { padding:0; width:34px; height:34px; justify-content:center; }
-    .pwa-doc-bar.icons-only .pwa-doc-label, .pwa-doc-bar.icons-only .pwa-doc-item > span:not(.pwa-doc-badge), .pwa-doc-bar.icons-only .pwa-doc-item > a { display:none; }
-    .pwa-doc-label { font-weight: 500; color: #64748b; }
 </style>
 
 <div class="page-content" style="margin-top: 5px; max-width: 1000px; margin: 5px auto 0 auto;">
@@ -408,57 +390,12 @@ $pwaDocs = reedcrm_get_pwa_projects_documents($pwaProjectIds);
 
         </div><!-- /ROW 3 -->
 
-        <!-- ROW DOCS BAR (Configurable pieces) -->
+        <!-- ROW DOCS BAR (chain bar fragment, shared) -->
         <?php
-        $enabledPieces = [];
-        if (!empty($conf->global->REEDCRM_PWA_SHOW_OPP_AMOUNT))     $enabledPieces['montant']        = ['icon' => 'fas fa-wallet'];
-        if (!empty($conf->global->REEDCRM_PWA_SHOW_PROPAL))         $enabledPieces['propal']         = ['icon' => 'fas fa-file-signature'];
-        if (!empty($conf->global->REEDCRM_PWA_SHOW_COMMANDE))       $enabledPieces['commande']       = ['icon' => 'fas fa-shopping-cart'];
-        if (!empty($conf->global->REEDCRM_PWA_SHOW_COMMANDE_FOURN)) $enabledPieces['commande_fourn'] = ['icon' => 'fas fa-shopping-bag'];
-        if (!empty($conf->global->REEDCRM_PWA_SHOW_RECEPTION))      $enabledPieces['reception']      = ['icon' => 'fas fa-dolly'];
-        if (!empty($conf->global->REEDCRM_PWA_SHOW_FACTURE_FOURN))  $enabledPieces['facture_fourn']  = ['icon' => 'fas fa-receipt'];
-        if (!empty($conf->global->REEDCRM_PWA_SHOW_EXPEDITION))     $enabledPieces['expedition']     = ['icon' => 'fas fa-shipping-fast'];
-        if (!empty($conf->global->REEDCRM_PWA_SHOW_FACTURE))        $enabledPieces['facture']        = ['icon' => 'fas fa-file-invoice-dollar'];
-        if (!empty($conf->global->REEDCRM_PWA_SHOW_PAYMENT))        $enabledPieces['payment']        = ['icon' => 'fas fa-coins'];
-
-        if (!empty($enabledPieces)) :
-            $projectDocs  = $pwaDocs[$project->id] ?? [];
-            $chain        = reedcrm_compute_opportunity_chain($projectDocs);
-            $iconsOnly    = !empty($conf->global->REEDCRM_PWA_PIECES_ICONS_ONLY);
+        print reedcrm_chain_bar_styles(); // emitted once per page (static guard)
+        $chainBarDocs = $pwaDocs[$project->id] ?? [];
+        include __DIR__ . '/reedcrm_opportunity_chain_bar.tpl.php';
         ?>
-            <div class="pwa-doc-bar<?php echo $iconsOnly ? ' icons-only' : ''; ?>">
-                <?php foreach ($enabledPieces as $key => $item) :
-                    $doc    = $projectDocs[$key] ?? null;
-                    $state  = $chain[$key]['state'] ?? 'todo';
-                    $issues = $chain[$key]['issues'] ?? [];
-                    $hasErr = false; $hasWarn = false; $issueMsgs = [];
-                    foreach ($issues as $iss) { if ($iss['level'] === 'err') { $hasErr = true; } else { $hasWarn = true; } $issueMsgs[] = $iss['msg']; }
-                    $label  = $langs->trans('PwaPieceLabel_' . $key);
-                    $statusLabel = '';
-                    if ($doc && !empty($doc['status'])) {
-                        $statusKey   = 'PwaPieceStatus_' . $key . '_' . (int) $doc['status'];
-                        $statusTrans = $langs->trans($statusKey);
-                        // Only show a status chip when a label is actually defined (otherwise trans() returns the raw key)
-                        $statusLabel = ($statusTrans !== $statusKey) ? $statusTrans : '';
-                    }
-                    $valueText = $doc ? ($doc['ref'] . ($doc['amount'] !== null ? ' · ' . price($doc['amount'], 0, '', 11, -1, -1, 'auto') : '')) : 'NA';
-                    $tooltip = trim($label . ' · ' . $valueText . ($statusLabel ? ' · ' . $statusLabel : '') . ($issueMsgs ? ' — ' . implode(' ; ', $issueMsgs) : ''));
-                    $cls = 'pwa-doc-item is-' . $state . ($doc ? '' : ' na') . ($hasErr ? ' has-err' : ($hasWarn ? ' has-warn' : ''));
-                ?>
-                    <div class="<?php echo $cls; ?>" title="<?php echo dol_escape_htmltag($tooltip); ?>">
-                        <?php if ($state === 'current') : ?><span class="pwa-doc-curtag"><?php echo $langs->trans('PwaCurrentStep'); ?></span><?php endif; ?>
-                        <?php if ($hasErr || $hasWarn) : ?><span class="pwa-doc-badge<?php echo $hasErr ? ' err' : ''; ?>"><?php echo $hasErr ? '!' : '⚠'; ?></span><?php endif; ?>
-                        <i class="<?php echo $item['icon']; ?>"></i>
-                        <span class="pwa-doc-label"><?php echo $label; ?> :</span>
-                        <?php if ($doc) : ?>
-                            <a href="<?php echo $doc['url']; ?>" class="prevent-edit-click"><?php echo $doc['ref'] . ($doc['amount'] !== null ? ' - ' . price($doc['amount'], 0, '', 11, -1, -1, 'auto') : ''); ?><?php echo $statusLabel ? ' · ' . $statusLabel : ''; ?></a>
-                        <?php else : ?>
-                            <span>NA</span>
-                        <?php endif; ?>
-                    </div>
-                <?php endforeach; ?>
-            </div>
-        <?php endif; ?>
 
     </div><!-- /pwa-card -->
 

--- a/core/tpl/frontend/reedcrm_opportunity_chain_bar.tpl.php
+++ b/core/tpl/frontend/reedcrm_opportunity_chain_bar.tpl.php
@@ -1,0 +1,76 @@
+<?php
+/* Copyright (C) 2023-2025 EVARISK <technique@evarisk.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * \file    core/tpl/frontend/reedcrm_opportunity_chain_bar.tpl.php
+ * \ingroup reedcrm
+ * \brief   Reusable fragment: opportunity->payment chain bar for ONE project.
+ *          Expects $chainBarDocs (= reedcrm_get_pwa_projects_documents([$id])[$id], may be []).
+ *          Uses globals $conf/$langs; chain logic in reedcrm_compute_opportunity_chain().
+ */
+if (!defined('DOL_DOCUMENT_ROOT')) {
+    exit;
+}
+
+$enabledPieces = [];
+if (!empty($conf->global->REEDCRM_PWA_SHOW_OPP_AMOUNT))     $enabledPieces['montant']        = ['icon' => 'fas fa-wallet'];
+if (!empty($conf->global->REEDCRM_PWA_SHOW_PROPAL))         $enabledPieces['propal']         = ['icon' => 'fas fa-file-signature'];
+if (!empty($conf->global->REEDCRM_PWA_SHOW_COMMANDE))       $enabledPieces['commande']       = ['icon' => 'fas fa-shopping-cart'];
+if (!empty($conf->global->REEDCRM_PWA_SHOW_COMMANDE_FOURN)) $enabledPieces['commande_fourn'] = ['icon' => 'fas fa-shopping-bag'];
+if (!empty($conf->global->REEDCRM_PWA_SHOW_RECEPTION))      $enabledPieces['reception']      = ['icon' => 'fas fa-dolly'];
+if (!empty($conf->global->REEDCRM_PWA_SHOW_FACTURE_FOURN))  $enabledPieces['facture_fourn']  = ['icon' => 'fas fa-receipt'];
+if (!empty($conf->global->REEDCRM_PWA_SHOW_EXPEDITION))     $enabledPieces['expedition']     = ['icon' => 'fas fa-shipping-fast'];
+if (!empty($conf->global->REEDCRM_PWA_SHOW_FACTURE))        $enabledPieces['facture']        = ['icon' => 'fas fa-file-invoice-dollar'];
+if (!empty($conf->global->REEDCRM_PWA_SHOW_PAYMENT))        $enabledPieces['payment']        = ['icon' => 'fas fa-coins'];
+
+if (!empty($enabledPieces)) :
+    $projectDocs = (isset($chainBarDocs) && is_array($chainBarDocs)) ? $chainBarDocs : [];
+    $chain       = reedcrm_compute_opportunity_chain($projectDocs);
+    $iconsOnly   = !empty($conf->global->REEDCRM_PWA_PIECES_ICONS_ONLY);
+    ?>
+    <div class="pwa-doc-bar<?php echo $iconsOnly ? ' icons-only' : ''; ?>">
+        <?php foreach ($enabledPieces as $key => $item) :
+            $doc    = $projectDocs[$key] ?? null;
+            $state  = $chain[$key]['state'] ?? 'todo';
+            $issues = $chain[$key]['issues'] ?? [];
+            $hasErr = false; $hasWarn = false; $issueMsgs = [];
+            foreach ($issues as $iss) { if ($iss['level'] === 'err') { $hasErr = true; } else { $hasWarn = true; } $issueMsgs[] = $iss['msg']; }
+            $label  = $langs->trans('PwaPieceLabel_' . $key);
+            $statusLabel = '';
+            if ($doc && !empty($doc['status'])) {
+                $statusKey   = 'PwaPieceStatus_' . $key . '_' . (int) $doc['status'];
+                $statusTrans = $langs->trans($statusKey);
+                $statusLabel = ($statusTrans !== $statusKey) ? $statusTrans : '';
+            }
+            $valueText = $doc ? ($doc['ref'] . ($doc['amount'] !== null ? ' · ' . price($doc['amount'], 0, '', 11, -1, -1, 'auto') : '')) : 'NA';
+            $tooltip = trim($label . ' · ' . $valueText . ($statusLabel ? ' · ' . $statusLabel : '') . ($issueMsgs ? ' — ' . implode(' ; ', $issueMsgs) : ''));
+            $cls = 'pwa-doc-item is-' . $state . ($doc ? '' : ' na') . ($hasErr ? ' has-err' : ($hasWarn ? ' has-warn' : ''));
+            ?>
+            <div class="<?php echo $cls; ?>" title="<?php echo dol_escape_htmltag($tooltip); ?>">
+                <?php if ($state === 'current') : ?><span class="pwa-doc-curtag"><?php echo $langs->trans('PwaCurrentStep'); ?></span><?php endif; ?>
+                <?php if ($hasErr || $hasWarn) : ?><span class="pwa-doc-badge<?php echo $hasErr ? ' err' : ''; ?>"><?php echo $hasErr ? '!' : '⚠'; ?></span><?php endif; ?>
+                <i class="<?php echo $item['icon']; ?>"></i>
+                <span class="pwa-doc-label"><?php echo $label; ?> :</span>
+                <?php if ($doc) : ?>
+                    <a href="<?php echo $doc['url']; ?>" class="prevent-edit-click"><?php echo $doc['ref'] . ($doc['amount'] !== null ? ' - ' . price($doc['amount'], 0, '', 11, -1, -1, 'auto') : ''); ?><?php echo $statusLabel ? ' · ' . $statusLabel : ''; ?></a>
+                <?php else : ?>
+                    <span>NA</span>
+                <?php endif; ?>
+            </div>
+        <?php endforeach; ?>
+    </div>
+<?php endif; ?>

--- a/lib/reedcrm.lib.php
+++ b/lib/reedcrm.lib.php
@@ -309,3 +309,37 @@ function reedcrm_compute_opportunity_chain(array $docs): array
 
     return $chain;
 }
+
+/**
+ * Return the <style> block for the opportunity chain bar, once per request only.
+ * Shared by the PWA opportunities list, the project Overview hook and procard.php.
+ *
+ * @return string The <style> block on the first call, '' afterwards.
+ */
+function reedcrm_chain_bar_styles(): string
+{
+    static $emitted = false;
+    if ($emitted) {
+        return '';
+    }
+    $emitted = true;
+
+    return '<style>
+    .pwa-doc-bar { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; background: #f8fafc; padding: 8px 10px; border-radius: 8px; border: 1px solid #e2e8f0; margin-top: 10px; width: 100%; box-sizing: border-box; }
+    .pwa-doc-item { position: relative; display: inline-flex; align-items: center; gap: 6px; font-size: 0.85em; background: #fff; padding: 4px 10px; border-radius: 6px; border: 1px solid #cbd5e0; color: #475569; box-shadow: 0 1px 2px rgba(0,0,0,0.05); }
+    .pwa-doc-item.na { border-style: dashed; color: #94a3b8; background: #fdfdfd; box-shadow: none; }
+    .pwa-doc-item a { color: #1d4ed8; font-weight: 600; text-decoration: none; border-bottom: 1px dashed #cbd5e0; }
+    .pwa-doc-item a:hover { color: #2563eb; }
+    .pwa-doc-item.is-done { background:#e7f5ea; border-color:#bfe3c7; color:#1f8a3b; }
+    .pwa-doc-item.is-current { background:#e8f0fe; border-color:#3b76e8; box-shadow:0 0 0 2px rgba(59,118,232,.25); color:#1f57c3; }
+    .pwa-doc-item.is-todo { background:#fafbfc; border-style:dashed; color:#94a3b8; box-shadow:none; }
+    .pwa-doc-item.has-warn { border-color:#e8923b !important; box-shadow:0 0 0 2px rgba(232,146,59,.25); }
+    .pwa-doc-item.has-err { border-color:#d34a4a !important; box-shadow:0 0 0 2px rgba(211,74,74,.25); }
+    .pwa-doc-badge { position:absolute; top:-7px; right:-7px; width:16px; height:16px; border-radius:50%; color:#fff; font-size:10px; line-height:16px; text-align:center; background:#e8923b; }
+    .pwa-doc-badge.err { background:#d34a4a; }
+    .pwa-doc-curtag { position:absolute; top:-8px; left:50%; transform:translateX(-50%); background:#3b76e8; color:#fff; font-size:8px; padding:1px 6px; border-radius:8px; font-weight:700; white-space:nowrap; }
+    .pwa-doc-bar.icons-only .pwa-doc-item { padding:0; width:34px; height:34px; justify-content:center; }
+    .pwa-doc-bar.icons-only .pwa-doc-label, .pwa-doc-bar.icons-only .pwa-doc-item > span:not(.pwa-doc-badge), .pwa-doc-bar.icons-only .pwa-doc-item > a { display:none; }
+    .pwa-doc-label { font-weight: 500; color: #64748b; }
+</style>';
+}

--- a/view/procard.php
+++ b/view/procard.php
@@ -398,6 +398,15 @@ if (empty($action)) {
     saturne_get_fiche_head($object, 'event', $title);
     saturne_banner_tab($object);
 
+    // ReedCRM: opportunity chain bar (projects only)
+    if ($object->element === 'project') {
+        require_once __DIR__ . '/../lib/reedcrm.lib.php';
+        $reedcrmChainDocs = reedcrm_get_pwa_projects_documents([$object->id]);
+        $chainBarDocs     = $reedcrmChainDocs[$object->id] ?? [];
+        print reedcrm_chain_bar_styles();
+        include __DIR__ . '/../core/tpl/frontend/reedcrm_opportunity_chain_bar.tpl.php';
+    }
+
     print '<div class="fichecenter">';
 
     print '<div class="fichehalfleft">';


### PR DESCRIPTION
Suite de #700 : réutilise la barre de chaîne (avancement + incohérences) pour **un** projet sur ses vues d'ensemble. 100 % module, aucune modif cœur Dolibarr.

## Changements
1. **Factorisation (DRY)** : le rendu de la barre #700 est extrait dans un **fragment réutilisable** `core/tpl/frontend/reedcrm_opportunity_chain_bar.tpl.php` + un helper CSS `reedcrm_chain_bar_styles()` (émis 1×/page, garde statique). La liste PWA #700 utilise désormais le fragment (rendu **identique**, vérifié).
2. **Onglet Vue d'ensemble** (`projet/element.php`, page cœur) : hook reedcrm `printOverviewProfit` (contexte `projectOverview`, garde statique → 1 seule barre) qui injecte styles + fragment du projet courant.
3. **`procard.php`** (fiche projet reedcrm) : barre sous le banner (projets uniquement, garde `$object->element === 'project'`).

## Vérification (Playwright live, projet PJ2603-6329)
- Liste PWA : non-régression OK (rendu identique, **1 seul** bloc de styles, modes complet **et** pictos).
- `element.php` : **1** barre en tête de l'onglet, états/incohérences corrects.
- `procard.php` : **1** barre sous le banner, données réelles (Amount 14 850€, Quote *Billed* ⚠, Sales Order NA !, Cust Inv CURRENT ⚠, Payment NA !).
- `php -l` OK sur les 6 fichiers.

## Notes
- Réutilise `reedcrm_compute_opportunity_chain()` (#700, déjà sur develop).
- Le nouveau contexte de hook `projectOverview` nécessite une **réactivation module** chez chaque client.

Closes #716