### PR TITLE
#601 [EventPro] fix: use dictionary refusal reason as closure event title

### DIFF
--- a/ajax/close_record.php
+++ b/ajax/close_record.php
@@ -64,17 +64,15 @@ if ($type === 'projet' || $type === 'project') {
         }
 
         // 1. Get the correct opp_status ID for WON/LOST
-        $sqlStatus = "SELECT rowid, code FROM " . MAIN_DB_PREFIX . "c_lead_status WHERE code = '" . $db->escape($statusStr) . "'";
-        $resStatus = $db->query($sqlStatus);
-        if ($resStatus && $db->num_rows($resStatus) > 0) {
-            $objStatus = $db->fetch_object($resStatus);
-            $object->fk_opp_status = $objStatus->rowid;
-            $object->opp_status = $objStatus->rowid;
-            
-            if ($objStatus->code === 'WON') {
+        $oppStatusId = dol_getIdFromCode($db, $statusStr, 'c_lead_status', 'code', 'rowid');
+        if ($oppStatusId > 0) {
+            $object->fk_opp_status = $oppStatusId;
+            $object->opp_status    = $oppStatusId;
+
+            if ($statusStr === 'WON') {
                 $object->opp_percent = 100;
                 $object->usage_opportunity = 0; // Uncheck "Suivre une opportunité"
-                
+
                 // Map the new fields
                 if (!empty($end_date)) {
                     $object->date_end = dol_stringtotime($end_date);
@@ -82,24 +80,20 @@ if ($type === 'projet' || $type === 'project') {
                 if ($budget !== '') {
                     $object->budget_amount = (float)$budget;
                 }
-            } elseif ($objStatus->code === 'LOST') {
+            } elseif ($statusStr === 'LOST') {
                 $object->opp_percent = 0;
             }
             // Native update of the opportunity status
             $object->update($user);
         }
 
-        // 2. Update Extrafield (opprefusal)
+        // 2. Update Extrafield (opprefusal) through the native extrafields API
         require_once DOL_DOCUMENT_ROOT . '/core/class/extrafields.class.php';
         $extrafields = new ExtraFields($db);
-        $extralabels = $extrafields->fetch_name_optionals_label($object->table_element);
+        $extrafields->fetch_name_optionals_label($object->table_element);
         $object->fetch_optionals();
         $object->array_options['options_opprefusal'] = $reason;
-        $object->insertExtraFields('PROJET_CUSTOM_OPTIONS'); // Use generic insert
-        
-        // Custom explicit update just in case native method name changes
-        $sqlExtra = "UPDATE " . MAIN_DB_PREFIX . "projet_extrafields SET opprefusal = '" . $db->escape($reason) . "' WHERE fk_object = " . ((int)$id);
-        $db->query($sqlExtra);
+        $object->insertExtraFields('PROJET_CUSTOM_OPTIONS');
 
         // 3. Trigger native closure ONLY IF LOST
         // Draft projects (status 0) cannot be closed directly in Dolibarr core. We must validate them first.
@@ -107,26 +101,39 @@ if ($type === 'projet' || $type === 'project') {
             $object->setValid($user);
         }
         
-        if ($objStatus->code !== 'WON') {
+        if ($statusStr !== 'WON') {
             // This will natively spawn the 'actioncomm' trigger "Projet ... fermé"
             $resClose = $object->setClose($user);
         }
         
-        // 4. Update the generated actioncomm label to match the strictly requested format
-        $newLabel = $object->ref . ($objStatus->code === 'WON' ? " - Gagné" : " - Clôturé");
-        if (!empty($comment)) {
-            $newLabel .= " - " . $comment;
+        // 4. Build the actioncomm label from the dictionary refusal reason (not the free text)
+        $reasonLabel = '';
+        if (!empty($reason)) {
+            $langs->load('reedcrm@reedcrm');
+            $reasonRef   = getDictionaryValue('c_refusal_reason', 'ref', (int) $reason);
+            $reasonLabel = $langs->trans($reasonRef);
+            if (empty($reasonRef) || $reasonLabel == $reasonRef) {
+                $reasonLabel = getDictionaryValue('c_refusal_reason', 'label', (int) $reason);
+            }
+        }
+
+        $newLabel = $object->ref . ($statusStr === 'WON' ? " - Gagné" : " - Clôturé");
+        if ($statusStr !== 'WON' && !empty($reasonLabel)) {
+            $newLabel .= " - " . $reasonLabel;
         }
 
         $eventUpdated = false;
-        if ($objStatus->code !== 'WON') {
-            // We called setClose(), let's try to find its generated event
-            $sqlEvent = "SELECT id FROM " . MAIN_DB_PREFIX . "actioncomm WHERE fk_project = " . ((int)$id) . " ORDER BY id DESC LIMIT 1";
-            $resEvent = $db->query($sqlEvent);
-            if ($resEvent && $db->num_rows($resEvent) > 0) {
-                $objEvent = $db->fetch_object($resEvent);
-                $sqlUpdateEvent = "UPDATE " . MAIN_DB_PREFIX . "actioncomm SET label = '" . $db->escape($newLabel) . "' WHERE id = " . ((int)$objEvent->id);
-                $db->query($sqlUpdateEvent);
+        if ($statusStr !== 'WON') {
+            // setClose() spawned an agenda event: fetch the latest one for this project via the ORM
+            $actionStatic = new ActionComm($db);
+            $events       = $actionStatic->getActions(0, $id, 'project', '', 'a.id', 'DESC', 1);
+            if (is_array($events) && count($events) > 0) {
+                $event        = array_shift($events);
+                $event->label = $newLabel;
+                if (!empty($comment)) {
+                    $event->note_private = $comment; // handwritten reason goes to the description
+                }
+                $event->update($user);
                 $eventUpdated = true;
             }
         }
@@ -139,13 +146,12 @@ if ($type === 'projet' || $type === 'project') {
             $actioncomm->fk_project = $id;
             $actioncomm->datep = dol_now();
             $actioncomm->userownerid = $user->id;
-            $rescreate = $actioncomm->create($user);
-            
-            if ($rescreate > 0) {
-                // Manually tag it as 'project_closed' so the summary widget can find it
-                $sqlExtraEvent = "INSERT INTO " . MAIN_DB_PREFIX . "actioncomm_extrafields (fk_object, reedcrm_status_object) VALUES (" . (int)$rescreate . ", 'project_closed') ON DUPLICATE KEY UPDATE reedcrm_status_object = 'project_closed'";
-                $db->query($sqlExtraEvent);
+            if (!empty($comment)) {
+                $actioncomm->note_private = $comment;
             }
+            // Tag it as 'project_closed' so the summary widget can find it (create() persists extrafields)
+            $actioncomm->array_options['options_reedcrm_status_object'] = 'project_closed';
+            $actioncomm->create($user);
         }
 
         $db->commit();

--- a/class/actions_reedcrm.class.php
+++ b/class/actions_reedcrm.class.php
@@ -3253,7 +3253,7 @@ class ActionsReedcrm
                                             <button type="button" id="rcrm-btn-won" style="background:none; border:2px solid transparent; border-radius:4px; padding:2px; font-size:20px; cursor:pointer; opacity:1; transition:all 0.2s; line-height:1;" title="Gagné">🤩</button>
                                         </div>
                                         <div id="rcrm-comment-row" style="display:flex; align-items:center; gap:8px; margin-top:6px;">
-                                            <input type="text" id="rcrm-close-comment" placeholder="La raison du refus..." style="flex-grow:1; border:1px solid #ced4da; border-radius:4px; font-size:12px; padding:4px; outline:none;" />
+                                            <input type="text" id="rcrm-close-comment" placeholder="Précision manuscrite (optionnel)..." style="flex-grow:1; border:1px solid #ced4da; border-radius:4px; font-size:12px; padding:4px; outline:none;" />
                                             <button type="button" id="rcrm-btn-save" disabled title="Enregistrer et clôturer" style="background:#f8f9fa; border:2px solid #ced4da; color:#adb5bd; border-radius:4px; padding:2px 6px; cursor:not-allowed; font-size:14px; transition:all 0.2s;"><i class="fas fa-save"></i></button>
                                         </div>
                                     </div>
@@ -3279,7 +3279,7 @@ class ActionsReedcrm
                                     
                                     if (selectedStatus === "WON") {
                                         isValid = true;
-                                    } else if (selectedStatus === "LOST" && reason && comment) {
+                                    } else if (selectedStatus === "LOST" && reason) {
                                         isValid = true;
                                     }
                                     
@@ -3300,7 +3300,7 @@ class ActionsReedcrm
                                     $("#rcrm-btn-won").css("border-color", "transparent");
                                     $("#rcrm-close-reason").show();
                                     $("#rcrm-won-date, #rcrm-won-budget, #rcrm-won-currency").hide();
-                                    $("#rcrm-close-comment").attr("placeholder", "La raison du refus...");
+                                    $("#rcrm-close-comment").attr("placeholder", "Précision manuscrite (optionnel)...");
                                     checkSaveEnabled();
                                 });
                                 $("#rcrm-btn-won").on("click", function(e) {


### PR DESCRIPTION
## Contexte

Fixes #601

À la clôture d'une opportunité en **Perdu**, le widget imposait de **choisir une raison dans le dictionnaire ET de la ré-écrire** dans un champ texte libre (obligatoire). La raison du dico n'était stockée que dans l'extrafield `opprefusal` et **n'apparaissait jamais** dans le libellé de l'event de clôture.

## Correctif fonctionnel

- **Commentaire optionnel** : sélectionner une raison dans la liste suffit pour enregistrer (`actions_reedcrm.class.php` — validation + placeholders).
- **Libellé de l'event = raison du dictionnaire** : `PJ… - Clôturé - <raison du dico>`.
- **Le manuscrit (si saisi) va en description** de l'event (`note_private`), plus dans le titre.

## Nettoyage `$sql` → fonctions natives Dolibarr (`ajax/close_record.php`)

| Avant (SQL à la main) | Après (natif) |
|---|---|
| `SELECT … c_lead_status WHERE code=…` | `dol_getIdFromCode($db, $statusStr, 'c_lead_status', 'code', 'rowid')` |
| `SELECT … c_refusal_reason WHERE rowid=…` | `getDictionaryValue('c_refusal_reason', 'ref'/'label', …)` |
| `SELECT id FROM actioncomm …` + `UPDATE actioncomm SET label …` | `ActionComm::getActions()` + `$event->update($user)` |
| `INSERT … actioncomm_extrafields …` | `$actioncomm->array_options['options_reedcrm_status_object']` (persisté par `create()`) |
| `UPDATE projet_extrafields SET opprefusal …` (failsafe redondant) | **supprimé** (`insertExtraFields()` le fait déjà) |

Bénéfices : escaping/entité gérés, triggers déclenchés, cache dico, code plus court.

## Notes
- Le `note_private` reçoit `$comment` (lu en `GETPOST(..., 'alpha')`). Comme il devient une vraie description, on pourrait passer à `'restricthtml'` pour préserver ponctuation/accents — laissé tel quel ici (hors périmètre), à voir en suivi.
- Le flux **reopen** (L41) garde sa requête JOIN sur `actioncomm_extrafields` (migration plus risquée, hors périmètre de cette PR).

## Test
1. Ouvrir une opportunité, cliquer 😭 **Perdu**, choisir une raison dans la liste **sans rien taper** → le bouton enregistrer s'active.
2. Enregistrer → l'event s'appelle `PJ… - Clôturé - <raison choisie>`.
3. Avec une précision manuscrite → elle apparaît dans la **description** de l'event (pas le titre).