### PR TITLE
#748 [CallList] fix: validate call lists with definitive ref instead of PROV

### DIFF
--- a/class/calllist.class.php
+++ b/class/calllist.class.php
@@ -22,6 +22,9 @@
  */
 
 require_once __DIR__ . '/../../saturne/class/saturneobject.class.php';
+// Preload the numbering module class: saturne_require_objects_mod() strips underscores from the
+// element type ('call_list' → 'calllist') and would not find the file in core/modules/reedcrm/call_list/
+require_once __DIR__ . '/../core/modules/reedcrm/call_list/mod_call_list_standard.php';
 
 /**
  * Class for CallList

--- a/core/modules/modReedCRM.class.php
+++ b/core/modules/modReedCRM.class.php
@@ -908,6 +908,27 @@ class modReedCRM extends DolibarrModules
         delDocumentModel('pdf_calllist_standard', 'calllist');
         addDocumentModel('pdf_calllist_standard', 'calllist', $langs->transnoentities('CallListPDF'));
 
+        // Backward compatibility: validate all call lists still having a provisional ref (PROV…)
+        if (getDolGlobalInt('REEDCRM_CALL_LIST_PROV_REF_MIGRATED') == 0) {
+            require_once __DIR__ . '/../../class/calllist.class.php';
+
+            $callList  = new CallList($this->db);
+            $callLists = $callList->fetchAll('', '', 0, 0, ['customsql' => "ref LIKE '(PROV%'"]);
+
+            if (is_array($callLists) && !empty($callLists)) {
+                foreach ($callLists as $objCallList) {
+                    // validate() aborts when status is already validated: lists activated by the legacy
+                    // code kept their (PROV…) ref with an active status, reset it in memory first
+                    if ($objCallList->status != CallList::STATUS_DRAFT) {
+                        $objCallList->status = CallList::STATUS_DRAFT;
+                    }
+                    $objCallList->validate($user, 1);
+                }
+            }
+
+            dolibarr_set_const($this->db, 'REEDCRM_CALL_LIST_PROV_REF_MIGRATED', 1, 'integer', 0, '', $conf->entity);
+        }
+
         // Ensure every active user owns a default call list
         require_once DOL_DOCUMENT_ROOT . '/user/class/user.class.php';
         require_once __DIR__ . '/../../lib/reedcrm_call_list.lib.php';

--- a/lib/reedcrm_call_list.lib.php
+++ b/lib/reedcrm_call_list.lib.php
@@ -91,7 +91,7 @@ function reedcrm_get_or_create_user_default_call_list(DoliDB $db, User $targetUs
     // Create a new default call list assigned to the user
     $callList                 = new CallList($db);
     $callList->label          = $langs->transnoentitiesnoconv('DefaultCallListLabel', dolGetFirstLastname($targetUser->firstname, $targetUser->lastname));
-    $callList->status         = CallList::STATUS_ACTIVE;
+    $callList->status         = CallList::STATUS_DRAFT;
     $callList->fk_user_assign = $targetUser->id;
     $callList->entity         = $entity;
 
@@ -99,6 +99,9 @@ function reedcrm_get_or_create_user_default_call_list(DoliDB $db, User $targetUs
     if ($newId <= 0) {
         return -1;
     }
+
+    // Validate right away: assigns the definitive ref (LA…) and the active status, no (PROV…) step
+    $callList->validate($targetUser);
 
     // dol_set_user_param writes the param and keeps $targetUser->conf in sync
     if (dol_set_user_param($db, $conf, $targetUser, ['REEDCRM_DEFAULT_CALL_LIST' => (string) $newId], $entity) < 0) {

--- a/view/call_list_card.php
+++ b/view/call_list_card.php
@@ -98,6 +98,8 @@ if (empty($resHook)) {
         $result = $object->create($user);
 
         if ($result > 0) {
+            // Validate right away: call lists are active by default with a definitive ref (LA…), no (PROV…) step
+            $object->validate($user);
             header('Location: ' . $_SERVER['PHP_SELF'] . '?id=' . $object->id);
             exit;
         } else {
@@ -137,12 +139,16 @@ if (empty($resHook)) {
         }
     }
 
-    // Validate (draft → active)
+    // Validate (draft → active) : assigns the definitive ref (LA…) through the numbering module
     if ($action === 'confirm_validate' && GETPOST('confirm') === 'yes' && $permissiontoadd) {
-        $object->status = CallList::STATUS_ACTIVE;
-        $object->update($user);
-        header('Location: ' . $_SERVER['PHP_SELF'] . '?id=' . $object->id);
-        exit;
+        $result = $object->validate($user);
+
+        if ($result > 0) {
+            header('Location: ' . $_SERVER['PHP_SELF'] . '?id=' . $object->id);
+            exit;
+        } else {
+            setEventMessages($object->error, $object->errors, 'errors');
+        }
     }
 
     // Archive (active → archived)


### PR DESCRIPTION
## Changements

### Cause racine
Le bouton **Valider** de la fiche liste d'appel faisait un simple `update()` du statut sans jamais appeler `validate()` — la référence définitive n'était donc jamais attribuée et les listes gardaient leur ref `(PROV…)` à vie.

### Correctifs
- **Validation directe à la création** : les listes d'appel naissent maintenant avec le statut **Validé** et une référence définitive `LA{aamm}-XXXX` (plus aucune étape `(PROV…)`) — aussi bien depuis la fiche que pour les listes par défaut utilisateur
- **Bouton Valider** : utilise `SaturneObject::validate()` (ref définitive + trigger `CALL_LIST_VALIDATE` + renommage du répertoire de documents), avec gestion d'erreur via `setEventMessages` au lieu d'une redirection silencieuse
- **Préchargement du module de numérotation** dans `calllist.class.php` : `saturne_require_objects_mod()` retire les underscores du type d'objet (`call_list` → `calllist`) et ne trouverait jamais la classe dans `core/modules/reedcrm/call_list/` (dossier requis tel quel par la page admin)
- **Migration backward dans `modReedCRM::init()`** : bloc one-shot (constante `REEDCRM_CALL_LIST_PROV_REF_MIGRATED`) qui valide toutes les listes existantes en `(PROV…)` — y compris celles « activées » par l'ancien code — sans déclencher les triggers. Se lance à la réactivation du module.

## Fichiers modifiés
- `view/call_list_card.php`
- `class/calllist.class.php`
- `lib/reedcrm_call_list.lib.php`
- `core/modules/modReedCRM.class.php`

## Issue
#748
