### PR TITLE
#790 [Relaunch] fix: load the module lang file in the relaunch list endpoint

### DIFF
--- a/ajax/get_relaunches_list.php
+++ b/ajax/get_relaunches_list.php
@@ -48,6 +48,11 @@ require_once DOL_DOCUMENT_ROOT . '/comm/action/class/actioncomm.class.php';
 require_once DOL_DOCUMENT_ROOT . '/core/lib/company.lib.php';
 require_once DOL_DOCUMENT_ROOT . '/projet/class/project.class.php';
 
+// This endpoint boots on the core main.inc.php, which only brings main.lang. Without this the
+// module keys of the table header render as raw keys, while Date / Status / Done / ToDo work
+// because they live in main.lang.
+$langs->loadLangs(['reedcrm@reedcrm']);
+
 // Security check
 if (!$user->hasRight('agenda', 'myactions', 'read') && !$user->hasRight('agenda', 'allactions', 'read')) {
     top_httphead('application/json');


### PR DESCRIPTION
## Le problème

Les en-têtes du tableau des relances, ajoutés par #805, s'affichaient en **clés brutes** : `RelaunchWho` et `RelaunchWhat` au lieu de « Qui » et « Quoi ».

Les clés existent pourtant bien en FR et EN. Le souci est ailleurs : `ajax/get_relaunches_list.php` démarre sur le `main.inc.php` du **noyau** (et non sur `reedcrm.main.inc.php` comme les autres endpoints du module) et **ne charge aucun fichier de langue**.

D'où un résultat en trompe-l'œil : les autres colonnes s'affichaient correctement parce qu'elles vivent dans `main.lang`, que le noyau charge toujours.

| Clé | Fichier | Rendu avant le fix |
|---|---|---|
| `Date`, `Status`, `Done`, `ToDo`, `ActionNotApplicable` | `main.lang` (noyau) | ✅ traduites |
| `RelaunchWho`, `RelaunchWhat` | `reedcrm.lang` | ❌ clés brutes |

## Le correctif

```php
$langs->loadLangs(['reedcrm@reedcrm']);
```

Une ligne, après le bootstrap. Je n'ai pas basculé l'endpoint sur `reedcrm.main.inc.php` : ce serait plus cohérent avec ses voisins, mais ça embarque aussi les langs saturne et les globales de module, pour un correctif qui doit rester minimal.

## Vérification

Reproduite avec un harnais qui **rejoue le bootstrap réel** de l'endpoint (noyau + `main.lang` uniquement, sans précharger la langue du module) :

- avant → `RelaunchWho` / `RelaunchWhat` rendus tels quels ;
- après → « Qui » / « Quoi ».

C'est précisément ce que mon test de la #805 n'avait pas vu : il chargeait `reedcrm@reedcrm` à la main, ce que l'endpoint ne fait pas. Le harnais était plus permissif que le vrai code, et a donc masqué le défaut.

## Fichiers modifiés

- `ajax/get_relaunches_list.php`

## Issue

#790 — régression introduite par #805.
