### PR TITLE
feat: suivi FA recurrentes, audits DU & detection Digirisk sans abonnement

### DIFF
--- a/class/recurringinvoicefollowupcron.class.php
+++ b/class/recurringinvoicefollowupcron.class.php
@@ -255,7 +255,8 @@ class RecurringInvoiceFollowupCron
     }
 
     /**
-     * Job: create or refresh DU audits from the invoiced audit services (product ref "DU_AU%").
+     * Job: create or refresh DU audits from the invoiced Document Unique services (product ref
+     * "DU_A%": DU_AU audits + DU_AC/DU_Accompagnement setup, which also start the yearly cycle).
      * One audit per client (the latest audit invoice). A newer audit invoice refreshes the cycle;
      * manual date moves for the current cycle are preserved (only a strictly newer invoice updates them).
      *
@@ -278,7 +279,7 @@ class RecurringInvoiceFollowupCron
         $sql .= ' FROM ' . MAIN_DB_PREFIX . 'facture as f';
         $sql .= ' INNER JOIN ' . MAIN_DB_PREFIX . 'facturedet as fd ON fd.fk_facture = f.rowid';
         $sql .= ' INNER JOIN ' . MAIN_DB_PREFIX . 'product as p ON p.rowid = fd.fk_product';
-        $sql .= " WHERE p.ref LIKE 'DU\_AU%'";
+        $sql .= " WHERE p.ref LIKE 'DU\_A%'"; // DU_AU (audit) + DU_AC/DU_Accompagnement (mise en place)
         $sql .= ' AND f.type <> 2'; // exclude credit notes (avoirs)
         $sql .= ' AND f.datef IS NOT NULL AND f.fk_soc > 0 AND f.entity IN (' . getEntity('facture') . ')';
         $sql .= ' GROUP BY f.fk_soc, f.rowid, f.datef';

--- a/lib/reedcrm_followup.lib.php
+++ b/lib/reedcrm_followup.lib.php
@@ -126,7 +126,7 @@ function reedcrmFollowupGetAuditsForMonth(DoliDB $db, int $periodStart, int $per
     $sql .= ' LEFT JOIN ' . MAIN_DB_PREFIX . 'propal as pr ON pr.rowid = (';
     $sql .= '   SELECT p2.rowid FROM ' . MAIN_DB_PREFIX . 'propal p2';
     $sql .= '   INNER JOIN ' . MAIN_DB_PREFIX . 'propaldet pd ON pd.fk_propal = p2.rowid';
-    $sql .= '   INNER JOIN ' . MAIN_DB_PREFIX . "product prod ON prod.rowid = pd.fk_product AND prod.ref LIKE 'DU\_AU%'";
+    $sql .= '   INNER JOIN ' . MAIN_DB_PREFIX . "product prod ON prod.rowid = pd.fk_product AND prod.ref LIKE 'DU\_A%'";
     $sql .= '   WHERE p2.fk_soc = a.fk_soc AND p2.entity IN (' . getEntity('propal') . ')';
     $sql .= '   AND (a.last_audit_date IS NULL OR p2.datep > a.last_audit_date)';
     $sql .= '   ORDER BY p2.datep DESC, p2.rowid DESC LIMIT 1)';
@@ -134,7 +134,7 @@ function reedcrmFollowupGetAuditsForMonth(DoliDB $db, int $periodStart, int $per
     $sql .= ' LEFT JOIN ' . MAIN_DB_PREFIX . 'facture as fa ON fa.rowid = (';
     $sql .= '   SELECT f2.rowid FROM ' . MAIN_DB_PREFIX . 'facture f2';
     $sql .= '   INNER JOIN ' . MAIN_DB_PREFIX . 'facturedet fd2 ON fd2.fk_facture = f2.rowid';
-    $sql .= '   INNER JOIN ' . MAIN_DB_PREFIX . "product prodf ON prodf.rowid = fd2.fk_product AND prodf.ref LIKE 'DU\_AU%'";
+    $sql .= '   INNER JOIN ' . MAIN_DB_PREFIX . "product prodf ON prodf.rowid = fd2.fk_product AND prodf.ref LIKE 'DU\_A%'";
     $sql .= '   WHERE f2.fk_soc = a.fk_soc AND f2.type <> 2 AND f2.entity IN (' . getEntity('facture') . ')';
     $sql .= '   AND (a.last_audit_date IS NULL OR f2.datef > a.last_audit_date)';
     $sql .= '   ORDER BY f2.datef DESC, f2.rowid DESC LIMIT 1)';
@@ -201,7 +201,7 @@ function reedcrmFollowupGetOverdueAudits(DoliDB $db): array
     $sql .= ' LEFT JOIN ' . MAIN_DB_PREFIX . 'propal as pr ON pr.rowid = (';
     $sql .= '   SELECT p2.rowid FROM ' . MAIN_DB_PREFIX . 'propal p2';
     $sql .= '   INNER JOIN ' . MAIN_DB_PREFIX . 'propaldet pd ON pd.fk_propal = p2.rowid';
-    $sql .= '   INNER JOIN ' . MAIN_DB_PREFIX . "product prod ON prod.rowid = pd.fk_product AND prod.ref LIKE 'DU\_AU%'";
+    $sql .= '   INNER JOIN ' . MAIN_DB_PREFIX . "product prod ON prod.rowid = pd.fk_product AND prod.ref LIKE 'DU\_A%'";
     $sql .= '   WHERE p2.fk_soc = a.fk_soc AND p2.entity IN (' . getEntity('propal') . ')';
     $sql .= '   AND (a.last_audit_date IS NULL OR p2.datep > a.last_audit_date)';
     $sql .= '   ORDER BY p2.datep DESC, p2.rowid DESC LIMIT 1)';
@@ -209,7 +209,7 @@ function reedcrmFollowupGetOverdueAudits(DoliDB $db): array
     $sql .= ' LEFT JOIN ' . MAIN_DB_PREFIX . 'facture as fa ON fa.rowid = (';
     $sql .= '   SELECT f2.rowid FROM ' . MAIN_DB_PREFIX . 'facture f2';
     $sql .= '   INNER JOIN ' . MAIN_DB_PREFIX . 'facturedet fd2 ON fd2.fk_facture = f2.rowid';
-    $sql .= '   INNER JOIN ' . MAIN_DB_PREFIX . "product prodf ON prodf.rowid = fd2.fk_product AND prodf.ref LIKE 'DU\_AU%'";
+    $sql .= '   INNER JOIN ' . MAIN_DB_PREFIX . "product prodf ON prodf.rowid = fd2.fk_product AND prodf.ref LIKE 'DU\_A%'";
     $sql .= '   WHERE f2.fk_soc = a.fk_soc AND f2.type <> 2 AND f2.entity IN (' . getEntity('facture') . ')';
     $sql .= '   AND (a.last_audit_date IS NULL OR f2.datef > a.last_audit_date)';
     $sql .= '   ORDER BY f2.datef DESC, f2.rowid DESC LIMIT 1)';

--- a/view/duaudit_list.php
+++ b/view/duaudit_list.php
@@ -142,7 +142,7 @@ if ($action === 'auditrenew' && $permissiontoadd) {
         $sqlInv  = 'SELECT f.rowid, f.datef, SUM(fd.total_ttc) as tot FROM ' . MAIN_DB_PREFIX . 'facture as f';
         $sqlInv .= ' INNER JOIN ' . MAIN_DB_PREFIX . 'facturedet as fd ON fd.fk_facture = f.rowid';
         $sqlInv .= ' INNER JOIN ' . MAIN_DB_PREFIX . 'product as p ON p.rowid = fd.fk_product';
-        $sqlInv .= " WHERE p.ref LIKE 'DU\_AU%' AND f.type <> 2 AND f.fk_soc = " . ((int) $audit->fk_soc);
+        $sqlInv .= " WHERE p.ref LIKE 'DU\_A%' AND f.type <> 2 AND f.fk_soc = " . ((int) $audit->fk_soc);
         $sqlInv .= ' AND f.datef IS NOT NULL AND f.entity IN (' . getEntity('facture') . ')';
         $sqlInv .= ' GROUP BY f.rowid, f.datef ORDER BY f.datef DESC' . $db->plimit(1);
         $resqlInv = $db->query($sqlInv);
@@ -320,7 +320,7 @@ $sqlChart .= ' FROM ' . MAIN_DB_PREFIX . 'reedcrm_du_audit as a INNER JOIN ' . M
 $sqlChart .= ' LEFT JOIN ' . MAIN_DB_PREFIX . 'propal as prc ON prc.rowid = (';
 $sqlChart .= '   SELECT p2.rowid FROM ' . MAIN_DB_PREFIX . 'propal p2';
 $sqlChart .= '   INNER JOIN ' . MAIN_DB_PREFIX . 'propaldet pd ON pd.fk_propal = p2.rowid';
-$sqlChart .= '   INNER JOIN ' . MAIN_DB_PREFIX . "product prod ON prod.rowid = pd.fk_product AND prod.ref LIKE 'DU\_AU%'";
+$sqlChart .= '   INNER JOIN ' . MAIN_DB_PREFIX . "product prod ON prod.rowid = pd.fk_product AND prod.ref LIKE 'DU\_A%'";
 $sqlChart .= '   WHERE p2.fk_soc = a.fk_soc AND p2.entity IN (' . getEntity('propal') . ')';
 $sqlChart .= '   AND (a.last_audit_date IS NULL OR p2.datep > a.last_audit_date)';
 $sqlChart .= '   ORDER BY p2.datep DESC, p2.rowid DESC LIMIT 1)';


### PR DESCRIPTION
Ajoute a ReedCRM un outil de suivi des **factures recurrentes** et des **audits annuels du Document Unique (DU)**, plus la detection des **clients Digirisk sans abonnement**. Remplace un suivi Excel.

## Objets & tables
- `RecurringInvoiceFollowup` -> `llx_reedcrm_facturerec_followup`
- `DuAudit` -> `llx_reedcrm_du_audit`
- `llx_reedcrm_digirisk_dismissed` (clients masques de la liste Digirisk)
- Modules de numerotation + SQL d'installation + migration `sql/update.sql`.

## Pages
1. **Suivi FA recurrentes** - tableau mensuel des factures recurrentes a traiter + tableau de bord, et section **Clients Digirisk sans abonnement**.
2. **Suivi client DU** - graphiques annuels, audits du mois, audits en retard, montant PR par personne (scope au mois).

## Workflow DU (etat auto-derive des vrais documents Dolibarr)
`A preparer -> PR envoyee -> PR signee -> Facture -> Paye`
- Devis DU et facture DU_AU derives automatiquement (ref cliquable + montant reel + statut + date).
- Bouton **Creer le devis** (propale pre-remplie).
- **Assignation** de l'audit a une personne + recap montant PR par personne.
- Bouton **Fait** avec **date reelle d'audit** (modifiable) : ancre le prochain audit sur la vraie date (+1 an) et fait rouler la ligne.
- Etat pilote par PR/facture avec pastilles de couleur ; dans les retards, un devis/facture de +6 mois = En retard.
- Un DU est **perdu** s'il n'a pas ete mis a jour depuis 3 ans (tuile globale).

## Clients Digirisk sans abonnement
Liste des **clients** (ou prospects deja factures) utilisant Digirisk - palier facture (D1..D5) **ou** vrai projet *.digirisk.com (delivery ou opportunite gagnee, pas les opportunites ouvertes) - **sans** facture recurrente (meme desactivee exclue). Colonne Instance liee au projet, bouton Creer facture modele, et bouton pour masquer une ligne.

## Jobs planifies (RecurringInvoiceFollowupCron)
Generation mensuelle (projetee sur le mois d'echeance de chaque FA), synchro statut factures, rappels DU, synchro audits DU depuis les services DU_AU.

## Divers
Permissions `followup`, 2 entrees de menu, traductions FR/EN.

## Migration
Table `llx_reedcrm_du_audit` enrichie (proposal_sent_date, fk_propal, fk_user_assign, date_done) via `sql/update.sql`, et nouvelle table `llx_reedcrm_digirisk_dismissed` - appliquees a la reactivation du module.

Generated with Claude Code