### PR TITLE
fix: register all hooks for reedcrm

### DIFF
--- a/core/modules/modReedCRM.class.php
+++ b/core/modules/modReedCRM.class.php
@@ -122,24 +122,7 @@ class modReedCRM extends DolibarrModules
             // Set here all hooks context managed by module. To find available hook context, make a "grep -r '>initHooks(' *" on source code. You can also set hook context to 'all')
             /* BEGIN MODULEBUILDER HOOKSCONTEXTS */
             'hooks' => [
-                'thirdpartycomm',
-                'projectcard',
-                'projectOverview',
-                'projectlist',
-                'projectdao',
-                'propalcard',
-                'propallist',
-                'invoicereccard',
-                'invoicereccontact',
-                'invoicereclist',
-                'invoicelist',
-                'invoicecard',
-                'receptioncard',
-                'contactcard',
-                'thirdpartycard',
-                'thirdpartylist',
-                'main',
-                'pwaadmin'
+                'all'
             ],
             /* END MODULEBUILDER HOOKSCONTEXTS */
             // Set this to 1 if features of module are opened to external users


### PR DESCRIPTION
This PR registers all hooks for reedcrm to fix missing hooks like printCommonFooter.