### PR TITLE
#790 [CallList] fix: restore the em dash in the default call list label

### DIFF
--- a/langs/fr_FR/reedcrm.lang
+++ b/langs/fr_FR/reedcrm.lang
@@ -435,7 +435,7 @@ CallListWidgetNoContact = Aucun contact associé à cet élément
 CallListWidgetNoPhone = Le contact n'a pas de numéro de téléphone
 CallListWidgetDuplicate = Déjà présent dans cette liste
 CallListWidgetError = Erreur lors de l'ajout
-DefaultCallListLabel = Liste d'appel �?? %s
+DefaultCallListLabel = Liste d'appel — %s
 AddToMyCallList = Ajouter à ma liste d'appel
 DefaultCallListNotFound = Aucune liste d'appel par défaut pour cet utilisateur
 

--- a/sql/migration/index.php
+++ b/sql/migration/index.php
@@ -1,0 +1,2 @@
+<?php
+//Silence is golden

--- a/sql/migration/llx_migration_reedcrm_call_list_label_em_dash.sql
+++ b/sql/migration/llx_migration_reedcrm_call_list_label_em_dash.sql
@@ -1,0 +1,29 @@
+-- Copyright (C) 2026 EVARISK <technique@evarisk.com>
+--
+-- This program is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with this program.  If not, see https://www.gnu.org/licenses/.
+
+-- Restore the em dash in the labels of the auto-created call lists.
+--
+-- The fr_FR DefaultCallListLabel key held a corrupted em dash: the bytes EF BF BD (U+FFFD,
+-- the replacement character) followed by two literal '?'. Every call list created for a user
+-- baked that sequence into llx_reedcrm_call_list.label, and it surfaced everywhere the label
+-- is shown, up to the titles of the agenda events created from a call list.
+--
+-- Bytes are addressed through UNHEX so this file stays pure ASCII and cannot be corrupted again
+-- the same way. EFBFBD3F3F = U+FFFD + '??', E28094 = the em dash the en_US key always had.
+--
+-- Idempotent: only rows still carrying the corrupted sequence match, so re-running the module
+-- activation is harmless.
+
+UPDATE llx_reedcrm_call_list SET label = REPLACE(label, UNHEX('EFBFBD3F3F'), UNHEX('E28094')) WHERE label LIKE CONCAT('%', UNHEX('EFBFBD3F3F'), '%');


### PR DESCRIPTION
## Le problème

La clé `DefaultCallListLabel` du fichier `fr_FR` contenait un **tiret cadratin corrompu** : les octets `EF BF BD` (U+FFFD, le caractère de remplacement) suivis de deux `?` littéraux, là où la clé `en_US` a toujours eu un vrai tiret cadratin.

```
fr_FR : Liste d'appel <U+FFFD>?? %s
en_US : Call list — %s
```

Cette clé sert à nommer la liste d'appel créée automatiquement pour chaque utilisateur (à l'activation du module et au `USER_CREATE`). La séquence corrompue était donc **figée dans `llx_reedcrm_call_list.label`** au moment de la création, et ressortait partout où le libellé est affiché — jusque dans les titres des événements d'agenda créés depuis une liste d'appel :

```
Appel depuis Liste d'appel ??? Justine Paye - Pas de réponse
```

Corriger la traduction ne suffit donc pas : les listes déjà en base gardent le libellé fautif. Sur la base de test, **44 listes** étaient concernées.

## Changements

**1. La clé de traduction** — le tiret cadratin est restauré, à l'identique de `en_US`. C'était le seul U+FFFD du fichier, il n'en reste aucun.

**2. Une migration pour les listes existantes** — `sql/migration/llx_migration_reedcrm_call_list_label_em_dash.sql` :

```sql
UPDATE llx_reedcrm_call_list SET label = REPLACE(label, UNHEX('EFBFBD3F3F'), UNHEX('E28094')) WHERE label LIKE CONCAT('%', UNHEX('EFBFBD3F3F'), '%');
```

Trois points sur ce fichier :

- **Les octets passent par `UNHEX`**, donc le fichier de migration reste en ASCII pur : il ne peut pas être corrompu de la même façon que la clé qu'il répare.
- **Il est idempotent** : seules les lignes portant encore la séquence fautive sont touchées. Rejouer l'activation du module est sans effet.
- **L'emplacement est contraint** : `_load_tables()` n'exécute que les fichiers commençant par `llx_` (`DolibarrModules.class.php`, filtre `substr($file, 0, 4) == 'llx_'`). Un ajout dans `sql/update.sql` n'aurait **jamais été exécuté**. Le dossier `sql/migration/` suit le précédent de doliopi, et `init()` charge les sous-dossiers de `sql/` avant la racine — `migration` passe après `call_list` dans l'ordre de `scandir`, donc la table existe forcément quand l'`UPDATE` tourne.

## Vérification

Migration exécutée sur la base de test :

- avant : 44 listes corrompues
- après : 0 ; le séparateur est passé de `EFBFBD3F3F` à `E28094` sur les 44 lignes
- seconde exécution : aucun effet (idempotence confirmée)
- la clé corrigée produit bien `e28094` pour les listes créées désormais

## Fichiers

- `langs/fr_FR/reedcrm.lang` — tiret cadratin restauré
- `sql/migration/llx_migration_reedcrm_call_list_label_em_dash.sql` (nouveau)
- `sql/migration/index.php` (nouveau, convention du module)

> La migration ne s'applique qu'à la **réactivation du module**. Sur une instance déjà déployée, les libellés existants restent fautifs jusque-là.

## Issue

#790 — bug trouvé en travaillant sur les items liste d'appel de cette issue (il n'est dans aucune case de la checklist).
