### PR TITLE
#790 [Relaunch] add: name the columns of the relaunch table (date, who, what, status)

### DIFF
--- a/ajax/get_relaunches_list.php
+++ b/ajax/get_relaunches_list.php
@@ -103,6 +103,14 @@ if (is_array($actionComms) && !empty($actionComms)) {
     print '<div class="reedcrm-relaunch-tooltip-content">';
     print '<table class="noborder centpercent">';
 
+    // Column order follows what a relance carries: when, who, what, where it stands
+    print '<tr class="liste_titre">';
+    print '<td>' . $langs->trans('Date') . '</td>';
+    print '<td>' . $langs->trans('RelaunchWho') . '</td>';
+    print '<td>' . $langs->trans('RelaunchWhat') . '</td>';
+    print '<td class="center">' . $langs->trans('Status') . '</td>';
+    print '</tr>';
+
     foreach ($actionComms as $ac) {
         // When type is 'all', show every action without filtering
         if ($actionType !== 'all') {
@@ -145,16 +153,13 @@ if (is_array($actionComms) && !empty($actionComms)) {
         }
 
         print '<tr class="oddeven">';
+
+        // Date
         print '<td class="nowrap" style="min-width: 150px;">';
         print dol_print_date($ac->datep, 'dayhour', 'tzuser');
         print '</td>';
-        print '<td class="tdoverflowmax200">';
-        print '<strong>' . dol_escape_htmltag($ac->label) . '</strong>';
-        if (!empty($ac->note_private)) {
-            $note = dolGetFirstLineOfText(dol_string_nohtmltag($ac->note_private, 1));
-            print '<br><span class="opacitymedium">' . dol_escape_htmltag(dol_trunc($note, 80)) . '</span>';
-        }
-        print '</td>';
+
+        // Who
         print '<td class="nowrap">';
         if ($contactName) {
             print '<span class="opacitymedium">' . img_picto('', 'contact', 'class="pictofixedwidth"') . ' ' . dol_escape_htmltag($contactName) . '</span>';
@@ -164,17 +169,33 @@ if (is_array($actionComms) && !empty($actionComms)) {
             print '<span class="opacitymedium">' . img_picto('', 'user', 'class="pictofixedwidth"') . ' ' . dol_escape_htmltag($userName) . '</span>';
         }
         print '</td>';
-        if (isset($ac->percentage) && $ac->percentage >= 100) {
-            print '<td class="center">';
-            print '<span class="badge badge-status4">' . $langs->trans('Done') . '</span>';
-            print '</td>';
-        } elseif (isset($ac->percentage) && $ac->percentage > 0) {
-            print '<td class="center">';
-            print '<span class="badge">' . $ac->percentage . '%</span>';
-            print '</td>';
-        } else {
-            print '<td></td>';
+
+        // What
+        print '<td class="tdoverflowmax200">';
+        if (dol_strlen($ac->label)) {
+            print '<strong>' . dol_escape_htmltag($ac->label) . '</strong>';
         }
+        if (!empty($ac->note_private)) {
+            $note = dolGetFirstLineOfText(dol_string_nohtmltag($ac->note_private, 1));
+            print (dol_strlen($ac->label) ? '<br>' : '') . '<span class="opacitymedium">' . dol_escape_htmltag(dol_trunc($note, 80)) . '</span>';
+        }
+        print '</td>';
+
+        // Status. Always rendered now that the column is named: an empty cell under a "Statut"
+        // header reads as missing data, where it actually means the relance is still to do.
+        print '<td class="center">';
+        if (!isset($ac->percentage) || $ac->percentage < 0) {
+            // -1 is the Dolibarr value for an event that does not track progress at all
+            print '<span class="opacitymedium">' . $langs->trans('ActionNotApplicable') . '</span>';
+        } elseif ($ac->percentage >= 100) {
+            print '<span class="badge badge-status4">' . $langs->trans('Done') . '</span>';
+        } elseif ($ac->percentage > 0) {
+            print '<span class="badge">' . $ac->percentage . '%</span>';
+        } else {
+            print '<span class="badge badge-status1">' . $langs->trans('ToDo') . '</span>';
+        }
+        print '</td>';
+
         print '</tr>';
     }
 

--- a/langs/en_US/reedcrm.lang
+++ b/langs/en_US/reedcrm.lang
@@ -72,6 +72,10 @@ ProjectsImported = %s projects imported out of %s rows.
 ProjectsImportErrors = %s rows could not be imported.
 NbLines = Number of lines
 
+# Relaunch table headers (Date and Status come from main.lang)
+RelaunchWho = Who
+RelaunchWhat = What
+
 # Dashboard graphs
 OpportunitySources = Distribution of opportunity sources
 

--- a/langs/fr_FR/reedcrm.lang
+++ b/langs/fr_FR/reedcrm.lang
@@ -58,6 +58,9 @@ QuickEventCreations = ajouts rapides d'événements
 CommercialRelaunching = Relance commerciale
 CommercialsRelaunching = Relances commerciales
 LastCommercialReminderDate = Date dernière relance commerciale
+# En-tetes du tableau des relances (Date et Statut viennent de main.lang)
+RelaunchWho = Qui
+RelaunchWhat = Quoi
 ActionCommCreation = Événement créé
 ReminderActionCommCreation = Rappel crée le %s
 ErrorNoProjectAndThirdpartyInformations = Veuillez renseigner un nom de projet et un nom de tiers


### PR DESCRIPTION
## Changements

Le tableau des relances (celui qui s'ouvre au survol des boutons de relance, sur fiche et liste projet / propale / tiers) **n'avait aucune ligne d'en-tête** : les colonnes s'enchaînaient sans être nommées, ce qui rend la lecture ambiguë — d'autant que beaucoup de relances n'ont pas de libellé.

Le tableau porte désormais ses colonnes, dans l'ordre que l'issue décrit (`date|qui|Quoi|status`) :

| Date | Qui | Quoi | État |
|---|---|---|---|
| 17/07/2026 07:55 | Laurent Magnin | | Effectué |
| 02/07/2026 12:53 | Laurent Magnin | aaa | Effectué |

Trois choses :

- **Ligne d'en-tête ajoutée** — `Date`, `Qui`, `Quoi`, `État`. `Date` et `État` viennent de `main.lang` (toujours chargé) ; `Qui` / `Quoi` sont deux nouvelles clés ReedCRM.
- **Colonnes réordonnées** — le rendu était `date | quoi | qui | statut`, il devient `date | qui | quoi | statut`, conforme à l'ordre annoté dans l'issue.
- **Le statut est toujours affiché.** Il ne l'était que si `percentage > 0` : une relance à faire produisait une cellule **vide**. Sous une colonne nommée « État », une cellule vide se lit comme une donnée manquante alors qu'elle signifie « à faire ». Désormais : `Effectué` (≥ 100), `xx%` (en cours), `À faire` (0), `Non applicable` (-1, la valeur Dolibarr pour un événement qui ne suit pas d'avancement).

Le libellé vide n'est plus enrobé d'un `<strong>` vide, et le `<br>` entre libellé et note n'est plus émis quand il n'y a pas de libellé.

## Vérification

Tableau rendu avec la même logique que l'endpoint, sur les 6 relances réelles du projet 140 de la base de test — en-têtes, ordre des colonnes et statuts conformes. `php -l` OK. Les deux nouvelles clés sont présentes en FR et EN ; les clés noyau utilisées (`Date`, `Status`, `Done`, `ToDo`, `ActionNotApplicable`) existent bien dans `main.lang`.

## Périmètre

Cette PR ne traite que **la mise en forme du tableau existant**, qui est ce que la capture « Création du tableau des relances et status » et son annotation `date|qui|Quoi|status` décrivent directement.

Elle ne touche pas :

- **la carte « Prochains rappels » du dashboard**, qui liste les *rappels* (`REEDCRM_ACTIONCOMM_CALL_REMINDER_TAG`) et non les *relances* (`..._COMMERCIAL_RELAUNCH_TAG`) — deux catégories distinctes. La passer en tableau `date|qui|quoi|statut` donnerait une colonne statut **constante par construction** (elle filtre déjà sur « à faire » et sur le futur : tous les rappels y sont à `percent = 0`) et une colonne « qui » vide (aucun `fk_contact` renseigné) ;
- **le périmètre propale**, qui reste ouvert : une relance n'a pas de rattachement propale, seulement `fk_project` et `fk_soc`.

## Fichiers modifiés

- `ajax/get_relaunches_list.php`
- `langs/fr_FR/reedcrm.lang`, `langs/en_US/reedcrm.lang` — 2 clés

## Issue

#790 — « Création d'un tableau de relance » / capture « Création du tableau des relances et status »
