### PR TITLE
#759 [PWA] fix: vcard modal visibility and double scrollbar

### DIFF
--- a/core/tpl/frontend/reedcrm_pwa_header.tpl.php
+++ b/core/tpl/frontend/reedcrm_pwa_header.tpl.php
@@ -76,14 +76,14 @@
 
 <!-- VCard Modal -->
 <?php if ($vcardUrl) { ?>
-<div id="vcard-modal" class="wpeo-modal modal-vcard" style="position: fixed; top: 0; left: 0; right: 0; bottom: 0; background: rgba(15, 23, 42, 0.7); z-index: 9999; display: none; align-items: center; justify-content: center;">
+<div id="vcard-modal" class="modal-vcard" style="position: fixed; top: 0; left: 0; right: 0; bottom: 0; background: rgba(15, 23, 42, 0.7); z-index: 9999; display: none; align-items: center; justify-content: center;">
     <div class="modal-container" style="background: #ffffff; border-radius: 12px; box-shadow: 0 10px 25px rgba(0, 0, 0, 0.2); width: 95%; max-width: 480px; max-height: 90vh; display: flex; flex-direction: column; overflow: hidden; animation: modalFadeIn 0.3s ease;">
         <div class="modal-header" style="display: flex; align-items: center; justify-content: space-between; padding: 15px 20px; border-bottom: 1px solid #e2e8f0; background: #f8fafc;">
             <h2 class="modal-title" style="margin: 0; font-size: 18px; font-weight: 600; color: #1e293b;">Carte de visite</h2>
             <div class="modal-close" data-action="close-vcard-modal" style="cursor: pointer; color: #64748b; font-size: 20px; line-height: 1;"><i class="fas fa-times"></i></div>
         </div>
-        <div class="modal-content" style="padding: 0; overflow-y: auto; flex-grow: 1; height: 75vh; background: #f1f5f9;">
-            <iframe src="<?php echo dol_escape_htmltag($vcardUrl); ?>" style="width: 100%; height: 100%; border: none;"></iframe>
+        <div class="modal-content" style="padding: 0; overflow: hidden; flex-grow: 1; height: 75vh; background: #f1f5f9;">
+            <iframe src="<?php echo dol_escape_htmltag($vcardUrl); ?>" style="display: block; width: 100%; height: 100%; border: none;"></iframe>
         </div>
     </div>
 </div>


### PR DESCRIPTION
## Changements
- Retrait de la classe `wpeo-modal` sur `#vcard-modal` : le CSS Saturne imposait `opacity: 0; pointer-events: none` sans la classe `.modal-active`, rendant la modal invisible alors que le JS la passait bien en `display: flex`
- Iframe vcard passée en `display: block` (supprime le gap de baseline des éléments inline) et `.modal-content` en `overflow: hidden` → une seule scrollbar, celle du contenu de l'iframe

## Fichiers modifiés
- `core/tpl/frontend/reedcrm_pwa_header.tpl.php`

## Issue
#759
