### PR TITLE
#790 [Relaunch] fix: propal list showed the relaunches of an unrelated project

### DIFF
--- a/lib/reedcrm_fields.lib.php
+++ b/lib/reedcrm_fields.lib.php
@@ -40,16 +40,28 @@ function reedcrm_field_relaunch_commercial(array $parameters, CommonObject $obje
 
     // In the saturne list loop the record id is $object->id (rowid is 0); the raw row
     // (carrying the real project id and socid) is passed via the hook param 'obj'.
+    // The row holds DB column names: both llx_projet and llx_propal expose fk_soc, never socid.
     $row       = !empty($parameters['obj']) ? $parameters['obj'] : $object;
-    $projectId = (int) (!empty($row->id) ? $row->id : $object->id);
-    $socid     = (int) ($row->socid ?? 0);
+    $isPropal  = ($object->element === 'propal');
+    $socid     = (int) ($row->fk_soc ?? $row->socid ?? 0);
+
+    // A relance is only ever attached to a project (fk_project) or a thirdparty (fk_soc), never to
+    // a propal. Passing the propal id as a project id showed the relances of whichever project
+    // happened to share that id. Use the propal's own project, and fall back to its thirdparty when
+    // it has none, which is what the propal card banner already does.
+    $projectId = $isPropal ? (int) ($row->fk_projet ?? 0) : (int) (!empty($row->id) ? $row->id : $object->id);
 
     require_once DOL_DOCUMENT_ROOT . '/comm/action/class/actioncomm.class.php';
 
     $actionComm = new ActionComm($db);
 
     $filter      = ' AND a.id IN (SELECT c.fk_actioncomm FROM ' . MAIN_DB_PREFIX . 'categorie_actioncomm as c WHERE c.fk_categorie = ' . $conf->global->REEDCRM_ACTIONCOMM_COMMERCIAL_RELAUNCH_TAG . ')';
-    $actionComms = $actionComm->getActions($socid, $projectId, 'project', $filter, 'a.datec');
+    // getActions() ANDs socid with the element, so passing both would drop the relances whose
+    // fk_soc is null or differs from the project's. The project id alone is already precise:
+    // the socid is only needed for the thirdparty fallback, where there is no project to key on.
+    $actionComms = $projectId > 0
+        ? $actionComm->getActions(0, $projectId, 'project', $filter, 'a.datec')
+        : $actionComm->getActions($socid, '', '', $filter, 'a.datec');
 
     $actonComsByType = [
         'call' => [
@@ -88,10 +100,16 @@ function reedcrm_field_relaunch_commercial(array $parameters, CommonObject $obje
         }
     }
 
-    $cardProUrl = '/custom/reedcrm/view/procard.php?from_id=' . $projectId . '&from_type=project&project_id=' . $projectId;
+    // Quick add: hang the new relance on the project when there is one, else on the thirdparty.
+    // Same two cases as the card banner; without this a propal without project posted project_id=0.
+    $cardProUrl = $projectId > 0
+        ? '/custom/reedcrm/view/procard.php?from_id=' . $projectId . '&from_type=project&project_id=' . $projectId
+        : '/custom/reedcrm/view/procard.php?from_id=' . $socid . '&from_type=societe';
 
     $out .= '<div class="reedcrm-plist-relaunch-wrapper">';
-    $out .= '<div class="reedcrm-plist-relaunch-buttons reedcrm-relaunch-buttons">';
+    // The hover tooltip needs the socid to scope itself when there is no project to key on
+    $socidAttr = $projectId > 0 ? '' : ' data-socid="' . $socid . '"';
+    $out .= '<div class="reedcrm-plist-relaunch-buttons reedcrm-relaunch-buttons"' . $socidAttr . '>';
 
     foreach ($actonComsByType as $actionCommType => $actonComByType) {
         $dialogUrl = dol_buildpath('custom/reedcrm/ajax/get_relaunches_list.php', 1);


### PR DESCRIPTION
## Le problème

Sur la liste des propales, la colonne « Relances » affichait les relances **d'un projet sans aucun rapport** : celui dont l'identifiant est égal à celui de la propale.

`reedcrm_field_relaunch_commercial()` sert les deux listes (`projectlist` et `propallist`, cf. `saturnePrintFieldListLoopObject`) mais ne testait jamais le type d'objet :

```php
$projectId = (int) (!empty($row->id) ? $row->id : $object->id);
$actionComms = $actionComm->getActions($socid, $projectId, 'project', $filter, 'a.datec');
```

Sur une ligne de propale, `$row->id` est l'id de la **propale**, envoyé comme id de **projet**.

Constaté sur la base de test : `PR2306-0001` (rowid 1) n'a **aucun projet** — ses vraies relances : 0. La colonne affichait **2**, celles du projet #1.

### Second défaut, au passage

```php
$socid = (int) ($row->socid ?? 0);
```

Ni `Project::$fields` ni `Propal::$fields` n'exposent `socid` — la colonne est `fk_soc` dans les deux tables, et la ligne brute porte les noms DB. Ce `$socid` valait donc **toujours 0**. Sans effet visible sur les projets (l'id de projet suffit à filtrer), mais il rendait impossible tout repli sur le tiers.

## Le correctif

Une relance n'est rattachée qu'à un **projet** (`fk_project`) ou à un **tiers** (`fk_soc`), jamais à une propale. Le périmètre retenu pour une propale est donc celui que la fiche propale applique déjà :

- propale **avec** projet → les relances de ce projet ;
- propale **sans** projet → les relances de son tiers.

Le bouton « + » de création rapide suit les mêmes deux cas (il postait `project_id=0` pour une propale sans projet), et le wrapper porte désormais `data-socid` dans le cas tiers — le tooltip en a besoin quand il n'y a pas de projet sur lequel s'accrocher.

### Le socid n'est passé que dans le cas tiers

C'est le point délicat. `getActions()` combine ses filtres en **ET** :

```php
if (!empty($socid))  { $sql .= " AND a.fk_soc = " . (int) $socid; }
if (... project ...) { $sql .= ' AND a.fk_project = ' . (int) $fk_element; }
```

Passer le socid **en plus** du projet restreint donc le résultat : toute relance dont le `fk_soc` est nul ou différent de celui du projet disparaîtrait des compteurs. Vérifié : sur le projet 140, forcer un socid étranger fait passer le compteur de **6 à 0**.

L'id de projet est déjà un filtre précis à lui seul. Le socid n'est donc transmis que dans le repli tiers, là où il n'y a pas de projet pour cadrer la requête. Le chemin projet reste ainsi **strictement identique** à l'existant.

## Vérification

| Contrôle | Résultat |
|---|---|
| Compteurs des projets porteurs de relances | 6 → 6, 2 → 2 — inchangés |
| `PR2306-0001` (propale sans projet) | **2 → 0** |
| Les 7 autres propales | inchangées |
| Le ET de `getActions` masque-t-il vraiment ? | projet 140 : 6 → 0 avec un socid étranger |

`php -l` OK.

## Fichiers modifiés

- `lib/reedcrm_fields.lib.php`

## Reste ouvert

Le rattachement d'une relance à une propale **en tant que tel** n'existe pas dans le modèle. Cette PR retire les chiffres faux et aligne la liste sur la fiche ; donner un vrai périmètre propale aux relances reste une décision de modèle (via `element_element`, un nouveau champ, ou l'abandon de l'idée), à trancher dans l'item « Création d'un tableau de relance (OPP, TIERS, PROPAL) ».

## Issue

#790
