### PR TITLE
#790 [Lang] fix: translate the reedcrm project extrafield labels

### DIFF
--- a/langs/en_US/reedcrm.lang
+++ b/langs/en_US/reedcrm.lang
@@ -87,6 +87,15 @@ KeyyoCalls = Keyyo Calls
 # Project Extra
 GravityFormLink=GravityForm Link
 
+# Module project extrafield labels (llx_extrafields.label doubles as the translation key,
+# and showOptionals() only loads the extrafield langfile, here reedcrm@reedcrm).
+# LastName / FirstName live in users.lang, not loaded on those screens, and the core key
+# is "WebSite" not "Website": without these, the quick creation form shows raw keys.
+LastName=Last name
+FirstName=First name
+Website=Website
+ReedCRMGravityForm=GravityForm link
+
 # Geolocation PWA
 DetectingLocation = Detecting your location
 GeolocationNotSupported = Geolocation is not supported by this browser

--- a/langs/fr_FR/reedcrm.lang
+++ b/langs/fr_FR/reedcrm.lang
@@ -212,7 +212,7 @@ UpdateObjectContactTrigger = Mise à jour du rôle "contacts facturation" des fa
 NoContact = Aucun contact
 AddContactNotificationTrigger = Ajout d'une notification contact "action Facture client validée" des tiers
 DictionarySource = Origine des opportunités/devis/commandes/factures
-OpportunityOrigin = Origine de l'opportunitée
+OpportunityOrigin = Origine de l'opportunité
 SRC_INTE = Internet
 SRC_CAMP_MAIL = Campagne Publipostage
 SRC_CAMP_EMAIL = Campagne d'emailing
@@ -237,6 +237,15 @@ Opportunities = Opportunités
 OpenedPropals = PR ouvertes
 RecurringInvoices = Factures récurrentes
 GravityFormLink                        = Lien GravityForm
+
+# Libellés des extrafields projet du module (llx_extrafields.label sert de clé de traduction,
+# et showOptionals() ne charge que le langfile de l'extrafield, ici reedcrm@reedcrm).
+# LastName / FirstName vivent dans users.lang, non chargé sur ces écrans ; le noyau écrit "WebSite"
+# et non "Website" : sans ces clés, l'Ajout rapide affiche les clés brutes.
+LastName                               = Nom
+FirstName                              = Prénom
+Website                                = Site web
+ReedCRMGravityForm                     = Lien GravityForm
 
 # Traductions pour ReedCRM - Notifications d'appel
 IncomingCall = Appel entrant


### PR DESCRIPTION
## Changements

Les extrafields projet du module affichaient leur **clé brute** au lieu d'un libellé traduit dans l'Ajout rapide (et partout ailleurs : fiche projet, sélecteur de colonnes des listes) :

| Champ | Affichait | Affiche |
|---|---|---|
| `reedcrm_lastname` | `LastName` | Nom |
| `reedcrm_firstname` | `FirstName` | Prénom |
| `reedcrm_website` | `Website` | Site web |
| `reedcrm_gravityform` | `ReedCRMGravityForm` | Lien GravityForm |

## Pourquoi

`llx_extrafields.label` sert de clé de traduction, et `showOptionals()` ne charge que le `langfile` déclaré sur l'extrafield — ici `reedcrm@reedcrm`. Or ces quatre clés n'existaient pas dans `reedcrm.lang` :

- `LastName` / `FirstName` vivent dans `users.lang` (noyau), qui n'est pas chargé sur ces écrans. À noter que `companies.lang` définit `Lastname` / `Firstname`, avec une casse différente : ce ne sont pas les mêmes clés.
- Le noyau définit **`WebSite`** (S majuscule) dans `main.lang`, pas `Website`. La casse ne correspondait pas.
- `ReedCRMGravityForm` n'était traduit nulle part.

Les ajouter à `reedcrm.lang` est le correctif le plus sûr : c'est le langfile que le noyau charge déjà pour ces champs, donc ça marche sans toucher à la base ni dépendre du chargement d'un autre domaine de langue.

`Email` n'est pas concerné : la clé se traduit par « Email » en français, elle était donc déjà correcte.

## Au passage

Faute d'orthographe corrigée sur un libellé du même écran : `OpportunityOrigin` = « Origine de l'opportunit**ée** » → « Origine de l'opportunité ».

## Vérification

Rendu réel de `showOptionals($extrafields, 'create')` en `fr_FR`, avant / après : les 4 clés brutes ont disparu du HTML généré. Libellés résolus après correctif :

```
LastName           => Nom
FirstName          => Prénom
Website            => Site web
ReedCRMGravityForm => Lien GravityForm
OpportunityOrigin  => Origine de l'opportunité
```

Aucune de ces clés n'était utilisée ailleurs dans le module (`trans('Website')` etc. : aucun usage direct), et aucune n'existait déjà dans `reedcrm.lang` — pas de collision.

Le champ `qc_frequency`, lui, n'est pas concerné : il appartient à DigiQuali et déclare son propre langfile, que `showOptionals()` charge automatiquement.

## Fichiers modifiés

- `langs/fr_FR/reedcrm.lang`
- `langs/en_US/reedcrm.lang`

## Issue

#790 — item « Traduction de reedcrm dans ajout rapide » (section Ajout rapide)
