### PR TITLE
[Expedition] Option : date d'expédition = date de création

### DIFF
--- a/admin/setup.php
+++ b/admin/setup.php
@@ -585,6 +585,20 @@ print '<td class="center">';
 print ajax_constantonoff('REEDCRM_EVENT_CATEGORIES_VISIBLE');
 print '</td></td><td></td></tr>';
 
+// EXPEDITION
+print '<tr class="oddeven"><td colspan="4" class="center"><div class="titre inline-block">' . $langs->trans('Configs', $langs->transnoentities('Shipments')) . '</div></td></tr>';
+
+// ShippingDateEqualsCreationDate
+print '<tr class="oddeven"><td>';
+print $langs->trans('ShippingDateEqualsCreationDate');
+print '</td><td>';
+print $langs->trans('ShippingDateEqualsCreationDateHelp');
+print '</td>';
+
+print '<td class="center">';
+print ajax_constantonoff('REEDCRM_EXPEDITION_SHIPPING_DATE_AS_CREATION_DATE');
+print '</td><td></td></tr>';
+
 print '</table>';
 print '<div class="tabsAction"><input type="submit" class="butAction" name="save" value="' . $langs->trans('Save') . '"></div>';
 print '</form>';

--- a/core/triggers/interface_99_modReedcrm_ReedcrmTriggers.class.php
+++ b/core/triggers/interface_99_modReedcrm_ReedcrmTriggers.class.php
@@ -159,6 +159,18 @@ class InterfaceReedCRMTriggers extends DolibarrTriggers
         $actioncomm->percentage  = -1;
 
         switch ($action) {
+            case 'SHIPPING_CREATE':
+                // ReedCRM : si aucune date d'expédition n'a été saisie, l'aligner sur la date de création.
+                if (getDolGlobalInt('REEDCRM_EXPEDITION_SHIPPING_DATE_AS_CREATION_DATE') > 0
+                    && empty($object->date_shipping) && empty($object->date_expedition)
+                    && !empty($object->date_creation) && $object->id > 0) {
+                    if ($object->setShippingDate($user, $object->date_creation) < 0) {
+                        $this->errors[] = $object->error;
+                        return -1;
+                    }
+                }
+                break;
+
             case 'BILL_CREATE' :
             case 'BILLREC_CREATE' :
                 $object->fetch($object->id);

--- a/langs/en_US/reedcrm.lang
+++ b/langs/en_US/reedcrm.lang
@@ -466,3 +466,7 @@ PropalStatusValidated = Validated (Open)
 PropalStatusSigned = Signed / Accepted
 PropalStatusNotSigned = Not signed / Refused
 PropalStatusBilled = Billed
+
+# Expedition
+ShippingDateEqualsCreationDate = Set shipping date equal to creation date
+ShippingDateEqualsCreationDateHelp = When a shipment is created, if no shipping date is entered, it automatically takes the creation date.

--- a/langs/fr_FR/reedcrm.lang
+++ b/langs/fr_FR/reedcrm.lang
@@ -474,3 +474,7 @@ PwaPieceStatus_facture_2 = Payée
 PwaPieceStatus_facture_3 = Abandonnée
 
 App-ReedCRM = App-ReedCRM
+
+# Expedition
+ShippingDateEqualsCreationDate = Aligner la date d'expédition sur la date de création
+ShippingDateEqualsCreationDateHelp = À la création d'une expédition, si aucune date d'expédition n'est saisie, elle prend automatiquement la date de création.

--- a/lib/reedcrm.lib.php
+++ b/lib/reedcrm.lib.php
@@ -32,7 +32,7 @@ function reedcrm_admin_prepare_head(): array
     global $conf, $langs;
 
     // Load translation files required by the page
-    saturne_load_langs(['products']);
+    saturne_load_langs(['products', 'sendings']);
 
     // Initialize values
     $h = 0;


### PR DESCRIPTION
Closes #722

## Résumé
Ajoute une option de configuration ReedCRM (`REEDCRM_EXPEDITION_SHIPPING_DATE_AS_CREATION_DATE`, désactivée par défaut) qui, à la création d'une expédition, aligne la **date d'expédition** sur la **date de création** — **uniquement si aucune date d'expédition n'a été saisie**. Implémenté via le trigger `SHIPPING_CREATE`.

## Changements
- **admin/setup.php** : section « Expéditions » + toggle `ajax_constantonoff`.
- **lib/reedcrm.lib.php** : chargement de la langue coeur `sendings` pour l'en-tête de section.
- **core/triggers/…ReedcrmTriggers.class.php** : case `SHIPPING_CREATE` → `Expedition::setShippingDate($user, $object->date_creation)` si la date d'expédition est vide.
- **langs/fr_FR + en_US/reedcrm.lang** : libellé + aide.

## Vérification (live, BDD)
3 scénarios validés via test d'intégration sur le trigger (ligne sauvegardée/restaurée) :
- ON + date vide → `date_expedition` = `date_creation` ✅
- ON + date saisie → date saisie conservée ✅
- OFF + date vide → reste NULL ✅

Spec & plan : `docs/superpowers/specs/2026-06-02-shipping-date-equals-creation-date-design.md`