### PR TITLE
#728 [EventPro] fix: show full project title in select (maxlength 16->64)

### DIFF
--- a/core/tpl/view/eventpro/view_eventpro_actioncomm.tpl.php
+++ b/core/tpl/view/eventpro/view_eventpro_actioncomm.tpl.php
@@ -71,7 +71,7 @@
             <div>
                 <label for="project_id">
                     <?php echo img_picto('', 'project'); ?>
-                    <div class="select2-container"><?php echo $formProject->select_projects($object->thirdparty->id, $object->id, 'project_id'); ?></div>
+                    <div class="select2-container"><?php echo $formProject->select_projects($object->thirdparty->id, $object->id, 'project_id', 64); ?></div>
                 </label>
             </div>
             <?php if (!empty($object->usage_opportunity)) { ?>

--- a/core/tpl/view/eventpro/view_eventpro_ticket.tpl.php
+++ b/core/tpl/view/eventpro/view_eventpro_ticket.tpl.php
@@ -63,7 +63,7 @@
 
         <tr class="oddeven">
             <td><?php echo $langs->trans("Project"); ?></td><td colspan="3">
-                <?php $formProject->select_projects($object->thirdparty->id, $object->id, 'project_id'); ?>
+                <?php $formProject->select_projects($object->thirdparty->id, $object->id, 'project_id', 64); ?>
             </td>
         </tr>
 


### PR DESCRIPTION
Closes #728

## Problème
Dans le panneau « Ajout rapide d'événement » (et l'onglet Ticket) de l'eventpro, le sélecteur de projet est construit via `FormProjets::select_projects()` **sans** 4ᵉ paramètre, donc avec `$maxlength = 16` par défaut. `dol_trunc()` coupe alors chaque titre : les projets partageant un préfixe commun (ex. « Document Unique 2024 » / « Document Unique 2026 ») s'affichaient tous « Document Unique … » et devenaient indistinguables.

## Correctif
`$maxlength = 64` sur les deux appels `select_projects()` :
- `core/tpl/view/eventpro/view_eventpro_actioncomm.tpl.php`
- `core/tpl/view/eventpro/view_eventpro_ticket.tpl.php`

Le suffixe distinctif du titre est désormais visible, tout en gardant des options compactes dans le panneau de 500px.

## Vérification (Playwright, tiers 464)
Lecture des `<option>` réels du select, avant/après :

| Projet | Avant (16) | Après (64) |
|---|---|---|
| PJ2411-1630 | `Document Unique …` | `Document Unique 2024` |
| PJ2602-5918 | `Document Unique …` | `Document Unique 2026` |

Lint PHP OK. Aucun rebuild d'asset (PHP pur).

🤖 Generated with [Claude Code](https://claude.com/claude-code)