### PR TITLE
#788 [Frontend] fix: page blanche sur quickcreation sans le module Projet

### DIFF
--- a/core/tpl/frontend/reedcrm_quickcreation_actions_frontend.tpl.php
+++ b/core/tpl/frontend/reedcrm_quickcreation_actions_frontend.tpl.php
@@ -30,8 +30,8 @@
  */
 
 // Protection to avoid direct call of template
-if (!$permissionToAddProject) {
-    exit;
+if (empty($permissionToAddProject)) {
+    accessforbidden();
 }
 
 require_once DOL_DOCUMENT_ROOT . '/core/lib/files.lib.php';

--- a/view/frontend/quickcreation.php
+++ b/view/frontend/quickcreation.php
@@ -89,7 +89,7 @@ if ($resHook < 0) {
     setEventMessages($hookmanager->error, $hookmanager->errors, 'errors');
 }
 
-if (empty($resHook)) {
+if (empty($resHook) && !empty($permissionToAddProject)) {
     $error = 0;
 
     // Actions add_img, add


### PR DESCRIPTION
Closes #788 — suite de #787 (warnings PHP).

## Probleme

Sans le module **Projet**, `view/frontend/quickcreation.php` renvoie un HTTP 200 avec `Content-Length: 0` -> **page blanche**. Ce n'est pas un fatal PHP : aucune erreur n'est loggee (`display_errors=On`, `log_errors=On`, `E_ALL`), le script sort silencieusement.

Instrumentation de la page : l'execution s'arrete dans le template d'actions, inclus l. 96.

```php
// core/tpl/frontend/reedcrm_quickcreation_actions_frontend.tpl.php
// Protection to avoid direct call of template
if (!$permissionToAddProject) {
    exit;   // <-- tue la page entiere, 0 octet
}
```

Le garde-fou vise l'appel **direct** du template, mais `quickcreation.php` l'inclut **inconditionnellement** dans le bloc Actions. Sans le module Projet, `$permissionToAddProject` vaut 0 -> `exit` -> l'`accessforbidden()` prevu l. 122 n'est jamais atteint.

## Correctif

1. `quickcreation.php` : le template d'actions n'est inclus que si la permission est presente -> le flux normal atteint `accessforbidden()`.
2. Template : `exit` -> `accessforbidden()`, qui affiche une vraie page et sort. Plus aucun chemin (y compris l'appel direct du template, protection conservee) ne peut renvoyer une reponse vide.

## Verifications

Reproduction reelle en desactivant le module Projet en base (`MAIN_MODULE_PROJET=0`), puis restauration :

| | avant | apres |
|---|---|---|
| `quickcreation.php` sans Projet | HTTP 200, **0 octet** (page blanche) | 54 680 octets, « Vous n'avez pas les permissions pour cette action », 0 warning |
| `pwa_projets.php` sans Projet | OK | OK |

Non-regression module **actif** (Playwright, PHP 8.5) :
- page « Ajout rapide » rendue, formulaire present, 0 warning/notice/deprecated ;
- **soumission reelle du formulaire** : lead cree en base (`llx_projet`) -> le template d'actions s'execute toujours normalement (donnee de test supprimee ensuite).
- `php -l` OK sur les 2 fichiers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)