### PR TITLE
#790 [QuickCreation] rework: hide the gravityform field in the project form

### DIFF
--- a/core/tpl/reedcrm_project_quickcreation.tpl.php
+++ b/core/tpl/reedcrm_project_quickcreation.tpl.php
@@ -83,6 +83,13 @@ if ($permissiontoaddproject) {
     if ($conf->global->REEDCRM_PROJECT_EXTRAFIELDS_VISIBLE > 0) {
         $object = $project;
         $extrafields->fetch_name_optionals_label($object->table_element);
+
+        // The GravityForm link is filled in by the incoming form itself, never typed here.
+        // Dropping the key from 'label' takes it out of the showOptionals() loop for this form only,
+        // leaving the extrafield untouched everywhere else (project card button, API).
+        // Same exclusion as the frontend form, see core/tpl/frontend/reedcrm_project_quickcreation_frontend.tpl.php.
+        unset($extrafields->attributes[$object->table_element]['label']['reedcrm_gravityform']);
+
         include DOL_DOCUMENT_ROOT . '/core/tpl/extrafields_add.tpl.php';
         $object = '';
     }


### PR DESCRIPTION
## Changements

Le champ **ReedCRMGravityForm** n'apparaît plus dans le formulaire projet de l'Ajout rapide.

Ce champ porte le lien du formulaire GravityForm d'origine : il est renseigné par le formulaire entrant lui-même (via l'API, `api_reedcrm.class.php`), jamais saisi à la main. Il n'avait donc rien à faire dans un écran de saisie.

L'exclusion retire la clé du tableau `label` juste avant l'appel à `showOptionals()`, dont c'est le tableau qui pilote la boucle de rendu. La portée est donc limitée à ce seul formulaire :

- l'extrafield reste inchangé en base (`list = 1`, `elementtype = projet`) ;
- le bouton « Lien GravityForm » de la fiche projet continue de fonctionner ;
- l'API continue de renseigner le champ.

C'est la même exclusion que celle déjà en place côté formulaire frontend (`core/tpl/frontend/reedcrm_project_quickcreation_frontend.tpl.php`), qui écartait déjà ce champ — seul le formulaire backend l'affichait encore.

## Vérification

Rendu de `showOptionals($extrafields, 'create')` comparé avant / après :

- avant : 5 occurrences de `reedcrm_gravityform` dans le HTML généré ;
- après : 0 ;
- `projectphone` et les autres extrafields du formulaire restent affichés ;
- l'extrafield est inchangé en base.

## Fichiers modifiés

- `core/tpl/reedcrm_project_quickcreation.tpl.php`

## Issue

#790 — item « ReedCRMGravityform à ne pas afficher » (section Ajout rapide)
