### PR TITLE
#724 [CallList] fix: fall back to project ReedCRM coordinates when no contact is linked

### DIFF
--- a/lib/reedcrm_call_list.lib.php
+++ b/lib/reedcrm_call_list.lib.php
@@ -167,6 +167,28 @@ function reedcrm_add_element_to_call_list(DoliDB $db, User $user, int $callListI
     );
 
     if (empty($contacts)) {
+        // No linked Dolibarr contact: for a project, fall back to its own coordinates
+        // (ReedCRM extrafields). The line is created without fk_contact and the name/phone
+        // are resolved from the project at display time (see call_list_card / pwa_call_list).
+        if ($elementType === 'project') {
+            $element->fetch_optionals();
+            $projectPhone = trim((string) ($element->array_options['options_projectphone'] ?? ''));
+            if ($projectPhone !== '') {
+                $newLine               = new CallListLine($db);
+                $newLine->fk_call_list = $callListId;
+                $newLine->element_type = $elementType;
+                $newLine->element_id   = $elementId;
+                $newLine->fk_contact   = 0;
+                $newLine->status       = CallListLine::STATUS_TO_CALL;
+
+                if ($newLine->create($user) <= 0) {
+                    return ['success' => false, 'message' => $langs->transnoentitiesnoconv('CallListWidgetError')];
+                }
+
+                return ['success' => true, 'message' => $langs->transnoentitiesnoconv('CallListWidgetSuccess', $callList->getNomUrl(1))];
+            }
+        }
+
         return ['success' => false, 'message' => $langs->transnoentitiesnoconv('CallListWidgetNoContact')];
     }
 

--- a/view/frontend/pwa_call_list.php
+++ b/view/frontend/pwa_call_list.php
@@ -211,6 +211,25 @@ if (empty($lines)) {
             $project = new Project($db);
             if ($project->fetch($line->element_id) > 0) {
                 $sourceHtml = $project->getNomUrl(1);
+                if (empty($line->fk_contact) || empty($lastname)) {
+                    $project->fetch_optionals();
+                    if (!empty($project->array_options['options_projectaddress'])) {
+                        $contact->fetch($project->array_options['options_projectaddress']);
+                        $lastname  = dol_escape_htmltag($contact->lastname);
+                        $firstname = dol_escape_htmltag($contact->firstname);
+                        $phone     = dol_escape_htmltag($contact->phone_pro ?: $contact->phone_mobile ?: '');
+                    } elseif (!empty($project->array_options['options_reedcrm_lastname']) || !empty($project->array_options['options_projectphone'])) {
+                        $lastname  = dol_escape_htmltag($project->array_options['options_reedcrm_lastname'] ?? '');
+                        $firstname = dol_escape_htmltag($project->array_options['options_reedcrm_firstname'] ?? '');
+                        $phone     = dol_escape_htmltag($project->array_options['options_projectphone'] ?? '');
+                    } elseif ($project->socid > 0) {
+                        require_once DOL_DOCUMENT_ROOT . '/societe/class/societe.class.php';
+                        $soc = new Societe($db);
+                        $soc->fetch($project->socid);
+                        $lastname = dol_escape_htmltag($soc->name);
+                        $phone    = dol_escape_htmltag($soc->phone);
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
## Problème

Closes #724

Quand on ajoute un **projet** à une liste d'appel, si le projet a un **Nom / Prénom / Téléphone** renseignés mais **aucun contact Dolibarr associé**, l'ajout échouait avec « aucun contact associé » au lieu d'utiliser les coordonnées du projet.

## Cause

Les coordonnées vivent dans des **extrafields du projet** : `options_reedcrm_firstname`, `options_reedcrm_lastname`, `options_projectphone`. `reedcrm_add_element_to_call_list()` se basait uniquement sur `liste_contact()` et renvoyait `CallListWidgetNoContact` quand il n'y avait aucun contact lié.

## Correctif

1. **`lib/reedcrm_call_list.lib.php`** — si un projet n'a aucun contact lié mais possède un `options_projectphone`, on crée la `CallListLine` avec `fk_contact = 0`. Le nom/prénom/téléphone sont résolus depuis les extrafields du projet à l'affichage (fallback déjà présent côté desktop via #725).
2. **`view/frontend/pwa_call_list.php`** — ajout du même fallback projet → extrafields (`options_projectaddress` → `reedcrm_*` / `projectphone` → société) que la fiche desktop, pour que ces lignes sans contact s'affichent et soient appelables aussi sur la PWA d'appel.

Comportement inchangé pour les projets **avec** contact ; un téléphone reste requis (cohérent avec « Nom Prénom **et** numéro présents »). Scope limité aux projets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
