### PR TITLE
#790 [Relaunch] add: link a relaunch to the reminder it generated

### DIFF
--- a/ajax/get_relaunches_list.php
+++ b/ajax/get_relaunches_list.php
@@ -47,6 +47,7 @@ global $conf, $db, $langs, $user;
 require_once DOL_DOCUMENT_ROOT . '/comm/action/class/actioncomm.class.php';
 require_once DOL_DOCUMENT_ROOT . '/core/lib/company.lib.php';
 require_once DOL_DOCUMENT_ROOT . '/projet/class/project.class.php';
+dol_include_once('/reedcrm/lib/reedcrm_function.lib.php');
 
 // This endpoint boots on the core main.inc.php, which only brings main.lang. Without this the
 // module keys of the table header render as raw keys, while Date / Status / Done / ToDo work
@@ -104,6 +105,13 @@ if (is_array($actionComms) && !empty($actionComms)) {
     if ($limit > 0) {
         $actionComms = array_slice($actionComms, 0, $limit);
     }
+
+    // Follow-up reminders of every listed relaunch, resolved in one query rather than per row
+    $relaunchIds  = [];
+    foreach ($actionComms as $ac) {
+        $relaunchIds[] = (int) $ac->id;
+    }
+    $remindersByRelaunch = reedcrm_get_reminders_by_relaunch($db, $relaunchIds);
 
     print '<div class="reedcrm-relaunch-tooltip-content">';
     print '<table class="noborder centpercent">';
@@ -175,14 +183,26 @@ if (is_array($actionComms) && !empty($actionComms)) {
         }
         print '</td>';
 
-        // What
+        // What, then the relaunch to come this one led to
         print '<td class="tdoverflowmax200">';
+        $hasText = false;
         if (dol_strlen($ac->label)) {
             print '<strong>' . dol_escape_htmltag($ac->label) . '</strong>';
+            $hasText = true;
         }
         if (!empty($ac->note_private)) {
             $note = dolGetFirstLineOfText(dol_string_nohtmltag($ac->note_private, 1));
-            print (dol_strlen($ac->label) ? '<br>' : '') . '<span class="opacitymedium">' . dol_escape_htmltag(dol_trunc($note, 80)) . '</span>';
+            print ($hasText ? '<br>' : '') . '<span class="opacitymedium">' . dol_escape_htmltag(dol_trunc($note, 80)) . '</span>';
+            $hasText = true;
+        }
+
+        $reminder = $remindersByRelaunch[(int) $ac->id] ?? null;
+        if ($reminder !== null) {
+            print ($hasText ? '<br>' : '');
+            print '<a class="reedcrm-relaunch-followup" href="' . dol_buildpath('/comm/action/card.php', 1) . '?id=' . ((int) $reminder->id) . '">';
+            print '<i class="fas fa-bell"></i> ';
+            print dol_escape_htmltag($langs->trans('RelaunchFollowUpOn', dol_print_date($db->jdate($reminder->datep), 'dayhour', 'tzuser')));
+            print '</a>';
         }
         print '</td>';
 

--- a/langs/en_US/reedcrm.lang
+++ b/langs/en_US/reedcrm.lang
@@ -75,6 +75,7 @@ NbLines = Number of lines
 # Relaunch table headers (Date and Status come from main.lang)
 RelaunchWho = Who
 RelaunchWhat = What
+RelaunchFollowUpOn = Reminder on %s
 
 # Dashboard graphs
 OpportunitySources = Distribution of opportunity sources

--- a/langs/fr_FR/reedcrm.lang
+++ b/langs/fr_FR/reedcrm.lang
@@ -61,6 +61,7 @@ LastCommercialReminderDate = Date dernière relance commerciale
 # En-tetes du tableau des relances (Date et Statut viennent de main.lang)
 RelaunchWho = Qui
 RelaunchWhat = Quoi
+RelaunchFollowUpOn = Rappel le %s
 ActionCommCreation = Événement créé
 ReminderActionCommCreation = Rappel crée le %s
 ErrorNoProjectAndThirdpartyInformations = Veuillez renseigner un nom de projet et un nom de tiers

--- a/lib/reedcrm_function.lib.php
+++ b/lib/reedcrm_function.lib.php
@@ -504,3 +504,68 @@ function reedcrm_get_call_reminder_category_id(DoliDB $db, User $user): int
 
     return 0;
 }
+
+/**
+ * Link a follow-up reminder event to the relaunch event it was created from.
+ *
+ * Stored in llx_actioncomm.fk_parent: the column exists on every install and no Dolibarr feature
+ * writes it, so there is nothing to collide with and no schema change to ship. It has to go through
+ * a direct query though: fk_parent is only declared in ActionComm::$fields for the generic ORM, and
+ * the class overrides create(), update() and fetch() without ever touching it — assigning
+ * $actionComm->fk_parent before create() is silently dropped.
+ *
+ * @param  DoliDB $db         Database handler
+ * @param  int    $reminderId Reminder event (the relaunch to come)
+ * @param  int    $relaunchId Relaunch event it follows up (the one that was done)
+ * @return int                1 if OK, -1 if KO
+ */
+function reedcrm_link_reminder_to_relaunch(DoliDB $db, int $reminderId, int $relaunchId): int
+{
+    if ($reminderId <= 0 || $relaunchId <= 0 || $reminderId === $relaunchId) {
+        return -1;
+    }
+
+    $sql  = 'UPDATE ' . MAIN_DB_PREFIX . 'actioncomm';
+    $sql .= ' SET fk_parent = ' . ((int) $relaunchId);
+    $sql .= ' WHERE id = ' . ((int) $reminderId);
+
+    return $db->query($sql) ? 1 : -1;
+}
+
+/**
+ * Return the follow-up reminders of a set of relaunch events, keyed by relaunch id.
+ *
+ * One query for the whole list: the tooltip renders several relaunches at once and must not fire a
+ * lookup per row. fk_parent is read here because ActionComm::fetch() does not load it either.
+ *
+ * @param  DoliDB $db          Database handler
+ * @param  int[]  $relaunchIds Relaunch event ids
+ * @return array               [relaunch id => reminder object (id, datep, label)]
+ */
+function reedcrm_get_reminders_by_relaunch(DoliDB $db, array $relaunchIds): array
+{
+    $reminders   = [];
+    $relaunchIds = array_filter(array_map('intval', $relaunchIds));
+
+    if (empty($relaunchIds)) {
+        return $reminders;
+    }
+
+    $sql  = 'SELECT id, fk_parent, datep, label FROM ' . MAIN_DB_PREFIX . 'actioncomm';
+    $sql .= ' WHERE fk_parent IN (' . implode(',', $relaunchIds) . ')';
+    $sql .= ' AND entity IN (' . getEntity('agenda') . ')';
+    $sql .= ' ORDER BY datep ASC';
+
+    $resql = $db->query($sql);
+    if ($resql) {
+        while ($obj = $db->fetch_object($resql)) {
+            // First one wins: a relaunch is created with a single follow-up reminder
+            if (!isset($reminders[(int) $obj->fk_parent])) {
+                $reminders[(int) $obj->fk_parent] = $obj;
+            }
+        }
+        $db->free($resql);
+    }
+
+    return $reminders;
+}

--- a/sql/migration/llx_migration_reedcrm_link_reminder_to_relaunch.sql
+++ b/sql/migration/llx_migration_reedcrm_link_reminder_to_relaunch.sql
@@ -1,0 +1,45 @@
+-- Copyright (C) 2026 EVARISK <technique@evarisk.com>
+--
+-- This program is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with this program.  If not, see https://www.gnu.org/licenses/.
+
+-- Backfill the link between a relaunch event and the reminder it generated.
+--
+-- The pair is created in one request by view/procard.php, so both rows share the exact same datec
+-- and the same fk_project. That signature is what identifies past pairs, since nothing recorded the
+-- link before. The two categories tell them apart: the relaunch carries
+-- REEDCRM_ACTIONCOMM_COMMERCIAL_RELAUNCH_TAG, the reminder REEDCRM_ACTIONCOMM_CALL_REMINDER_TAG.
+--
+-- Deliberately conservative:
+--   - only reminders whose fk_parent is still unset are touched, so a link set by the module wins;
+--   - the pair must be unique on both sides (one relaunch <-> one reminder for a given datec and
+--     project). Anything ambiguous is left alone rather than guessed: a wrong link would be worse
+--     than no link.
+--   - the tag ids are read from llx_const, they differ per install.
+--
+-- Idempotent: re-running matches nothing once fk_parent is set.
+
+UPDATE llx_actioncomm AS rem
+INNER JOIN (
+    SELECT rap.id AS reminder_id, MIN(rel.id) AS relaunch_id, COUNT(DISTINCT rel.id) AS nb_relaunch
+    FROM llx_actioncomm AS rap
+    INNER JOIN llx_categorie_actioncomm AS crap ON crap.fk_actioncomm = rap.id
+    INNER JOIN llx_const AS kr ON kr.name = 'REEDCRM_ACTIONCOMM_CALL_REMINDER_TAG' AND crap.fk_categorie = kr.value
+    INNER JOIN llx_actioncomm AS rel ON rel.datec = rap.datec AND rel.id <> rap.id AND rel.entity = rap.entity AND (rel.fk_project <=> rap.fk_project)
+    INNER JOIN llx_categorie_actioncomm AS crel ON crel.fk_actioncomm = rel.id
+    INNER JOIN llx_const AS kl ON kl.name = 'REEDCRM_ACTIONCOMM_COMMERCIAL_RELAUNCH_TAG' AND crel.fk_categorie = kl.value
+    WHERE rap.fk_parent = 0 OR rap.fk_parent IS NULL
+    GROUP BY rap.id
+    HAVING nb_relaunch = 1
+) AS pair ON pair.reminder_id = rem.id
+SET rem.fk_parent = pair.relaunch_id;

--- a/view/procard.php
+++ b/view/procard.php
@@ -189,6 +189,10 @@ if (empty($resHook)) {
 
         $result = $actionComm->create($user);
 
+        // Keep the relaunch id: the same $actionComm object is reused to create the reminder below,
+        // and $result is overwritten by that second create()
+        $relaunchId = (int) $result;
+
         $category->fetch(getDolGlobalInt('REEDCRM_ACTIONCOMM_COMMERCIAL_RELAUNCH_TAG'));
         $category->add_type($actionComm, 'actioncomm');
 
@@ -214,6 +218,9 @@ if (empty($resHook)) {
                     $reminderCategory->fetch($reminderCategoryID);
                     $reminderCategory->add_type($actionComm, 'actioncomm');
                 }
+
+                // Keep track of which relaunch this reminder follows up
+                reedcrm_link_reminder_to_relaunch($db, (int) $result, $relaunchId);
             }
 
             $actionCommReminder = new ActionCommReminder($db);


### PR DESCRIPTION
## Changements

Quand une relance est saisie avec un rappel, les deux événements étaient créés **sans aucun lien entre eux** : rien ne permettait de savoir que tel rappel faisait suite à tel appel.

Le lien est désormais enregistré, et affiché dans le tableau des relances :

```
17/07/2026 07:55 | Laurent Magnin | (sans libellé)          | Effectué
                                   🔔 Rappel le 19/07/2026
```

Le libellé est cliquable et mène à la fiche de l'événement de rappel.

## Où le lien est stocké

Dans `llx_actioncomm.fk_parent`. La colonne existe sur toutes les installations et **aucune fonctionnalité Dolibarr ne l'écrit** (zéro occurrence dans le noyau hors la déclaration `$fields`) : rien à percuter, et aucun changement de schéma à livrer.

Elle impose en revanche du SQL direct, et c'est le point non évident : `fk_parent` n'est déclarée dans `ActionComm::$fields` que pour l'ORM générique, alors que la classe **surcharge** `create()`, `update()` et `fetch()` — et aucune des trois ne la touche. Assigner `$actionComm->fk_parent` avant `create()` est **silencieusement perdu**. D'où deux helpers dédiés, l'un pour écrire, l'autre pour lire.

## Reprise de l'historique

Un lien qui ne vaudrait que pour les futures relances n'aurait rien à montrer : aucune paire existante n'est liée. Les paires passées sont heureusement identifiables de façon fiable — `view/procard.php` crée les deux événements **dans la même requête**, ils partagent donc le `datec` à la seconde près et le même `fk_project`, et leurs catégories respectives les distinguent.

D'où la migration `sql/migration/llx_migration_reedcrm_link_reminder_to_relaunch.sql`, volontairement prudente :

- ne touche que les rappels dont `fk_parent` est encore vide (un lien posé par le module l'emporte) ;
- exige une paire **non ambiguë** (`HAVING nb_relaunch = 1`) : tout cas douteux est laissé tel quel plutôt que deviné — un mauvais lien serait pire que pas de lien ;
- lit les ids de catégorie depuis `llx_const`, ils diffèrent d'une install à l'autre ;
- idempotente.

## Vérification

Migration exécutée sur la base de test : **0 → 2 liens**, tous deux corrects. Puis le tableau rendu avec la logique de l'endpoint :

```
Projet 140 : #15315  17/07 07:55  ->  Rappel le 19/07/2026 07:55  (evt #15316)
Projet 1   : #14407  02/07 07:19  ->  Rappel le 03/07/2026 07:19  (evt #14408)
```

Les relances sans rappel n'affichent rien. `php -l` OK sur les 3 fichiers.

Les rappels de suivi sont résolus en **une seule requête** pour toute la liste (`reedcrm_get_reminders_by_relaunch`), pas une par ligne : le tableau en affiche plusieurs à la fois.

## Périmètre

`view/procard.php` est le **seul** endroit qui crée une paire relance + rappel. `view/quickevent.php` crée bien un `ActionCommReminder`, mais c'est la notification d'un événement (ligne `llx_actioncomm_reminder`), pas une seconde `ActionComm` — il n'est donc pas concerné.

## Fichiers modifiés

- `lib/reedcrm_function.lib.php` — helpers d'écriture et de lecture du lien
- `view/procard.php` — pose le lien à la création
- `ajax/get_relaunches_list.php` — affiche le rappel de suivi
- `langs/fr_FR` + `en_US` — 1 clé
- `sql/migration/llx_migration_reedcrm_link_reminder_to_relaunch.sql` (nouveau)

> La migration ne s'applique qu'à la **réactivation du module**.

## Issue

#790 — « Afficher la liaison entre l'evenement réalisé et la relance à venir »
