### PR TITLE
#729 [EventPro] fix: reminder created from eventpro is "to do" instead of "done"

### DIFF
--- a/view/procard.php
+++ b/view/procard.php
@@ -195,6 +195,7 @@ if (empty($resHook)) {
             $date_reminder = dol_mktime(GETPOSTINT('reminder_hour'), GETPOSTINT('reminder_min'), 0, GETPOSTINT('reminder_month'), GETPOSTINT('reminder_day'), GETPOSTINT('reminder_year'), 'tzuserrel');
 
             $actionComm->type_code    = 'AC_OTH';
+            $actionComm->percentage   = 0; // Reminder is a future "to do", not the completed event reused above
 
             $actionComm->datep        = $date_reminder;
 


### PR DESCRIPTION
## Problème

Closes #729

Un rappel créé depuis un **eventpro** (formulaire « Ajouter un événement » + rappel) apparaissait comme **« Réalisé »** au lieu de **« À faire »** dans l'agenda.

## Cause

Dans `view/procard.php`, le handler `add_event` :
1. crée l'événement principal (action consignée, passée) avec `percentage = 100` ;
2. pour le rappel optionnel, **réutilise le même objet `$actionComm`** et rappelle `create()` en ne réinitialisant que `type_code` / `datep` / `label` / `note_private`.

Le rappel héritait donc de `percentage = 100`. `ActionComm::create()` ne force `percentage` à 0 que s'il est *vide*, ce qui n'était pas le cas.

## Correctif

Réinitialiser `percentage = 0` sur le rappel avant son `create()`.

- Événement de base (action passée) → reste à **100 %** (« Réalisé »)
- Rappel (à venir) → **0 %** (« À faire »)

Conforme à la sémantique du coeur (`ActionComm::LibStatut` : `percent == 0` → « À faire », `percent == 100` → « Réalisé »).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
