### PR TITLE
#773 [Traductions] Fix: Clés manquantes RelauchCommercial et ContactDetails

### DIFF
--- a/langs/fr_FR/reedcrm.lang
+++ b/langs/fr_FR/reedcrm.lang
@@ -511,3 +511,8 @@ ReedCRMNoTimeEntries=Aucun temps pointé sur cette tâche.
 ReadMyCallLists=Voir mes listes d'appel
 ReadSubordinatesCallLists=Voir les listes d'appel de mes subordonnés
 ReadAllCallLists=Voir toutes les listes d'appel
+
+# Propositions - Colonnes liste
+PropalList=Liste des propositions
+RelauchCommercial=Relance commerciale
+ContactDetails=Coordonnées du contact


### PR DESCRIPTION
## Description
Sur la liste des propositions commerciales, les en-tetes de colonnes affichent les cles brutes :
- `RelauchCommercial` → `Relance commerciale`
- `ContactDetails` → `Coordonnees du contact`

## Correction
Ajout des traductions manquantes dans `langs/fr_FR/reedcrm.lang`.

Closes #773