### PR TITLE
#817 [Facture] fix: onglets facture récurrente cassés (boucle infinie + Factures générées écrasé)

### DIFF
--- a/class/actions_reedcrm.class.php
+++ b/class/actions_reedcrm.class.php
@@ -1887,7 +1887,7 @@ class ActionsReedcrm
     {
         global $langs;
 
-        if (preg_match('/invoicereccard|invoicereccontact/', $parameters['context'])) {
+        if (preg_match('/invoicereccard|invoicereccontact/', $parameters['context']) && ($parameters['mode'] ?? '') === 'add') {
             $nbContact = 0;
             // Enable caching of thirdrparty count Contacts
             require_once DOL_DOCUMENT_ROOT . '/core/lib/memory.lib.php';
@@ -1908,14 +1908,14 @@ class ActionsReedcrm
 
                 dol_setcache($cacheKey, $nbContact, 120); // If setting cache fails, this is not a problem, so we do not test result
             }
-            $parameters['head'][1][0] = DOL_URL_ROOT . '/custom/reedcrm/view/contact.php?id=' . $parameters['object']->id;
-            $parameters['head'][1][1] = $langs->trans('ContactsAddresses');
+            // Append the tab instead of overwriting index 1, which is the native "InvoicesGeneratedFromRec" tab on recurring invoices.
+            $rank = count($parameters['head']);
+            $parameters['head'][$rank][0] = DOL_URL_ROOT . '/custom/reedcrm/view/contact.php?id=' . $parameters['object']->id;
+            $parameters['head'][$rank][1] = $langs->trans('ContactsAddresses');
             if ($nbContact > 0) {
-                $parameters['head'][1][1] .= '<span class="badge marginleftonlyshort">' . $nbContact . '</span>';
+                $parameters['head'][$rank][1] .= '<span class="badge marginleftonlyshort">' . $nbContact . '</span>';
             }
-            $parameters['head'][1][2] = 'contact';
-
-            $this->results = $parameters;
+            $parameters['head'][$rank][2] = 'contact';
         }
 
         if (strpos($parameters['context'], 'main') !== false) {


### PR DESCRIPTION
Closes #817

## Problème
La fiche facture récurrente (`card-rec.php`) partait en **boucle infinie** (timeout 120 s) → aucun onglet, impossible d'accéder aux factures générées.

## Cause — `ActionsReedcrm::completeTabsHead`
1. `$this->results = $parameters` injecte des clés non numériques (`object`, `mode`, `head`…) dans `$head` → `max(array_keys($head))` renvoie une chaîne → `for ($i = 0; $i <= 'object'; $i++)` de `dol_get_fiche_head` ne se termine jamais.
2. Écriture dans `$parameters['head'][1]` = écrasement de l'onglet natif « Factures générées ».

## Correctif (`class/actions_reedcrm.class.php`)
- Retrait de `$this->results = $parameters` — la modif d'onglet passe déjà par référence (cf. dolimeet / template modulebuilder V14+).
- Onglet Contacts **ajouté** via `count($parameters['head'])` au lieu d'écraser l'index 1 → « Factures générées » préservé.
- Garde `mode === 'add'` pour éviter le doublon (hook appelé en passes *add* et *remove*).

## Tests (Playwright + CLI)
- `card-rec.php?id=68` : ~850 ms (avant : timeout).
- Onglets : Facture modèle · **Factures générées (5)** · Notes · Événements/Agenda · Contacts/Adresses (8).
- Clic « Factures générées » → `list.php?search_fk_fac_rec_source=68` → 5 factures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)