### PR TITLE
#786 [Frontend] fix: warnings PHP 8 quand le module Projet n'est pas active

### DIFF
--- a/view/frontend/pwa_projets.php
+++ b/view/frontend/pwa_projets.php
@@ -39,7 +39,7 @@ if (!empty($action)) {
     $task    = new Task($db);
     $extraFields = new ExtraFields($db);
     $extraFields->fetch_name_optionals_label($project->table_element);
-    $permissionToAddProject = $user->rights->projet->creer;
+    $permissionToAddProject = $user->hasRight('projet', 'creer');
     require_once __DIR__ . '/../../core/tpl/frontend/reedcrm_quickcreation_actions_frontend.tpl.php';
 }
 
@@ -69,7 +69,7 @@ print '<style>
 }
 </style>';
 
-if (!$user->rights->projet->lire) {
+if (!$user->hasRight('projet', 'lire')) {
     accessforbidden($langs->trans('NotEnoughPermissions'), 0);
     exit;
 }

--- a/view/frontend/quickcreation.php
+++ b/view/frontend/quickcreation.php
@@ -75,8 +75,8 @@ if (isModEnabled('project')) {
 $hookmanager->initHooks(['reedcrm_quickcreation_frontend']); // Note that conf->hooks_modules contains array
 
 // Security check - Protection if external user
-$permissionToRead       = $user->rights->reedcrm->read;
-$permissionToAddProject = $user->rights->projet->creer;
+$permissionToRead       = $user->hasRight('reedcrm', 'read');
+$permissionToAddProject = $user->hasRight('projet', 'creer');
 saturne_check_access($permissionToRead);
 
 /*

--- a/view/quickcreation.php
+++ b/view/quickcreation.php
@@ -88,10 +88,10 @@ $hookmanager->initHooks(['reedcrm_quickcreation']); // Note that conf->hooks_mod
 $date_start = dol_mktime(0, 0, 0, GETPOST('projectstartmonth', 'int'), GETPOST('projectstartday', 'int'), GETPOST('projectstartyear', 'int'));
 
 // Security check - Protection if external user
-$permissiontoread          = $user->rights->reedcrm->read;
-$permissiontoaddproject    = $user->rights->projet->creer;
-$permissiontoaddthirdparty = $user->rights->societe->creer;
-$permissiontoaddcontact    = $user->rights->societe->contact->creer;
+$permissiontoread          = $user->hasRight('reedcrm', 'read');
+$permissiontoaddproject    = $user->hasRight('projet', 'creer');
+$permissiontoaddthirdparty = $user->hasRight('societe', 'creer');
+$permissiontoaddcontact    = $user->hasRight('societe', 'contact', 'creer');
 saturne_check_access($permissiontoread);
 
 /*


### PR DESCRIPTION
Closes #786

## Probleme

Sur la PWA `view/frontend/quickcreation.php`, un client **sans le module Projet** declenche deux warnings PHP 8 :

```
Warning: Undefined property: stdClass::$projet ... on line 79
Warning: Attempt to read property "creer" on null ... on line 79
```

`$user->rights->{module}` n'est peuple que pour les modules **actives** (`User::getrights()` lit `rights_def`). Sans Projet, `$user->rights->projet` n'existe pas -> warning, `null`, puis lecture de `->creer` sur `null`.

## Correctif

Passage a `$user->hasRight(...)`, deja la convention majoritaire du module (`reedcrm_fields.lib.php`, `actions_reedcrm.class.php`, `api_reedcrm.class.php`). `hasRight()` sort en `return 0` des que `!isModEnabled($module)` sans toucher a `$user->rights`.

Corrige aussi le meme bug latent sur :
- `view/frontend/pwa_projets.php` (lignes 42 et 72)
- `view/quickcreation.php` (`projet`, `societe`, `societe->contact`)

`ajax/close_record.php` utilise `empty(...)` : pas de warning, non modifie.

## Verifications

- **Reproduction** avec un bootstrap Dolibarr reel et `$conf->modules['project']` retire : les 2 warnings a l'identique avant / **0 warning** apres, `hasRight()` renvoie `0`.
- **Non-regression module actif** : les 6 expressions renvoient la meme valeur qu'avant (`1`), y compris `hasRight('societe', 'contact', 'creer')` (3 niveaux).
- `php -l` OK (PHP 8.2) sur les 3 fichiers.
- **E2E Playwright** sur l'URL du client : page « Ajout rapide » rendue normalement, formulaire present, 0 warning/notice/deprecated dans le HTML.
- Verdict d'acces inchange : sans le module, `accessforbidden('NotEnoughPermissions')` comme avant, mais proprement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)