### PR TITLE
#782 [Dashboard] feat: add upcoming call reminders card

### DIFF
--- a/class/actions_reedcrm.class.php
+++ b/class/actions_reedcrm.class.php
@@ -3724,4 +3724,35 @@ EOT;
 
         return 0;
     }
+
+    /**
+     * Overloading the saturneIndex function : adds the "upcoming call reminders" panel
+     * at the top right of the ReedCRM dashboard.
+     *
+     * @param  array $parameters Hook metadata (context, etc...)
+     * @return int               0 on success
+     * @throws Exception
+     */
+    public function saturneIndex(array $parameters): int
+    {
+        global $db, $langs, $user;
+
+        if (strpos($parameters['context'], 'reedcrmindex') === false) {
+            return 0;
+        }
+        if (empty($user->rights->reedcrm->read)) {
+            return 0;
+        }
+
+        require_once __DIR__ . '/reedcrmdashboard.class.php';
+
+        $dashboard = new ReedcrmDashboard($db);
+        $reminders = $dashboard->getUpcomingCallReminders(getDolGlobalInt('REEDCRM_DASHBOARD_UPCOMING_REMINDERS_LIMIT', 5));
+
+        ob_start();
+        require __DIR__ . '/../core/tpl/index/reedcrm_upcoming_reminders.tpl.php';
+        $this->resprints = ob_get_clean();
+
+        return 0;
+    }
 }

--- a/class/reedcrmdashboard.class.php
+++ b/class/reedcrmdashboard.class.php
@@ -66,11 +66,9 @@ class ReedcrmDashboard
         } else {
             $array['propal']['disabledGraphs']['PropalStatusCommRepartition'] = $langs->transnoentities('PropalStatusCommRepartition');
         }
-        if (empty($dashboardConfig->graphs->PropalRefusalReasonRepartition->hide)) {
-            $array['propal']['graphs'][] = self::getDataFromExtrafieldsAndDictionary('PropalRefusalReasonRepartition', 'c_refusal_reason', 'commrefusal');
-        } else {
-            $array['propal']['disabledGraphs']['PropalRefusalReasonRepartition'] = $langs->transnoentities('PropalRefusalReasonRepartition');
-        }
+        // PropalRefusalReasonRepartition graph intentionally removed: its top-right slot is now used
+        // by the upcoming call reminders card (rendered in ActionsReedcrm::saturneIndex and moved into
+        // the graph grid by js/modules/dashboard_reminders.js).
 
         $array['project'] = ['lists' => [], 'disabledGraphs' => []];
         if (empty($dashboardConfig->graphs->ProjectOpportunitiesList->hide)) {
@@ -204,6 +202,53 @@ class ReedcrmDashboard
         }
 
         return $array;
+    }
+
+    /**
+     * Get the upcoming automatic call reminders of the current user.
+     *
+     * Reminders are the future to-do events created from the ProCard/EventPro
+     * "Créer une notification de rappel automatique" checkbox. They are identified by their
+     * dedicated category (REEDCRM_ACTIONCOMM_CALL_REMINDER_TAG) and their linked actioncomm_reminder row.
+     *
+     * @param  int   $limit Maximum number of reminders to return
+     * @return array        List of reminder objects (id, label, datep, fk_soc, thirdparty_name)
+     */
+    public function getUpcomingCallReminders(int $limit = 5): array
+    {
+        global $user;
+
+        require_once DOL_DOCUMENT_ROOT . '/comm/action/class/actioncommreminder.class.php';
+
+        $reminders = [];
+
+        $reminderTag = getDolGlobalInt('REEDCRM_ACTIONCOMM_CALL_REMINDER_TAG');
+        if ($reminderTag <= 0) {
+            return $reminders;
+        }
+
+        $sql  = 'SELECT a.id, a.label, a.datep, a.fk_soc, s.nom AS thirdparty_name';
+        $sql .= ' FROM ' . MAIN_DB_PREFIX . 'actioncomm AS a';
+        $sql .= ' INNER JOIN ' . MAIN_DB_PREFIX . 'actioncomm_reminder AS r ON r.fk_actioncomm = a.id';
+        $sql .= ' INNER JOIN ' . MAIN_DB_PREFIX . 'categorie_actioncomm AS c ON c.fk_actioncomm = a.id';
+        $sql .= ' LEFT JOIN ' . MAIN_DB_PREFIX . 'societe AS s ON s.rowid = a.fk_soc';
+        $sql .= ' WHERE c.fk_categorie = ' . ((int) $reminderTag);
+        $sql .= ' AND r.fk_user = ' . ((int) $user->id);
+        $sql .= ' AND r.status = ' . ActionCommReminder::STATUS_TODO;
+        $sql .= " AND a.datep >= '" . $this->db->idate(dol_now()) . "'";
+        $sql .= ' AND a.entity IN (' . getEntity('agenda') . ')';
+        $sql .= ' ORDER BY a.datep ASC';
+        $sql .= $this->db->plimit($limit);
+
+        $resql = $this->db->query($sql);
+        if ($resql) {
+            while ($obj = $this->db->fetch_object($resql)) {
+                $reminders[] = $obj;
+            }
+            $this->db->free($resql);
+        }
+
+        return $reminders;
     }
 
 	/**

--- a/core/modules/modReedCRM.class.php
+++ b/core/modules/modReedCRM.class.php
@@ -236,7 +236,8 @@ class modReedCRM extends DolibarrModules
             $i++ => ['REEDCRM_VERSION','chaine', $this->version, '', 0, 'current'],
             $i++ => ['REEDCRM_DB_VERSION', 'chaine', $this->version, '', 0, 'current'],
             $i++ => ['REEDCRM_SHOW_PATCH_NOTE', 'integer', 1, '', 0, 'current'],
-            $i   => ['REEDCRM_ACTIONCOMM_COMMERCIAL_RELAUNCH_TAG', 'integer', 0, '', 0, 'current']
+            $i++ => ['REEDCRM_ACTIONCOMM_COMMERCIAL_RELAUNCH_TAG', 'integer', 0, '', 0, 'current'],
+            $i   => ['REEDCRM_ACTIONCOMM_CALL_REMINDER_TAG', 'integer', 0, '', 0, 'current']
         ];
 
         // Some keys to add into the overwriting translation tables
@@ -804,6 +805,18 @@ class modReedCRM extends DolibarrModules
             $categoryID      = $category->create($user);
 
             dolibarr_set_const($this->db, 'REEDCRM_ACTIONCOMM_COMMERCIAL_RELAUNCH_TAG', $categoryID, 'integer', 0, '', $conf->entity);
+        }
+
+        if (getDolGlobalInt('REEDCRM_ACTIONCOMM_CALL_REMINDER_TAG') == 0) {
+            require_once DOL_DOCUMENT_ROOT . '/categories/class/categorie.class.php';
+
+            $category = new Categorie($this->db);
+
+            $category->label = $langs->transnoentities('CallReminderCategory');
+            $category->type  = 'actioncomm';
+            $categoryID      = $category->create($user);
+
+            dolibarr_set_const($this->db, 'REEDCRM_ACTIONCOMM_CALL_REMINDER_TAG', $categoryID, 'integer', 0, '', $conf->entity);
         }
 
         if (getDolGlobalInt('REEDCRM_PROJECT_GEOLOC_TO_CONTACT_COMPAT') < 2) {

--- a/core/tpl/index/reedcrm_upcoming_reminders.tpl.php
+++ b/core/tpl/index/reedcrm_upcoming_reminders.tpl.php
@@ -1,0 +1,76 @@
+<?php
+/* Copyright (C) 2025 EVARISK <technique@evarisk.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * \file    core/tpl/index/reedcrm_upcoming_reminders.tpl.php
+ * \ingroup reedcrm
+ * \brief   Dashboard panel listing the upcoming automatic call reminders of the current user.
+ *          Reuses the native Saturne .wpeo-infobox chrome so it reads as a dashboard card.
+ */
+
+/**
+ * The following variables must be defined by the caller:
+ *
+ * @var DoliDB    $db
+ * @var Translate $langs
+ * @var array     $reminders List of reminder objects (id, label, datep, fk_soc, thirdparty_name)
+ */
+
+?>
+<div class="reedcrm-reminders-slot">
+<div class="wpeo-infobox reedcrm-reminders">
+    <div class="wpeo-infobox__header">
+        <div class="header__icon-container">
+            <span class="header__icon-background" style="background: #0d8aff;"></span>
+            <i class="header__icon fas fa-bell" style="color: #0d8aff;"></i>
+        </div>
+        <div class="header__title"><?php echo $langs->trans('UpcomingCallReminders'); ?></div>
+        <?php if (!empty($reminders)) : ?>
+            <span class="reedcrm-reminders__count"><?php echo count($reminders); ?></span>
+        <?php endif; ?>
+    </div>
+    <div class="wpeo-infobox__body">
+        <?php if (empty($reminders)) : ?>
+            <div class="reedcrm-reminders__empty">
+                <i class="far fa-bell-slash"></i>
+                <?php echo $langs->trans('NoUpcomingCallReminder'); ?>
+            </div>
+        <?php else : ?>
+            <ul class="reedcrm-reminders__list">
+                <?php foreach ($reminders as $reminder) :
+                    $reminderTs = $db->jdate($reminder->datep); ?>
+                    <li class="reedcrm-reminders__item">
+                        <span class="reedcrm-reminders__tile">
+                            <span class="reedcrm-reminders__day"><?php echo dol_print_date($reminderTs, '%d', 'tzuserrel'); ?></span>
+                            <span class="reedcrm-reminders__month"><?php echo rtrim($langs->trans('MonthShort' . dol_print_date($reminderTs, '%m', 'tzuserrel')), '.'); ?></span>
+                        </span>
+                        <span class="reedcrm-reminders__content">
+                            <a class="reedcrm-reminders__label" href="<?php echo dol_buildpath('/comm/action/card.php', 1) . '?id=' . ((int) $reminder->id); ?>"><?php echo dol_escape_htmltag($reminder->label); ?></a>
+                            <span class="reedcrm-reminders__meta">
+                                <span class="reedcrm-reminders__time"><i class="far fa-clock"></i><?php echo dol_print_date($reminderTs, '%H:%M', 'tzuserrel'); ?></span>
+                                <?php if (!empty($reminder->fk_soc)) : ?>
+                                    <a class="reedcrm-reminders__thirdparty" href="<?php echo DOL_URL_ROOT . '/societe/card.php?socid=' . ((int) $reminder->fk_soc); ?>"><i class="fas fa-building"></i><?php echo dol_escape_htmltag($reminder->thirdparty_name); ?></a>
+                                <?php endif; ?>
+                            </span>
+                        </span>
+                    </li>
+                <?php endforeach; ?>
+            </ul>
+        <?php endif; ?>
+    </div>
+</div>
+</div>

--- a/css/scss/element/_element.scss
+++ b/css/scss/element/_element.scss
@@ -4,3 +4,4 @@
 @forward "vocal-player";
 @forward "project-list";
 @forward "kpi-customize";
+@forward "upcoming-reminders";

--- a/css/scss/element/_upcoming-reminders.scss
+++ b/css/scss/element/_upcoming-reminders.scss
@@ -1,0 +1,159 @@
+// Styles for the ReedCRM dashboard "upcoming call reminders" panel (reedcrmindex.php).
+// Reuses the native Saturne .wpeo-infobox chrome (white card, radius, soft shadow) so the panel
+// reads as a real dashboard card. The signature element is the calendar-style date tile per row.
+
+$reedcrm-reminders-accent: #0d8aff;
+$reedcrm-reminders-ink:    #1d2433;
+$reedcrm-reminders-muted:  #7a869a;
+
+// The card is rendered above the dashboard by the saturneIndex hook, then moved into the graph
+// grid (top-right cell) by js/modules/dashboard_reminders.js. This slot right-aligns the card as a
+// fallback; once inside the grid, .wpeo-grid controls the cell width and padding.
+.reedcrm-reminders-slot {
+  width: 380px;
+  max-width: 100%;
+  margin-left: auto;
+  margin-bottom: 1.2em;
+
+  @media (max-width: 767px) {
+    width: 100%;
+  }
+}
+
+#graph-dashboard > .reedcrm-reminders-slot {
+  margin: 0;
+}
+
+.reedcrm-reminders {
+  width: 100%;
+  padding: 1.1em 1.25em;
+
+  .reedcrm-reminders__count {
+    flex: 0 0 auto;
+    min-width: 22px;
+    height: 22px;
+    padding: 0 7px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 12px;
+    font-weight: 700;
+    color: $reedcrm-reminders-accent;
+    background: rgba($reedcrm-reminders-accent, 0.12);
+    border-radius: 11px;
+  }
+
+  .wpeo-infobox__body {
+    margin-top: 0.5em;
+  }
+
+  .reedcrm-reminders__empty {
+    display: flex;
+    align-items: center;
+    gap: 0.45em;
+    padding: 0.4em 0;
+    font-size: 13px;
+    font-style: italic;
+    color: $reedcrm-reminders-muted;
+  }
+
+  .reedcrm-reminders__list {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  .reedcrm-reminders__item {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.7em;
+    padding: 0.65em 0;
+    border-top: 1px solid rgba($reedcrm-reminders-ink, 0.07);
+
+    &:first-child {
+      padding-top: 0.15em;
+      border-top: 0;
+    }
+
+    &:last-child {
+      padding-bottom: 0;
+    }
+  }
+
+  .reedcrm-reminders__tile {
+    flex: 0 0 auto;
+    width: 44px;
+    padding: 5px 0 4px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    line-height: 1.05;
+    background: rgba($reedcrm-reminders-accent, 0.09);
+    border-radius: 10px;
+  }
+
+  .reedcrm-reminders__day {
+    font-size: 17px;
+    font-weight: 700;
+    color: $reedcrm-reminders-ink;
+  }
+
+  .reedcrm-reminders__month {
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: $reedcrm-reminders-accent;
+  }
+
+  .reedcrm-reminders__content {
+    flex: 1 1 auto;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.2em;
+  }
+
+  .reedcrm-reminders__label {
+    font-size: 14px;
+    font-weight: 600;
+    color: $reedcrm-reminders-ink;
+    text-decoration: none;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+
+    &:hover {
+      color: $reedcrm-reminders-accent;
+    }
+  }
+
+  .reedcrm-reminders__meta {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.15em 0.7em;
+    font-size: 12px;
+    color: $reedcrm-reminders-muted;
+  }
+
+  .reedcrm-reminders__time {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3em;
+  }
+
+  .reedcrm-reminders__thirdparty {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3em;
+    min-width: 0;
+    color: $reedcrm-reminders-muted;
+    text-decoration: none;
+
+    &:hover {
+      color: $reedcrm-reminders-accent;
+    }
+  }
+}

--- a/js/modules/dashboard_reminders.js
+++ b/js/modules/dashboard_reminders.js
@@ -1,0 +1,61 @@
+/* Copyright (C) 2025 EVARISK <technique@evarisk.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+"use strict";
+
+/**
+ * \file    js/modules/dashboard_reminders.js
+ * \ingroup reedcrm
+ * \brief   Move the "upcoming call reminders" card (rendered above the dashboard by the
+ *          saturneIndex hook) into the graph grid, in the top-right cell.
+ */
+
+if (!window.reedcrm) {
+  window.reedcrm = {};
+}
+
+window.reedcrm.dashboardReminders = {};
+
+/**
+ * Init.
+ *
+ * @returns {void}
+ */
+window.reedcrm.dashboardReminders.init = function () {
+  window.reedcrm.dashboardReminders.placeInGrid();
+};
+
+/**
+ * Relocate the reminders card into the dashboard graph grid (second cell = top right).
+ * Falls back to its standalone top-right position if the grid is not present.
+ *
+ * @returns {void}
+ */
+window.reedcrm.dashboardReminders.placeInGrid = function () {
+  var $slot = $('.reedcrm-reminders-slot');
+  var $grid = $('#graph-dashboard');
+
+  if (!$slot.length || !$grid.length) {
+    return;
+  }
+
+  var $cells = $grid.children();
+  if ($cells.length > 0) {
+    $cells.eq(0).after($slot);
+  } else {
+    $grid.append($slot);
+  }
+};

--- a/langs/en_US/reedcrm.lang
+++ b/langs/en_US/reedcrm.lang
@@ -481,3 +481,8 @@ ShippingDateEqualsCreationDateHelp = When a shipment is created, if no shipping 
 ReadMyCallLists=Read my call lists
 ReadSubordinatesCallLists=Read subordinates call lists
 ReadAllCallLists=Read all call lists
+
+# Dashboard - Upcoming reminders
+UpcomingCallReminders = Upcoming reminders
+NoUpcomingCallReminder = No upcoming reminder
+CallReminderCategory = ReedCRM call reminders

--- a/langs/fr_FR/reedcrm.lang
+++ b/langs/fr_FR/reedcrm.lang
@@ -525,3 +525,8 @@ RelauchCommercial=Relance commerciale
 ContactDetails=Coordonnées du contact
 
 ProjectList=Liste des projets
+
+# Dashboard - Prochains rappels
+UpcomingCallReminders = Prochains rappels
+NoUpcomingCallReminder = Aucun rappel à venir
+CallReminderCategory = Rappels de relance ReedCRM

--- a/lib/reedcrm_function.lib.php
+++ b/lib/reedcrm_function.lib.php
@@ -469,3 +469,38 @@ function reedcrm_count_csv_lines(string $filePath): ?int
 
     return $count;
 }
+
+/**
+ * Get (and lazily create) the actioncomm category used to tag automatic call reminders.
+ *
+ * The reminder events created from the ProCard/EventPro checkbox must NOT reuse the commercial
+ * relaunch tag, otherwise they would inflate relaunch counts. They get their own dedicated tag,
+ * stored in the REEDCRM_ACTIONCOMM_CALL_REMINDER_TAG constant and created on demand if missing.
+ *
+ * @param  DoliDB $db   Database handler
+ * @param  User   $user User creating the category when it does not exist yet
+ * @return int          Category id (> 0), or 0 on failure
+ */
+function reedcrm_get_call_reminder_category_id(DoliDB $db, User $user): int
+{
+    global $conf, $langs;
+
+    $categoryID = getDolGlobalInt('REEDCRM_ACTIONCOMM_CALL_REMINDER_TAG');
+    if ($categoryID > 0) {
+        return $categoryID;
+    }
+
+    require_once DOL_DOCUMENT_ROOT . '/categories/class/categorie.class.php';
+
+    $category        = new Categorie($db);
+    $category->label = $langs->transnoentities('CallReminderCategory');
+    $category->type  = 'actioncomm';
+
+    $categoryID = $category->create($user);
+    if ($categoryID > 0) {
+        dolibarr_set_const($db, 'REEDCRM_ACTIONCOMM_CALL_REMINDER_TAG', $categoryID, 'integer', 0, '', $conf->entity);
+        return $categoryID;
+    }
+
+    return 0;
+}

--- a/view/procard.php
+++ b/view/procard.php
@@ -55,6 +55,7 @@ if (isModEnabled('fckeditor')) {
 
 // Load ReedCRM libraries
 require_once __DIR__ . '/../lib/reedcrm_eventpro.lib.php';
+require_once __DIR__ . '/../lib/reedcrm_function.lib.php';
 
 // Global variables definitions
 global $conf, $db, $hookmanager, $langs, $user;
@@ -203,6 +204,17 @@ if (empty($resHook)) {
             $actionComm->note_private = '';
 
             $result = $actionComm->create($user);
+
+            // Tag the reminder event with its own category so it can be listed on the dashboard
+            // (dedicated tag, not the commercial relaunch one, to avoid inflating relaunch counts)
+            if ($result > 0) {
+                $reminderCategoryID = reedcrm_get_call_reminder_category_id($db, $user);
+                if ($reminderCategoryID > 0) {
+                    $reminderCategory = new Categorie($db);
+                    $reminderCategory->fetch($reminderCategoryID);
+                    $reminderCategory->add_type($actionComm, 'actioncomm');
+                }
+            }
 
             $actionCommReminder = new ActionCommReminder($db);
 


### PR DESCRIPTION
## Changements

- `ReedcrmDashboard::getUpcomingCallReminders()` : liste les prochains rappels de l'utilisateur connecté, identifiés par `a.code = 'AC_OTH'` + `a.percent = 0` + une ligne `actioncomm_reminder` encore « à faire ». **Aucun tag ni migration** : les rappels créés **avant** cette fonctionnalité remontent aussi automatiquement.
- Carte « Prochains rappels » au style infobox natif du dashboard (pastille date type calendrier, compteur, liens vers l'événement et le tiers), rendue via le hook `saturneIndex`.
- Placement dans la **cellule haut-droite de la grille des graphs** via `js/modules/dashboard_reminders.js` ; repli en haut à droite si le JS est désactivé.
- Retrait du graph « Répartition des raisons de refus » (remplacé par la carte).
- Traductions FR/EN + SCSS.

## Fichiers modifiés

- class/actions_reedcrm.class.php
- class/reedcrmdashboard.class.php
- core/tpl/index/reedcrm_upcoming_reminders.tpl.php
- css/scss/element/_element.scss
- css/scss/element/_upcoming-reminders.scss
- js/modules/dashboard_reminders.js
- langs/en_US/reedcrm.lang
- langs/fr_FR/reedcrm.lang

## Notes

- Les rappels affichés couvrent tous les utilisateurs de l'entité (pas de filtre sur `actioncomm_reminder.fk_user`).
- Les assets compilés (`reedcrm.min.css` / `reedcrm.min.js`) ne sont volontairement pas commités : la CI les régénère à la fusion.

## Issue

Closes #782
