### PR TITLE
#791 [ProCard] fix: avoid "Class FormTicket not found" when Ticket module is disabled

### DIFF
--- a/view/procard.php
+++ b/view/procard.php
@@ -78,7 +78,7 @@ $category   = new Categorie($db);
 $form        = new Form($db);
 $formProject = new FormProjets($db);
 $formActions = new FormActions($db);
-$formTicket  = new FormTicket($db);
+$formTicket  = isModEnabled('ticket') ? new FormTicket($db) : null; // FormTicket class is only loaded when the Ticket module is enabled (see require above)
 
 $hookmanager->initHooks([$object->element . 'eventpro', 'globalcard']); // Note that conf->hooks_modules contains array
 


### PR DESCRIPTION
Closes #791

### Problème
Le quick event (ajout rapide d'événement) depuis la liste des projets — ou une fiche tiers/propale — affiche **« Erreur lors du chargement »** sur les installs **sans le module Ticket**.

`view/procard.php` instanciait `FormTicket` sans condition alors que la classe n'est chargée que sous `isModEnabled('ticket')` → fatal `Class "FormTicket" not found` → HTTP 500 en prod (`display_errors=Off`) → callback `error` de l'AJAX.

### Correctif
```php
-$formTicket  = new FormTicket($db);
+$formTicket  = isModEnabled('ticket') ? new FormTicket($db) : null;
```
`FormTicket` n'est déréférencé que dans l'onglet Ticket, déjà gardé par `isModEnabled('ticket')` — `null` n'est donc jamais utilisé quand le module est absent.

### Tests (local)
| Module Ticket | Code | Résultat |
|---|---|---|
| ON | original | 200 |
| ON | corrigé | 200 (pas de régression) |
| OFF | original | fatal `FormTicket not found` (= 500 en prod) |
| OFF | corrigé | 200, formulaire rendu normalement |

`php -l` OK.