### PR TITLE
#769 [Dolistore] fix: use 2-attempt reedcrm.main.inc.php include

### DIFF
--- a/ajax/close_record.php
+++ b/ajax/close_record.php
@@ -6,7 +6,14 @@
 
 // define('NOCSRFCHECK', 1); // We now pass the token natively
 
-require '../../../main.inc.php';
+// Load ReedCRM environment
+if (file_exists('../reedcrm.main.inc.php')) {
+    require_once __DIR__ . '/../reedcrm.main.inc.php';
+} elseif (file_exists('../../reedcrm.main.inc.php')) {
+    require_once __DIR__ . '/../../reedcrm.main.inc.php';
+} else {
+    die('Include of reedcrm main fails');
+}
 
 header('Content-Type: application/json; charset=utf-8');
 require_once DOL_DOCUMENT_ROOT . '/projet/class/project.class.php';

--- a/ajax/save_kpi_layout.php
+++ b/ajax/save_kpi_layout.php
@@ -22,7 +22,15 @@
  * \brief   AJAX endpoint to save/reset the per-user opportunity KPI banner layout (order + hidden cards)
  */
 
-require '../../../main.inc.php';
+// Load ReedCRM environment
+if (file_exists('../reedcrm.main.inc.php')) {
+    require_once __DIR__ . '/../reedcrm.main.inc.php';
+} elseif (file_exists('../../reedcrm.main.inc.php')) {
+    require_once __DIR__ . '/../../reedcrm.main.inc.php';
+} else {
+    die('Include of reedcrm main fails');
+}
+
 require_once DOL_DOCUMENT_ROOT . '/core/lib/functions2.lib.php';
 
 header('Content-Type: application/json');

--- a/ajax/save_project_view.php
+++ b/ajax/save_project_view.php
@@ -22,7 +22,15 @@
  * \brief   AJAX endpoint to save/delete per-user saved views (stored in llx_user_param)
  */
 
-require '../../../main.inc.php';
+// Load ReedCRM environment
+if (file_exists('../reedcrm.main.inc.php')) {
+    require_once __DIR__ . '/../reedcrm.main.inc.php';
+} elseif (file_exists('../../reedcrm.main.inc.php')) {
+    require_once __DIR__ . '/../../reedcrm.main.inc.php';
+} else {
+    die('Include of reedcrm main fails');
+}
+
 require_once DOL_DOCUMENT_ROOT . '/core/lib/functions2.lib.php';
 
 header('Content-Type: application/json');

--- a/ajax/save_pwa_nav_favorites.php
+++ b/ajax/save_pwa_nav_favorites.php
@@ -22,7 +22,15 @@
  * \brief   AJAX endpoint to save/reset the per-user PWA bottom nav favorites (stored in llx_user_param)
  */
 
-require '../../../main.inc.php';
+// Load ReedCRM environment
+if (file_exists('../reedcrm.main.inc.php')) {
+    require_once __DIR__ . '/../reedcrm.main.inc.php';
+} elseif (file_exists('../../reedcrm.main.inc.php')) {
+    require_once __DIR__ . '/../../reedcrm.main.inc.php';
+} else {
+    die('Include of reedcrm main fails');
+}
+
 require_once DOL_DOCUMENT_ROOT . '/core/lib/functions2.lib.php';
 require_once __DIR__ . '/../lib/reedcrm_pwa_nav.lib.php';
 

--- a/ajax/update_action_label.php
+++ b/ajax/update_action_label.php
@@ -1,5 +1,13 @@
 <?php
-require '../../../main.inc.php';
+// Load ReedCRM environment
+if (file_exists('../reedcrm.main.inc.php')) {
+    require_once __DIR__ . '/../reedcrm.main.inc.php';
+} elseif (file_exists('../../reedcrm.main.inc.php')) {
+    require_once __DIR__ . '/../../reedcrm.main.inc.php';
+} else {
+    die('Include of reedcrm main fails');
+}
+
 require_once DOL_DOCUMENT_ROOT . '/comm/action/class/actioncomm.class.php';
 
 header('Content-Type: application/json');

--- a/expedition_list.php
+++ b/expedition_list.php
@@ -32,8 +32,15 @@
  *      \brief      Page to list all shipments
  */
 
-// Load Dolibarr environment
-require '../../main.inc.php';
+// Load ReedCRM environment
+if (file_exists('reedcrm.main.inc.php')) {
+    require_once __DIR__ . '/reedcrm.main.inc.php';
+} elseif (file_exists('../reedcrm.main.inc.php')) {
+    require_once __DIR__ . '/../reedcrm.main.inc.php';
+} else {
+    die('Include of reedcrm main fails');
+}
+
 require_once DOL_DOCUMENT_ROOT.'/expedition/class/expedition.class.php';
 require_once DOL_DOCUMENT_ROOT.'/core/class/html.formfile.class.php';
 require_once DOL_DOCUMENT_ROOT.'/core/class/html.formother.class.php';


### PR DESCRIPTION
## Changements

- Remplacement de l'include direct `require '../../../main.inc.php';` par le bloc à **2 tentatives** sur `reedcrm.main.inc.php` (support module en racine Dolibarr **et** dans `custom/`), conforme aux règles de package Dolistore.
- Correction des 2 fichiers signalés par le validateur Dolistore + 4 autres fichiers porteurs du même anti-pattern (rejetés au prochain upload).

## Fichiers modifiés

- `ajax/close_record.php`
- `ajax/update_action_label.php`
- `ajax/save_pwa_nav_favorites.php`
- `ajax/save_project_view.php`
- `ajax/save_kpi_layout.php`
- `expedition_list.php` (racine : pattern `reedcrm.main.inc.php` / `../reedcrm.main.inc.php`)

`php -l` : aucune erreur de syntaxe sur les 6 fichiers.

## Issue

Closes #769
