### PR TITLE
#726 [CallList] feat: liste d'appels via la liste générique Saturne

### DIFF
--- a/class/actions_reedcrm.class.php
+++ b/class/actions_reedcrm.class.php
@@ -1518,6 +1518,41 @@ class ActionsReedcrm
     }
 
     /**
+     * Overloading the saturneExtendGetObjectsMetadata hook : register ReedCRM objects in the
+     * generic saturne object registry so they can use saturne_list.php, the agenda, attendants, etc.
+     *
+     * @param  array $parameters Hook metadatas (objectsMetadata, objectType)
+     * @return int               0 < on error, 0 on success, 1 to replace standard code
+     */
+    public function saturneExtendGetObjectsMetadata(array $parameters): int
+    {
+        $this->results['call_list'] = [
+            'mainmenu'       => 'reedcrm',
+            'leftmenu'       => 'call_list',
+            'langs'          => 'CallList',
+            'langfile'       => 'reedcrm@reedcrm',
+            'picto'          => 'fontawesome_fa-phone_fas_#63ACC9',
+            'color'          => '#63ACC9',
+            'class_name'     => 'CallList',
+            'name_field'     => 'ref',
+            'post_name'      => 'fk_call_list',
+            'link_name'      => 'call_list',
+            'tab_type'       => 'call_list',
+            'table_element'  => 'reedcrm_call_list',
+            'hook_name_card' => 'call_listcard',
+            'hook_name_list' => 'call_list_list',
+            'create_url'     => 'custom/reedcrm/view/call_list_card.php',
+            'list_url'       => 'custom/reedcrm/view/call_list_list.php',
+            'defaultsort'    => 't.rowid',
+            'defaultorder'   => 'DESC',
+            'class_path'     => 'custom/reedcrm/class/calllist.class.php',
+            'lib_path'       => 'custom/reedcrm/lib/reedcrm_call_list.lib.php',
+        ];
+
+        return 0; // or return 1 to replace standard code
+    }
+
+    /**
      * Overloading the saturneListAddCustomFields hook : inject custom fields for propal list
      *
      * @param  array        $parameters Hook metadatas (objectType, excludeFields)
@@ -1925,6 +1960,12 @@ class ActionsReedcrm
                 $this->results     = [$key => $fn($parameters, $object)];
                 return 1;
             }
+        }
+
+        // Call list: render the ref as a clickable link to the card (generic loop prints it as plain text)
+        if (strpos($parameters['context'], 'call_list_list') !== false && $parameters['key'] === 'ref') {
+            $this->results = ['ref' => $object->getNomUrl(1)];
+            return 1;
         }
 
         return 0; // or return 1 to replace standard code

--- a/core/modules/modReedCRM.class.php
+++ b/core/modules/modReedCRM.class.php
@@ -543,7 +543,7 @@ class modReedCRM extends DolibarrModules
             'prefix'   => '<i class="fas fa-phone pictofixedwidth"></i>',
             'mainmenu' => 'reedcrm',
             'leftmenu' => 'call_list',
-            'url'      => '/reedcrm/view/call_list_list.php',
+            'url'      => '/custom/saturne/view/saturne_list.php?object_type=call_list',
             'langs'    => 'reedcrm@reedcrm',
             'position' => 1000 + $r,
             'enabled'  => 'isModEnabled(\'reedcrm\')',

--- a/langs/en_US/reedcrm.lang
+++ b/langs/en_US/reedcrm.lang
@@ -122,6 +122,9 @@ ReedCRMStatusAsBadge = Status: badge
 CallList = Call list
 CallLists = Call lists
 NewCallList = New call list
+# Derived keys auto-built by the generic saturne_list.php from the element name (call_list)
+Call_listList = Call lists
+NewCall_list = New call list
 CallListStatus0 = Draft
 CallListStatus1 = Active
 CallListStatus2 = Archived

--- a/langs/fr_FR/reedcrm.lang
+++ b/langs/fr_FR/reedcrm.lang
@@ -375,6 +375,9 @@ ReedCRMStatusAsBadge = État : pastille
 CallList = Liste d'appel
 CallLists = Listes d'appel
 NewCallList = Nouvelle liste d'appel
+# Derived keys auto-built by the generic saturne_list.php from the element name (call_list)
+Call_listList = Listes d'appel
+NewCall_list = Nouvelle liste d'appel
 CallListStatus0 = Brouillon
 CallListStatus1 = Active
 CallListStatus2 = Archivée

--- a/view/call_list_card.php
+++ b/view/call_list_card.php
@@ -156,7 +156,7 @@ if (empty($resHook)) {
     // Delete
     if ($action === 'confirm_delete' && GETPOST('confirm') === 'yes' && $permissiontodelete) {
         $object->delete($user);
-        header('Location: ' . dol_buildpath('/custom/reedcrm/view/call_list_list.php', 1));
+        header('Location: ' . dol_buildpath('/custom/saturne/view/saturne_list.php', 1) . '?object_type=call_list');
         exit;
     }
 
@@ -331,7 +331,7 @@ if ($show === 'notes' && $object->id > 0) {
     $head = call_list_prepare_head($object);
     print dol_get_fiche_head($head, 'notes', $title, -1, 'fontawesome_fa-phone_fas_#63ACC9');
 
-    $morehtml = '<a href="' . dol_buildpath('/custom/reedcrm/view/call_list_list.php', 1) . '">' . $langs->trans('BackToList') . '</a>';
+    $morehtml = '<a href="' . dol_buildpath('/custom/saturne/view/saturne_list.php', 1) . '?object_type=call_list">' . $langs->trans('BackToList') . '</a>';
     saturne_banner_tab($object, 'ref', $morehtml, 1, 'ref', 'ref', '', false);
 
     print '<div class="fichecenter">';
@@ -376,7 +376,7 @@ if ($object->id > 0) {
     $head = call_list_prepare_head($object);
     print dol_get_fiche_head($head, 'card', $title, -1, 'fontawesome_fa-phone_fas_#63ACC9');
 
-    $morehtml = '<a href="' . dol_buildpath('/custom/reedcrm/view/call_list_list.php', 1) . '">' . $langs->trans('BackToList') . '</a>';
+    $morehtml = '<a href="' . dol_buildpath('/custom/saturne/view/saturne_list.php', 1) . '?object_type=call_list">' . $langs->trans('BackToList') . '</a>';
     saturne_banner_tab($object, 'ref', $morehtml, 1, 'ref', 'ref', '', false);
 
     // Confirm dialogs

--- a/view/call_list_list.php
+++ b/view/call_list_list.php
@@ -18,7 +18,7 @@
 /**
  * \file    view/call_list_list.php
  * \ingroup reedcrm
- * \brief   List of call lists
+ * \brief   Backward-compatible redirect to the generic saturne list for call lists
  */
 
 // Load ReedCRM environment
@@ -30,137 +30,14 @@ if (file_exists('../reedcrm.main.inc.php')) {
     die('Include of reedcrm main fails');
 }
 
-require_once __DIR__ . '/../class/calllist.class.php';
-
-global $conf, $db, $hookmanager, $langs, $user;
-
-saturne_load_langs();
-
-$action      = GETPOST('action', 'aZ09');
-$contextpage = GETPOST('contextpage', 'aZ') ? GETPOST('contextpage', 'aZ') : 'call_list_list';
-$backtopage  = GETPOST('backtopage', 'alpha');
-$sortfield   = GETPOST('sortfield', 'aZ09comma');
-$sortorder   = GETPOST('sortorder', 'aZ09comma');
-$page        = GETPOSTINT('page');
-$limit       = $conf->liste_limit;
-$offset      = $page * $limit;
-
-if (empty($sortfield)) {
-    $sortfield = 't.rowid';
-}
-if (empty($sortorder)) {
-    $sortorder = 'DESC';
+// The call list now uses the generic saturne list page.
+// Keep this entry point so existing bookmarks and back-to-list links keep working,
+// forwarding any extra query parameters (filters, sort, ...) to the generic list.
+$queryString = $_SERVER['QUERY_STRING'] ?? '';
+$target      = dol_buildpath('/custom/saturne/view/saturne_list.php', 1) . '?object_type=call_list';
+if (!empty($queryString)) {
+    $target .= '&' . $queryString;
 }
 
-$object = new CallList($db);
-
-$permissiontoread   = $user->hasRight('reedcrm', 'call_list', 'read');
-$permissiontoadd    = $user->hasRight('reedcrm', 'call_list', 'write');
-$permissiontodelete = $user->hasRight('reedcrm', 'call_list', 'delete');
-
-saturne_check_access($permissiontoread);
-
-$hookmanager->initHooks(['call_list_list', 'reedcrmglobal', 'globallist']);
-
-/*
- * Actions
- */
-
-$parameters = [];
-$resHook    = $hookmanager->executeHooks('doActions', $parameters, $object, $action);
-if ($resHook < 0) {
-    setEventMessages($hookmanager->error, $hookmanager->errors, 'errors');
-}
-
-if ($action === 'delete' && $permissiontodelete) {
-    $objectToDelete = new CallList($db);
-    if ($objectToDelete->fetch(GETPOSTINT('id')) > 0) {
-        $objectToDelete->delete($user);
-    }
-    header('Location: ' . $_SERVER['PHP_SELF']);
-    exit;
-}
-
-/*
- * View
- */
-
-$title   = $langs->trans('CallLists');
-$helpUrl = 'FR:Module_ReedCRM';
-
-saturne_header(0, '', $title, $helpUrl);
-
-$newCardButton = '';
-if ($permissiontoadd) {
-    $newCardButton = '<a href="' . dol_buildpath('/custom/reedcrm/view/call_list_card.php', 1) . '?action=create" class="butAction">';
-    $newCardButton .= $langs->trans('NewCallList');
-    $newCardButton .= '</a>';
-}
-
-print load_fiche_titre($title, $newCardButton, 'fontawesome_fa-phone_fas_#63ACC9');
-
-// Fetch list
-$sql  = 'SELECT t.rowid, t.ref, t.label, t.status, t.date_start, t.date_end, t.fk_user_assign';
-$sql .= ' FROM ' . $db->prefix() . 'reedcrm_call_list AS t';
-$sql .= ' WHERE t.entity IN (' . getEntity($object->element) . ')';
-$sql .= ' AND t.status >= 0';
-$sql .= $db->order($sortfield, $sortorder);
-$sql .= $db->plimit($limit, $offset);
-
-$resql = $db->query($sql);
-
-print '<div class="div-table-responsive">';
-print '<table class="noborder centpercent">';
-print '<tr class="liste_titre">';
-print '<td>' . $langs->trans('Ref') . '</td>';
-print '<td>' . $langs->trans('Label') . '</td>';
-print '<td>' . $langs->trans('DateStart') . '</td>';
-print '<td>' . $langs->trans('DateEnd') . '</td>';
-print '<td>' . $langs->trans('AssignedTo') . '</td>';
-print '<td class="center">' . $langs->trans('Status') . '</td>';
-if ($permissiontodelete) {
-    print '<td></td>';
-}
-print '</tr>';
-
-if ($resql && $db->num_rows($resql) > 0) {
-    $userStatic = new User($db);
-
-    while ($obj = $db->fetch_object($resql)) {
-        $callList = new CallList($db);
-        $callList->fetch($obj->rowid);
-
-        print '<tr class="oddeven">';
-        print '<td>' . $callList->getNomUrl(1) . '</td>';
-        print '<td>' . dol_escape_htmltag($callList->label) . '</td>';
-        print '<td>' . dol_print_date($callList->date_start, 'day') . '</td>';
-        print '<td>' . dol_print_date($callList->date_end, 'day') . '</td>';
-
-        print '<td>';
-        if (!empty($callList->fk_user_assign)) {
-            $userStatic->fetch($callList->fk_user_assign);
-            print $userStatic->getNomUrl(1);
-        }
-        print '</td>';
-
-        print '<td class="center">' . $callList->getLibStatut(5) . '</td>';
-
-        if ($permissiontodelete) {
-            print '<td class="center">';
-            print '<a href="' . $_SERVER['PHP_SELF'] . '?action=delete&id=' . $callList->id . '&token=' . newToken() . '">';
-            print img_delete();
-            print '</a>';
-            print '</td>';
-        }
-
-        print '</tr>';
-    }
-} else {
-    print '<tr><td colspan="' . ($permissiontodelete ? 7 : 6) . '"><div class="opacitymedium">' . $langs->trans('None') . '</div></td></tr>';
-}
-
-print '</table>';
-print '</div>';
-
-llxFooter();
-$db->close();
+header('Location: ' . $target);
+exit;


### PR DESCRIPTION
Closes #726

## Problème
`view/call_list_list.php` était un tableau fait main : aucun filtre, tri, pagination, action de masse ni sélecteur de colonnes.

## Solution
Enregistrement de l'objet `call_list` dans le registre Saturne (`saturneExtendGetObjectsMetadata`) pour qu'il s'affiche via le moteur générique `saturne_list.php` — d'où toutes les fonctionnalités d'une liste Dolibarr standard.

## Changements
- **actions_reedcrm** : hook `saturneExtendGetObjectsMetadata` (métadonnées `call_list`) ; Réf. cliquable (`getNomUrl`) via `saturnePrintFieldListLoopObject` sur le contexte `call_list_list`.
- **modReedCRM** : menu *Listes d'appel* → `saturne_list.php?object_type=call_list`.
- **langs** : clés dérivées `Call_listList` / `NewCall_list` (fr_FR + en_US).
- **call_list_list.php** : conservé en redirection (compat. marque-pages) ; liens « retour à la liste » de la fiche repointés.

Aucune réactivation de module nécessaire (le contexte `main` charge déjà les hooks reedcrm).

## Tests
- Vérif. CLI : le hook enregistre bien `call_list`, l'objet `CallList` se résout (15 champs), clés de langue traduites.
- Vérif. navigateur (Playwright) : titre « Listes d'appel », filtres par colonne, tri, pagination, compteur (20), cases d'actions de masse, sélecteur « Colonnes », Réf. cliquable, badges d'état, bouton + ; redirection OK ; aucune clé non traduite ni erreur PHP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)