### PR TITLE
#709 [RelaunchBlock] fix: restore hover tooltip on header relaunch buttons

### DIFF
--- a/class/actions_reedcrm.class.php
+++ b/class/actions_reedcrm.class.php
@@ -550,7 +550,9 @@ class ActionsReedcrm
                 $out .= '<div class="contact-inline-wrapper reedcrm-header-relaunch-master" style="display: inline-flex; align-items: center; background: #f8fbff; border: 1px solid #e2e8f0; border-radius: 6px; padding: 4px 8px 4px 6px; vertical-align: middle; font-weight: 500; font-size: 0.9em; margin-bottom: 2px; color: #4a5568;">';
                 $out .= '<img src="' . $pictoPath . '" style="height: 18px; width: 18px; object-fit: contain; margin-right: 8px; border-right: 1px solid #cbd5e0; padding-right: 8px;" alt="ReedCRM" />';
 
-                $out .= '<div class="reedcrm-plist-relaunch-buttons reedcrm-relaunch-buttons" style="display: inline-flex; align-items: center; gap: 4px;">';
+                // socid is required by the hover tooltip when there is no project context (propal/thirdparty cards)
+                $socidAttr = !$isProjectContext ? ' data-socid="' . (int) $socid . '"' : '';
+                $out .= '<div class="reedcrm-plist-relaunch-buttons reedcrm-relaunch-buttons"' . $socidAttr . ' style="display: inline-flex; align-items: center; gap: 4px;">';
                 $relaunchAjaxUrl = dol_buildpath('/custom/reedcrm/ajax/get_relaunches_list.php', 1);
 
                 foreach ($actonComsByType as $actionCommType => $actonComByType) {
@@ -562,6 +564,7 @@ class ActionsReedcrm
                     $out .= ' data-dialog-url="' . dol_escape_htmltag($relaunchAjaxUrl) . '"';
                     $out .= ' data-dialog-footer="none"';
                     $out .= ' data-project-id="' . $projectId . '"';
+                    $out .= ' data-relaunch-type="' . $actionCommType . '"'; // consumed by the hover tooltip (initRelaunchTooltips)
                     $out .= ' data-action-comm-type="' . $actonComByType['actioncode'] . '">';
 
                     $out .= '<div class="reedcrm-plist-relaunch-btn-content">';


### PR DESCRIPTION
## Contexte

Le survol des boutons de relance ne montrait plus la liste des dernières relances sur les fiches propale (et tiers).

La rework #674 (`669334f`) a remplacé l'ancien badge unique de l'en-tête par des boutons typés, sans reporter les attributs `data-*` consommés par le tooltip au survol (`initRelaunchTooltips` dans `js/modules/eventpro.js`). Résultat : sur une propale `projectId = 0`, `data-socid` absent et `data-relaunch-type` manquant → le garde du handler sort immédiatement et le tooltip ne s'affiche jamais.

## Changements

- Ajout de `data-relaunch-type` sur chaque bouton de relance de l'en-tête (aligne le header sur le pattern de la vue liste, qui fonctionne).
- Ajout de `data-socid` sur le wrapper pour les contextes hors projet (propale / tiers), nécessaire car `projectId` y vaut 0.

Aucune modification du JS partagé : pas de risque de régression sur la vue liste. L'attribut `data-action-comm-type` existant (utilisé par le dialog au clic) est conservé. Le tooltip reste accessible aux utilisateurs en lecture seule (l'endpoint AJAX ne requiert que le droit `agenda read`).

## Fichiers modifiés

- `class/actions_reedcrm.class.php`

## Issue

#709
