### PR TITLE
fix: exclure les factures modeles desactivees du suivi FA recurrentes

### DIFF
--- a/lib/reedcrm_followup.lib.php
+++ b/lib/reedcrm_followup.lib.php
@@ -328,6 +328,8 @@ function reedcrmFollowupGetDashboardData(DoliDB $db, int $periodStart, int $peri
     $sql .= ' t.facture_creee, t.facture_envoyee, t.facture_payee, t.paiement_ok, t.date_relance, s.nom as thirdparty_name';
     $sql .= ' FROM ' . MAIN_DB_PREFIX . 'reedcrm_facturerec_followup as t';
     $sql .= ' LEFT JOIN ' . MAIN_DB_PREFIX . 'societe as s ON s.rowid = t.fk_soc';
+    // Only active recurring templates (exclude deactivated/suspended or deleted ones).
+    $sql .= ' INNER JOIN ' . MAIN_DB_PREFIX . 'facture_rec as fr ON fr.rowid = t.fk_facture_rec AND fr.suspended = 0';
     $sql .= ' WHERE t.entity IN (' . getEntity('reedcrm_facturerec_followup') . ')';
     $sql .= " AND t.status = 1";
     $sql .= " AND t.period >= '" . $db->idate($periodStart) . "'";
@@ -364,6 +366,7 @@ function reedcrmFollowupGetDashboardData(DoliDB $db, int $periodStart, int $peri
     $sqlDu  = 'SELECT t.rowid, t.ref, t.fk_soc, t.next_maj_du, s.nom as thirdparty_name';
     $sqlDu .= ' FROM ' . MAIN_DB_PREFIX . 'reedcrm_facturerec_followup as t';
     $sqlDu .= ' LEFT JOIN ' . MAIN_DB_PREFIX . 'societe as s ON s.rowid = t.fk_soc';
+    $sqlDu .= ' INNER JOIN ' . MAIN_DB_PREFIX . 'facture_rec as fr ON fr.rowid = t.fk_facture_rec AND fr.suspended = 0';
     $sqlDu .= ' WHERE t.entity IN (' . getEntity('reedcrm_facturerec_followup') . ')';
     $sqlDu .= ' AND t.status = 1 AND t.next_maj_du IS NOT NULL';
     $sqlDu .= " AND t.next_maj_du <= '" . $db->idate($windowEnd) . "'";

--- a/view/recurringinvoicefollowup_list.php
+++ b/view/recurringinvoicefollowup_list.php
@@ -130,6 +130,8 @@ $sql .= ' FROM ' . MAIN_DB_PREFIX . 'reedcrm_facturerec_followup as t';
 $sql .= ' LEFT JOIN ' . MAIN_DB_PREFIX . 'societe as s ON s.rowid = t.fk_soc';
 $sql .= ' LEFT JOIN ' . MAIN_DB_PREFIX . 'facture_rec as fr ON fr.rowid = t.fk_facture_rec';
 $sql .= ' WHERE t.entity IN (' . getEntity('reedcrm_facturerec_followup') . ')';
+// Only follow-ups of an active recurring template (exclude deactivated/suspended or deleted ones).
+$sql .= ' AND fr.suspended = 0';
 $sql .= " AND ((t.period >= '" . $db->idate($periodStart) . "' AND t.period <= '" . $db->idate($periodEnd) . "')";
 $sql .= " OR (t.period < '" . $db->idate($todayMonthStart) . "' AND t.facture_payee = 0 AND t.status = 1))";
 if (dol_strlen($search_ref)) {
@@ -219,8 +221,9 @@ print '</div>';
  */
 $chartYear = $monthYear;
 $faByMonth = array_fill(1, 12, 0.0);
-$sqlChartFa  = 'SELECT MONTH(period) as m, SUM(montant_ttc) as tot FROM ' . MAIN_DB_PREFIX . 'reedcrm_facturerec_followup';
-$sqlChartFa .= ' WHERE entity IN (' . getEntity('reedcrm_facturerec_followup') . ') AND status = 1 AND YEAR(period) = ' . $chartYear . ' GROUP BY m';
+$sqlChartFa  = 'SELECT MONTH(t.period) as m, SUM(t.montant_ttc) as tot FROM ' . MAIN_DB_PREFIX . 'reedcrm_facturerec_followup as t';
+$sqlChartFa .= ' INNER JOIN ' . MAIN_DB_PREFIX . 'facture_rec as fr ON fr.rowid = t.fk_facture_rec AND fr.suspended = 0';
+$sqlChartFa .= ' WHERE t.entity IN (' . getEntity('reedcrm_facturerec_followup') . ') AND t.status = 1 AND YEAR(t.period) = ' . $chartYear . ' GROUP BY m';
 $resChartFa  = $db->query($sqlChartFa);
 if ($resChartFa) {
     while ($o = $db->fetch_object($resChartFa)) {


### PR DESCRIPTION
Un suivi dont le modele de facture recurrente (facture_rec) est desactive/suspendu (ou supprime) apparaissait quand meme dans la liste, le graphe et les tuiles (ex. un modele Small Company desactive affiche en aout). Correction : jointure sur facture_rec avec suspended = 0 dans la requete liste, le graphe annuel et les tuiles du tableau de bord, afin que le suivi ne refletent que les modeles actifs et evolue quand on en ajoute/suspend/supprime.

Generated with Claude Code