### PR TITLE
fix: ajout des informations de contact dans le PDF Call List et configuration Admin (#597)

### DIFF
--- a/admin/call_list.php
+++ b/admin/call_list.php
@@ -50,13 +50,40 @@ $permissiontoread = $user->hasRight('reedcrm','adminpage','read');
 
 saturne_check_access($permissiontoread);
 
-/*
- * Actions
- */
+$moduleName = 'ReedCRM';
+$moduleNameLowerCase = 'reedcrm';
+$documentParentType = 'calllist';
+$documentType = 'call_list';
+$objectModSubdir = 'call_list';
+
+require_once DOL_DOCUMENT_ROOT . '/core/lib/files.lib.php';
+require_once __DIR__ . '/../class/calllist.class.php';
+$object = new CallList($db);
+
+require_once __DIR__ . '/../../saturne/core/tpl/actions/admin_conf_actions.tpl.php';
+
+$modelName = GETPOST('model_name', 'alpha');
+$type      = GETPOST('type', 'alpha');
+$label     = GETPOST('label', 'alpha');
+$const     = GETPOST('const', 'alpha');
+
+if ($action == 'set' && $permissiontoread) {
+    addDocumentModel($modelName, $type, $label, $const);
+    header('Location: ' . $_SERVER['PHP_SELF']);
+    exit;
+} elseif ($action == 'del' && $permissiontoread) {
+    delDocumentModel($modelName, $type);
+    header('Location: ' . $_SERVER['PHP_SELF']);
+    exit;
+} elseif ($action == 'setdoc' && $permissiontoread) {
+    $confName = dol_strtoupper($moduleName . '_' . $documentParentType) . '_DEFAULT_MODEL';
+    dolibarr_set_const($db, $confName, $modelName, 'chaine', 0, '', $conf->entity);
+    header('Location: ' . $_SERVER['PHP_SELF']);
+    exit;
+}
 
 if ($action == 'set_config') {
-    // Save settings will go here
-    
+    // Other settings if needed
     setEventMessage('SavedConfig');
     header('Location: ' . $_SERVER['PHP_SELF']);
     exit;
@@ -85,22 +112,8 @@ print dol_get_fiche_head($head, 'call_list', $title, -1, 'reedcrm_color@reedcrm'
 
 print load_fiche_titre($langs->trans('Configs', $langs->trans('CallList')), '', '');
 
-print '<form method="POST" action="' . $_SERVER['PHP_SELF'] . '">';
-print '<input type="hidden" name="token" value="' . newToken() . '">';
-print '<input type="hidden" name="action" value="set_config">';
+// Numbering Module
+require_once __DIR__ . '/../../saturne/core/tpl/admin/object/object_numbering_module_view.tpl.php';
 
-print '<table class="noborder centpercent">';
-print '<tr class="liste_titre">';
-print '<td>' . $langs->trans('Name') . '</td>';
-print '<td>' . $langs->trans('Description') . '</td>';
-print '<td>' . $langs->trans('Value') . '</td>';
-print '</tr>';
-
-// Placeholder empty table as requested: "on livrera tout à la fin que je te dirais"
-print '<tr class="oddeven"><td colspan="3" class="opacitymedium">';
-print $langs->trans('FeatureUnderConstruction');
-print '</td></tr>';
-
-print '</table>';
-print '<div class="tabsAction"><input type="submit" class="butAction" name="save" value="' . $langs->trans('Save') . '" disabled></div>';
-print '</form>';
+// Document Model
+require_once __DIR__ . '/../../saturne/core/tpl/admin/object/object_document_model_view.tpl.php';

--- a/admin/call_list.php
+++ b/admin/call_list.php
@@ -113,7 +113,7 @@ print dol_get_fiche_head($head, 'call_list', $title, -1, 'reedcrm_color@reedcrm'
 print load_fiche_titre($langs->trans('Configs', $langs->trans('CallList')), '', '');
 
 // Numbering Module
-$documentPath = false;
+unset($documentPath);
 $objectModSubdir = ''; // so $dir becomes /custom/reedcrm/core/modules/reedcrm/call_list/
 $filelist = [];
 require_once __DIR__ . '/../../saturne/core/tpl/admin/object/object_numbering_module_view.tpl.php';

--- a/admin/call_list.php
+++ b/admin/call_list.php
@@ -113,7 +113,21 @@ print dol_get_fiche_head($head, 'call_list', $title, -1, 'reedcrm_color@reedcrm'
 print load_fiche_titre($langs->trans('Configs', $langs->trans('CallList')), '', '');
 
 // Numbering Module
+$documentPath = false;
+$objectModSubdir = ''; // so $dir becomes /custom/reedcrm/core/modules/reedcrm/call_list/
+$filelist = [];
 require_once __DIR__ . '/../../saturne/core/tpl/admin/object/object_numbering_module_view.tpl.php';
 
 // Document Model
+$dir = dol_buildpath('/custom/reedcrm/core/modules/reedcrm/call_list/doc/');
+$filelist = [];
+if (is_dir($dir)) {
+    $handle = opendir($dir);
+    if (is_resource($handle)) {
+        while (($file = readdir($handle)) !== false) {
+            $filelist[] = $file;
+        }
+        closedir($handle);
+    }
+}
 require_once __DIR__ . '/../../saturne/core/tpl/admin/object/object_document_model_view.tpl.php';

--- a/admin/call_list.php
+++ b/admin/call_list.php
@@ -53,7 +53,7 @@ saturne_check_access($permissiontoread);
 $moduleName = 'ReedCRM';
 $moduleNameLowerCase = 'reedcrm';
 $documentParentType = 'calllist';
-$documentType = 'call_list';
+$documentType = 'calllist';
 $objectModSubdir = 'call_list';
 
 require_once DOL_DOCUMENT_ROOT . '/core/lib/files.lib.php';

--- a/admin/call_list.php
+++ b/admin/call_list.php
@@ -114,7 +114,7 @@ print load_fiche_titre($langs->trans('Configs', $langs->trans('CallList')), '', 
 
 // Numbering Module
 unset($documentPath);
-$objectModSubdir = ''; // so $dir becomes /custom/reedcrm/core/modules/reedcrm/call_list/
+unset($objectModSubdir);
 $filelist = [];
 require_once __DIR__ . '/../../saturne/core/tpl/admin/object/object_numbering_module_view.tpl.php';
 

--- a/class/actions_reedcrm.class.php
+++ b/class/actions_reedcrm.class.php
@@ -3649,4 +3649,51 @@ EOT;
 
         return $html;
     }
+
+    /**
+     * Overwrites the PDF target company or target contact to inject ReedCRM extrafields
+     * (e.g. phone, email) from the project when they are missing.
+     *
+     * @param array             $parameters Hook parameters
+     * @param CommonObject|null $object     Current object
+     * @param string            $action     Current action
+     * @return int                          0 < on error, 0 on success, 1 to replace standard code
+     */
+    public function pdf_build_address(array $parameters, ?CommonObject $object, string &$action): int
+    {
+        global $db;
+
+        if (!is_object($object) || empty($object->fk_project)) {
+            return 0;
+        }
+
+        require_once DOL_DOCUMENT_ROOT . '/projet/class/project.class.php';
+        $project = new Project($db);
+        if ($project->fetch($object->fk_project) > 0) {
+            $project->fetch_optionals();
+
+            $projectPhone = $project->array_options['options_projectphone'] ?? '';
+            $projectEmail = $project->array_options['options_reedcrm_email'] ?? '';
+
+            if (isset($parameters['targetcompany']) && is_object($parameters['targetcompany'])) {
+                if (empty($parameters['targetcompany']->phone) && !empty($projectPhone)) {
+                    $parameters['targetcompany']->phone = $projectPhone;
+                }
+                if (empty($parameters['targetcompany']->email) && !empty($projectEmail)) {
+                    $parameters['targetcompany']->email = $projectEmail;
+                }
+            }
+
+            if (isset($parameters['targetcontact']) && is_object($parameters['targetcontact'])) {
+                if (empty($parameters['targetcontact']->phone_pro) && !empty($projectPhone)) {
+                    $parameters['targetcontact']->phone_pro = $projectPhone;
+                }
+                if (empty($parameters['targetcontact']->email) && !empty($projectEmail)) {
+                    $parameters['targetcontact']->email = $projectEmail;
+                }
+            }
+        }
+
+        return 0;
+    }
 }

--- a/core/modules/reedcrm/call_list/doc/pdf_calllist_standard.modules.php
+++ b/core/modules/reedcrm/call_list/doc/pdf_calllist_standard.modules.php
@@ -138,6 +138,14 @@ class pdf_calllist_standard extends ModelePDFCallList
                 if ($p->fetch($line->element_id) > 0) {
                     $sourceRef = $p->ref;
                     $amount    = !empty($p->total_ht) ? price($p->total_ht) . ' ' . $outputlangs->transnoentities('HT') : '';
+
+                    if (empty($line->fk_contact) || (empty($lastname) && empty($phone))) {
+                        $p->fetch_thirdparty();
+                        if (is_object($p->thirdparty)) {
+                            $lastname = $p->thirdparty->name;
+                            $phone    = $p->thirdparty->phone;
+                        }
+                    }
                 }
             } elseif ($line->element_type === 'project' && isModEnabled('projet')) {
                 require_once DOL_DOCUMENT_ROOT . '/projet/class/project.class.php';
@@ -145,6 +153,26 @@ class pdf_calllist_standard extends ModelePDFCallList
                 if ($p->fetch($line->element_id) > 0) {
                     $sourceRef = $p->ref;
                     $amount    = !empty($p->opp_amount) ? price($p->opp_amount) : '';
+
+                    if (empty($line->fk_contact) || (empty($lastname) && empty($phone))) {
+                        $p->fetch_optionals();
+                        if (!empty($p->array_options['options_projectaddress'])) {
+                            $contact->fetch($p->array_options['options_projectaddress']);
+                            $lastname  = $contact->lastname;
+                            $firstname = $contact->firstname;
+                            $phone     = $contact->phone_pro ?: $contact->phone_mobile ?: '';
+                        } elseif (!empty($p->array_options['options_reedcrm_lastname']) || !empty($p->array_options['options_projectphone'])) {
+                            $lastname  = $p->array_options['options_reedcrm_lastname'] ?? '';
+                            $firstname = $p->array_options['options_reedcrm_firstname'] ?? '';
+                            $phone     = $p->array_options['options_projectphone'] ?? '';
+                        } elseif ($p->socid > 0) {
+                            require_once DOL_DOCUMENT_ROOT . '/societe/class/societe.class.php';
+                            $soc = new Societe($this->db);
+                            $soc->fetch($p->socid);
+                            $lastname = $soc->name;
+                            $phone    = $soc->phone;
+                        }
+                    }
                 }
             }
 

--- a/core/modules/reedcrm/call_list/modules_calllist.php
+++ b/core/modules/reedcrm/call_list/modules_calllist.php
@@ -21,7 +21,7 @@
  * \brief   Abstract class for CallList numbering modules.
  */
 
-require_once __DIR__ . '/../../../../saturne/core/modules/saturne/modules_saturne.php';
+require_once __DIR__ . '/../../../../../saturne/core/modules/saturne/modules_saturne.php';
 
 /**
  * Abstract class for CallList numbering modules.


### PR DESCRIPTION
Fixes #597

Ce correctif englobe les points suivants pour finaliser l'issue 597 :
- Injection automatique des informations de contact (téléphone, nom, prénom) depuis l'opportunité (Projet) ou la proposition commerciale si le contact standard est manquant lors de la génération du PDF d'une liste d'appel.
- Ajout de la page d'administration \dmin/call_list.php\ pour configurer les modèles de documents (PDF) et les modules de numérotation.
- Mise en conformité de l'interface avec l'architecture Saturne.