### PR TITLE
#755 [CallList] fix: allow admins to read call lists in PWA

### DIFF
--- a/view/frontend/pwa_call_list.php
+++ b/view/frontend/pwa_call_list.php
@@ -69,7 +69,7 @@ if (empty($object->id)) {
 }
 
 $canRead = false;
-if ($user->hasRight('reedcrm', 'call_list', 'read_all')) {
+if ($user->hasRight('reedcrm', 'call_list', 'read_all') || $user->admin) {
     $canRead = true;
 } elseif ($user->hasRight('reedcrm', 'call_list', 'read_subordinates')) {
     $childIds = $user->getAllChildIds(1);


### PR DESCRIPTION
## Changements
- Le contrôle d'accès `$canRead` de la vue PWA des listes d'appel accepte désormais les **admins** au même titre que le droit `reedcrm->call_list->read_all` (`|| $user->admin`)
- Avant : un admin sans droit explicite, ni assigné à la liste, ni supérieur de l'assigné, recevait `NotEnoughPermissions`

## Fichiers modifiés
- `view/frontend/pwa_call_list.php` (1 ligne)

## Issue
Closes #755
