### PR TITLE
refactor(fa): suivi FA recurrentes pilote en live par les factures modeles

### DIFF
--- a/lib/reedcrm_followup.lib.php
+++ b/lib/reedcrm_followup.lib.php
@@ -339,8 +339,8 @@ function reedcrmFollowupGetDashboardData(DoliDB $db, int $periodStart, int $peri
     $sql .= '   AND MONTH(f9.datef) = ' . $browsedMonth . ' AND YEAR(f9.datef) = ' . $browsedYear . ' ORDER BY f9.datef DESC' . $db->plimit(1) . ')';
     $sql .= ' LEFT JOIN ' . MAIN_DB_PREFIX . 'societe as s ON s.rowid = fr.fk_soc';
     $sql .= ' WHERE fr.entity IN (' . getEntity('facturerec') . ') AND fr.suspended = 0 AND fr.frequency > 0 AND fr.fk_soc > 0';
-    // Recurring calendar: match the billing month, regardless of the year.
-    $sql .= ' AND MONTH(fr.date_when) = ' . $browsedMonth;
+    // Reality for the browsed month+year: billed that month (fa) OR next generation falls that month+year.
+    $sql .= ' AND (fa.rowid IS NOT NULL OR (MONTH(fr.date_when) = ' . $browsedMonth . ' AND YEAR(fr.date_when) = ' . $browsedYear . '))';
     $sql .= ' ORDER BY fr.total_ttc DESC';
 
     $resql = $db->query($sql);

--- a/lib/reedcrm_followup.lib.php
+++ b/lib/reedcrm_followup.lib.php
@@ -332,8 +332,8 @@ function reedcrmFollowupGetDashboardData(DoliDB $db, int $periodStart, int $peri
     $sql .= ' LEFT JOIN ' . MAIN_DB_PREFIX . 'reedcrm_facturerec_followup as t ON t.fk_facture_rec = fr.rowid AND t.entity IN (' . getEntity('reedcrm_facturerec_followup') . ')';
     $sql .= ' LEFT JOIN ' . MAIN_DB_PREFIX . 'societe as s ON s.rowid = fr.fk_soc';
     $sql .= ' WHERE fr.entity IN (' . getEntity('facturerec') . ') AND fr.suspended = 0 AND fr.frequency > 0 AND fr.fk_soc > 0';
-    $sql .= " AND fr.date_when >= '" . $db->idate($periodStart) . "'";
-    $sql .= " AND fr.date_when <= '" . $db->idate($periodEnd) . "'";
+    // Recurring calendar: match the billing month, regardless of the year.
+    $sql .= ' AND MONTH(fr.date_when) = ' . ((int) dol_print_date($periodStart, '%m'));
     $sql .= ' ORDER BY fr.total_ttc DESC';
 
     $resql = $db->query($sql);

--- a/lib/reedcrm_followup.lib.php
+++ b/lib/reedcrm_followup.lib.php
@@ -325,15 +325,22 @@ function reedcrmFollowupGetDashboardData(DoliDB $db, int $periodStart, int $peri
 
     // Current month = active recurring templates (factures modèles) due this month, read live.
     // Manual annotations + billing sync come from the stored follow-up (t) when it exists.
+    $browsedMonth = (int) dol_print_date($periodStart, '%m');
+    $browsedYear  = (int) dol_print_date($periodStart, '%Y');
     $sql  = 'SELECT fr.rowid as frec_id, fr.titre as frec_titre, fr.fk_soc, fr.total_ttc as montant_ttc,';
     $sql .= ' t.prestation, t.montant_pr, t.temps_sav, t.facture_creee, t.facture_envoyee, t.facture_payee, t.paiement_ok, t.date_relance,';
+    $sql .= ' fa.datef as gen_date, fa.paye as gen_paye,';
     $sql .= ' s.nom as thirdparty_name';
     $sql .= ' FROM ' . MAIN_DB_PREFIX . 'facture_rec as fr';
     $sql .= ' LEFT JOIN ' . MAIN_DB_PREFIX . 'reedcrm_facturerec_followup as t ON t.fk_facture_rec = fr.rowid AND t.entity IN (' . getEntity('reedcrm_facturerec_followup') . ')';
+    // The invoice actually generated from this template in the browsed month+year (done or not).
+    $sql .= ' LEFT JOIN ' . MAIN_DB_PREFIX . 'facture as fa ON fa.rowid = (SELECT f9.rowid FROM ' . MAIN_DB_PREFIX . 'facture f9';
+    $sql .= '   WHERE f9.fk_fac_rec_source = fr.rowid AND f9.type <> 2 AND f9.entity IN (' . getEntity('facture') . ')';
+    $sql .= '   AND MONTH(f9.datef) = ' . $browsedMonth . ' AND YEAR(f9.datef) = ' . $browsedYear . ' ORDER BY f9.datef DESC' . $db->plimit(1) . ')';
     $sql .= ' LEFT JOIN ' . MAIN_DB_PREFIX . 'societe as s ON s.rowid = fr.fk_soc';
     $sql .= ' WHERE fr.entity IN (' . getEntity('facturerec') . ') AND fr.suspended = 0 AND fr.frequency > 0 AND fr.fk_soc > 0';
     // Recurring calendar: match the billing month, regardless of the year.
-    $sql .= ' AND MONTH(fr.date_when) = ' . ((int) dol_print_date($periodStart, '%m'));
+    $sql .= ' AND MONTH(fr.date_when) = ' . $browsedMonth;
     $sql .= ' ORDER BY fr.total_ttc DESC';
 
     $resql = $db->query($sql);
@@ -341,6 +348,11 @@ function reedcrmFollowupGetDashboardData(DoliDB $db, int $periodStart, int $peri
         while ($obj = $db->fetch_object($resql)) {
             $prestation = !empty($obj->prestation) ? $obj->prestation : reedcrmFollowupGuessPrestation((string) $obj->frec_titre);
             $tempsSav   = $obj->temps_sav !== null ? (int) $obj->temps_sav : reedcrmFollowupSavSecondsForPrestation($prestation);
+            // Billing status from the invoice really generated this month (done), else the annotation.
+            if (!empty($obj->gen_date)) {
+                $obj->facture_creee = 1;
+                $obj->facture_payee = (int) $obj->gen_paye;
+            }
             $code       = reedcrmFollowupStatusCode($obj, $now);
             $data['counts'][$code]++;
             $data['counts']['total']++;

--- a/lib/reedcrm_followup.lib.php
+++ b/lib/reedcrm_followup.lib.php
@@ -323,33 +323,37 @@ function reedcrmFollowupGetDashboardData(DoliDB $db, int $periodStart, int $peri
         'to_process'  => [],
     ];
 
-    // Current month follow-ups.
-    $sql  = 'SELECT t.rowid, t.ref, t.fk_soc, t.prestation, t.montant_ttc, t.montant_pr, t.temps_sav,';
-    $sql .= ' t.facture_creee, t.facture_envoyee, t.facture_payee, t.paiement_ok, t.date_relance, s.nom as thirdparty_name';
-    $sql .= ' FROM ' . MAIN_DB_PREFIX . 'reedcrm_facturerec_followup as t';
-    $sql .= ' LEFT JOIN ' . MAIN_DB_PREFIX . 'societe as s ON s.rowid = t.fk_soc';
-    $sql .= ' WHERE t.entity IN (' . getEntity('reedcrm_facturerec_followup') . ')';
-    $sql .= " AND t.status = 1";
-    $sql .= " AND t.period >= '" . $db->idate($periodStart) . "'";
-    $sql .= " AND t.period <= '" . $db->idate($periodEnd) . "'";
-    $sql .= ' ORDER BY t.montant_ttc DESC';
+    // Current month = active recurring templates (factures modèles) due this month, read live.
+    // Manual annotations + billing sync come from the stored follow-up (t) when it exists.
+    $sql  = 'SELECT fr.rowid as frec_id, fr.titre as frec_titre, fr.fk_soc, fr.total_ttc as montant_ttc,';
+    $sql .= ' t.prestation, t.montant_pr, t.temps_sav, t.facture_creee, t.facture_envoyee, t.facture_payee, t.paiement_ok, t.date_relance,';
+    $sql .= ' s.nom as thirdparty_name';
+    $sql .= ' FROM ' . MAIN_DB_PREFIX . 'facture_rec as fr';
+    $sql .= ' LEFT JOIN ' . MAIN_DB_PREFIX . 'reedcrm_facturerec_followup as t ON t.fk_facture_rec = fr.rowid AND t.entity IN (' . getEntity('reedcrm_facturerec_followup') . ')';
+    $sql .= ' LEFT JOIN ' . MAIN_DB_PREFIX . 'societe as s ON s.rowid = fr.fk_soc';
+    $sql .= ' WHERE fr.entity IN (' . getEntity('facturerec') . ') AND fr.suspended = 0 AND fr.frequency > 0 AND fr.fk_soc > 0';
+    $sql .= " AND fr.date_when >= '" . $db->idate($periodStart) . "'";
+    $sql .= " AND fr.date_when <= '" . $db->idate($periodEnd) . "'";
+    $sql .= ' ORDER BY fr.total_ttc DESC';
 
     $resql = $db->query($sql);
     if ($resql) {
         while ($obj = $db->fetch_object($resql)) {
-            $code = reedcrmFollowupStatusCode($obj, $now);
+            $prestation = !empty($obj->prestation) ? $obj->prestation : reedcrmFollowupGuessPrestation((string) $obj->frec_titre);
+            $tempsSav   = $obj->temps_sav !== null ? (int) $obj->temps_sav : reedcrmFollowupSavSecondsForPrestation($prestation);
+            $code       = reedcrmFollowupStatusCode($obj, $now);
             $data['counts'][$code]++;
             $data['counts']['total']++;
             $data['montant_ttc'] += (float) $obj->montant_ttc;
             $data['montant_pr']  += (float) $obj->montant_pr;
-            $data['temps_sav']   += (int) $obj->temps_sav;
+            $data['temps_sav']   += $tempsSav;
 
             if (in_array($code, ['tobill', 'tosend', 'late'])) {
                 $data['to_process'][] = [
-                    'id'          => (int) $obj->rowid,
-                    'ref'         => $obj->ref,
+                    'id'          => (int) $obj->frec_id,
+                    'ref'         => $obj->frec_titre,
                     'thirdparty'  => $obj->thirdparty_name,
-                    'prestation'  => $obj->prestation,
+                    'prestation'  => $prestation,
                     'montant_ttc' => (float) $obj->montant_ttc,
                     'code'        => $code,
                 ];
@@ -364,6 +368,7 @@ function reedcrmFollowupGetDashboardData(DoliDB $db, int $periodStart, int $peri
     $sqlDu  = 'SELECT t.rowid, t.ref, t.fk_soc, t.next_maj_du, s.nom as thirdparty_name';
     $sqlDu .= ' FROM ' . MAIN_DB_PREFIX . 'reedcrm_facturerec_followup as t';
     $sqlDu .= ' LEFT JOIN ' . MAIN_DB_PREFIX . 'societe as s ON s.rowid = t.fk_soc';
+    $sqlDu .= ' INNER JOIN ' . MAIN_DB_PREFIX . 'facture_rec as fr ON fr.rowid = t.fk_facture_rec AND fr.suspended = 0';
     $sqlDu .= ' WHERE t.entity IN (' . getEntity('reedcrm_facturerec_followup') . ')';
     $sqlDu .= ' AND t.status = 1 AND t.next_maj_du IS NOT NULL';
     $sqlDu .= " AND t.next_maj_du <= '" . $db->idate($windowEnd) . "'";

--- a/view/recurringinvoicefollowup_card.php
+++ b/view/recurringinvoicefollowup_card.php
@@ -36,6 +36,7 @@ require_once DOL_DOCUMENT_ROOT . '/core/lib/date.lib.php';
 
 // Load ReedCRM libraries.
 require_once __DIR__ . '/../class/recurringinvoicefollowup.class.php';
+require_once __DIR__ . '/../lib/reedcrm_followup.lib.php';
 
 global $conf, $db, $hookmanager, $langs, $moduleNameLowerCase, $user;
 
@@ -66,6 +67,30 @@ $object->fetch($id, $ref);
 // Load numbering module.
 $numberingModules = [$object->element => getDolGlobalString('REEDCRM_RECURRINGINVOICEFOLLOWUP_ADDON')];
 list($refReedcrmMod) = saturne_require_objects_mod($numberingModules, $moduleNameLowerCase);
+
+// Opened from a recurring template (frec): find its annotation follow-up, or create it on the fly
+// (the follow-up is now an annotation store keyed by the active recurring template).
+$frec = GETPOSTINT('frec');
+if ($id <= 0 && $ref === '' && $frec > 0) {
+    $resFrec = $db->query('SELECT rowid FROM ' . MAIN_DB_PREFIX . 'reedcrm_facturerec_followup WHERE fk_facture_rec = ' . $frec . ' AND entity IN (' . getEntity('reedcrm_facturerec_followup') . ') ' . $db->plimit(1));
+    if ($resFrec && $rowFrec = $db->fetch_object($resFrec)) {
+        $object->fetch((int) $rowFrec->rowid);
+    } else {
+        $resTpl = $db->query('SELECT fk_soc, titre, total_ttc, date_when FROM ' . MAIN_DB_PREFIX . 'facture_rec WHERE rowid = ' . $frec . ' AND entity IN (' . getEntity('facturerec') . ')');
+        if ($resTpl && $tpl = $db->fetch_object($resTpl)) {
+            $object->fk_soc         = (int) $tpl->fk_soc;
+            $object->fk_facture_rec = $frec;
+            $object->period         = !empty($tpl->date_when) ? $db->jdate($tpl->date_when) : dol_now();
+            $object->montant_ttc    = (float) $tpl->total_ttc;
+            $object->prestation     = reedcrmFollowupGuessPrestation((string) $tpl->titre);
+            $object->temps_sav      = reedcrmFollowupSavSecondsForPrestation($object->prestation);
+            $object->status         = $object::STATUS_ACTIVE;
+            if ($object->create($user) > 0) {
+                $id = $object->id;
+            }
+        }
+    }
+}
 
 // Security check.
 $permissiontoread   = $user->hasRight('reedcrm', 'followup', 'read');

--- a/view/recurringinvoicefollowup_list.php
+++ b/view/recurringinvoicefollowup_list.php
@@ -129,9 +129,15 @@ if (!in_array($sortfield, ['fr.date_when', 'fr.titre', 'fr.fk_soc', 'fr.total_tt
 }
 $sql  = 'SELECT fr.rowid as frec_id, fr.titre as frec_titre, fr.total_ttc as montant_ttc, fr.date_when as period, fr.fk_soc,';
 $sql .= ' t.rowid as followup_id, t.prestation, t.facture_creee, t.facture_envoyee, t.facture_payee, t.paiement_ok, t.date_relance, t.date_maj_du, t.next_maj_du, t.besoin,';
+$sql .= ' fa.rowid as gen_facture_id, fa.ref as gen_facture_ref, fa.datef as gen_date, fa.paye as gen_paye,';
 $sql .= ' s.nom as thirdparty_name';
 $sql .= ' FROM ' . MAIN_DB_PREFIX . 'facture_rec as fr';
 $sql .= ' LEFT JOIN ' . MAIN_DB_PREFIX . 'reedcrm_facturerec_followup as t ON t.fk_facture_rec = fr.rowid AND t.entity IN (' . getEntity('reedcrm_facturerec_followup') . ')';
+// The invoice actually generated from this template within the browsed month+year (if any) — to show
+// when it was really billed on past/current months.
+$sql .= ' LEFT JOIN ' . MAIN_DB_PREFIX . 'facture as fa ON fa.rowid = (SELECT f9.rowid FROM ' . MAIN_DB_PREFIX . 'facture f9';
+$sql .= '   WHERE f9.fk_fac_rec_source = fr.rowid AND f9.type <> 2 AND f9.entity IN (' . getEntity('facture') . ')';
+$sql .= '   AND MONTH(f9.datef) = ' . ((int) $monthMonth) . ' AND YEAR(f9.datef) = ' . ((int) $monthYear) . ' ORDER BY f9.datef DESC' . $db->plimit(1) . ')';
 $sql .= ' LEFT JOIN ' . MAIN_DB_PREFIX . 'societe as s ON s.rowid = fr.fk_soc';
 $sql .= ' WHERE fr.entity IN (' . getEntity('facturerec') . ') AND fr.suspended = 0 AND fr.frequency > 0 AND fr.fk_soc > 0';
 // Recurring calendar: a subscription bills in the same month every year, so filter on the month of
@@ -342,6 +348,12 @@ while ($i < min($num, $limit)) {
     // Fill missing (unseeded) annotation defaults so the object helpers work on live rows.
     if (empty($obj->prestation)) {
         $obj->prestation = reedcrmFollowupGuessPrestation((string) $obj->frec_titre);
+    }
+    // When the invoice for the browsed month was really generated, derive billing status from it.
+    $genTs = !empty($obj->gen_date) ? $db->jdate($obj->gen_date) : 0;
+    if ($genTs) {
+        $obj->facture_creee = 1;
+        $obj->facture_payee = (int) $obj->gen_paye;
     }
     $object->setVarsFromFetchObj($obj);
     $followupStatus = $object->getFollowupStatus();

--- a/view/recurringinvoicefollowup_list.php
+++ b/view/recurringinvoicefollowup_list.php
@@ -134,8 +134,9 @@ $sql .= ' FROM ' . MAIN_DB_PREFIX . 'facture_rec as fr';
 $sql .= ' LEFT JOIN ' . MAIN_DB_PREFIX . 'reedcrm_facturerec_followup as t ON t.fk_facture_rec = fr.rowid AND t.entity IN (' . getEntity('reedcrm_facturerec_followup') . ')';
 $sql .= ' LEFT JOIN ' . MAIN_DB_PREFIX . 'societe as s ON s.rowid = fr.fk_soc';
 $sql .= ' WHERE fr.entity IN (' . getEntity('facturerec') . ') AND fr.suspended = 0 AND fr.frequency > 0 AND fr.fk_soc > 0';
-$sql .= " AND ((fr.date_when >= '" . $db->idate($periodStart) . "' AND fr.date_when <= '" . $db->idate($periodEnd) . "')";
-$sql .= " OR (fr.date_when < '" . $db->idate($todayMonthStart) . "' AND (t.facture_payee IS NULL OR t.facture_payee = 0)))";
+// Recurring calendar: a subscription bills in the same month every year, so filter on the month of
+// its next generation date, regardless of the year (avoids the 12-month rolling-window gaps).
+$sql .= ' AND MONTH(fr.date_when) = ' . ((int) $monthMonth);
 if (dol_strlen($search_ref)) {
     $sql .= natural_search('fr.titre', $search_ref);
 }
@@ -223,8 +224,9 @@ print '</div>';
  */
 $chartYear = $monthYear;
 $faByMonth = array_fill(1, 12, 0.0);
+// Annual recurring calendar: amount per billing month across all active templates (same every year).
 $sqlChartFa  = 'SELECT MONTH(fr.date_when) as m, SUM(fr.total_ttc) as tot FROM ' . MAIN_DB_PREFIX . 'facture_rec as fr';
-$sqlChartFa .= ' WHERE fr.entity IN (' . getEntity('facturerec') . ') AND fr.suspended = 0 AND fr.frequency > 0 AND fr.fk_soc > 0 AND YEAR(fr.date_when) = ' . $chartYear . ' GROUP BY m';
+$sqlChartFa .= ' WHERE fr.entity IN (' . getEntity('facturerec') . ') AND fr.suspended = 0 AND fr.frequency > 0 AND fr.fk_soc > 0 GROUP BY m';
 $resChartFa  = $db->query($sqlChartFa);
 if ($resChartFa) {
     while ($o = $db->fetch_object($resChartFa)) {
@@ -233,7 +235,7 @@ if ($resChartFa) {
 }
 $monthLabels = ['Janv', 'Févr', 'Mars', 'Avr', 'Mai', 'Juin', 'Juil', 'Août', 'Sept', 'Oct', 'Nov', 'Déc'];
 
-print '<div class="rcf-chartbox"><div class="rcf-charttitle">' . $langs->trans('FollowupChartFaAmount') . ' — ' . $chartYear . '</div><div class="rcf-canvaswrap"><canvas id="rcfChartFa"></canvas></div></div>';
+print '<div class="rcf-chartbox"><div class="rcf-charttitle">' . $langs->trans('FollowupChartFaAmount') . '</div><div class="rcf-canvaswrap"><canvas id="rcfChartFa"></canvas></div></div>';
 print '<script src="' . DOL_URL_ROOT . '/includes/nnnick/chartjs/dist/chart.min.js"></script>';
 print '<script>
 (function() {

--- a/view/recurringinvoicefollowup_list.php
+++ b/view/recurringinvoicefollowup_list.php
@@ -235,7 +235,7 @@ if ($resChartFa) {
 }
 $monthLabels = ['Janv', 'Févr', 'Mars', 'Avr', 'Mai', 'Juin', 'Juil', 'Août', 'Sept', 'Oct', 'Nov', 'Déc'];
 
-print '<div class="rcf-chartbox"><div class="rcf-charttitle">' . $langs->trans('FollowupChartFaAmount') . '</div><div class="rcf-canvaswrap"><canvas id="rcfChartFa"></canvas></div></div>';
+print '<div class="rcf-chartbox"><div class="rcf-charttitle">' . $langs->trans('FollowupChartFaAmount') . ' — ' . $chartYear . '</div><div class="rcf-canvaswrap"><canvas id="rcfChartFa"></canvas></div></div>';
 print '<script src="' . DOL_URL_ROOT . '/includes/nnnick/chartjs/dist/chart.min.js"></script>';
 print '<script>
 (function() {
@@ -353,9 +353,10 @@ while ($i < min($num, $limit)) {
     print '<td class="tdoverflowmax150">' . dol_escape_htmltag($obj->thirdparty_name) . '</td>';
     print '<td>' . dol_escape_htmltag(isset($object->fields['prestation']['arrayofkeyval'][$obj->prestation]) ? $langs->trans($object->fields['prestation']['arrayofkeyval'][$obj->prestation]) : $obj->prestation) . '</td>';
     print '<td class="right">' . (dol_strlen($obj->montant_ttc) ? price($obj->montant_ttc, 0, $langs, 1, -1, -1, $conf->currency) : '') . '</td>';
+    // Show the real next-generation date (kept as-is: it may shift from one year to the next).
     $periodTs    = !empty($obj->period) ? $db->jdate($obj->period) : 0;
     $isFaOverdue = ($periodTs && $periodTs < $todayMonthStart && empty($obj->facture_payee));
-    print '<td class="center nowraponall">' . ($periodTs ? dol_print_date($periodTs, '%m/%Y') : '');
+    print '<td class="center nowraponall">' . ($periodTs ? dol_print_date($periodTs, 'day') : '');
     if ($isFaOverdue) {
         print ' <span style="color:#cf4257;font-weight:bold" title="' . dol_escape_htmltag($langs->trans('FollowupLate')) . '"><i class="fas fa-exclamation-triangle"></i> ' . ((int) floor((dol_now() - $periodTs) / 86400)) . $langs->trans('FollowupDaysLateShort') . '</span>';
     }

--- a/view/recurringinvoicefollowup_list.php
+++ b/view/recurringinvoicefollowup_list.php
@@ -140,9 +140,9 @@ $sql .= '   WHERE f9.fk_fac_rec_source = fr.rowid AND f9.type <> 2 AND f9.entity
 $sql .= '   AND MONTH(f9.datef) = ' . ((int) $monthMonth) . ' AND YEAR(f9.datef) = ' . ((int) $monthYear) . ' ORDER BY f9.datef DESC' . $db->plimit(1) . ')';
 $sql .= ' LEFT JOIN ' . MAIN_DB_PREFIX . 'societe as s ON s.rowid = fr.fk_soc';
 $sql .= ' WHERE fr.entity IN (' . getEntity('facturerec') . ') AND fr.suspended = 0 AND fr.frequency > 0 AND fr.fk_soc > 0';
-// Recurring calendar: a subscription bills in the same month every year, so filter on the month of
-// its next generation date, regardless of the year (avoids the 12-month rolling-window gaps).
-$sql .= ' AND MONTH(fr.date_when) = ' . ((int) $monthMonth);
+// Reality for the browsed month+year: subscriptions actually billed that month (fa) OR whose next
+// generation falls that month+year (upcoming). Avoids showing a subscription in a year it did not bill.
+$sql .= ' AND (fa.rowid IS NOT NULL OR (MONTH(fr.date_when) = ' . ((int) $monthMonth) . ' AND YEAR(fr.date_when) = ' . ((int) $monthYear) . '))';
 if (dol_strlen($search_ref)) {
     $sql .= natural_search('fr.titre', $search_ref);
 }

--- a/view/recurringinvoicefollowup_list.php
+++ b/view/recurringinvoicefollowup_list.php
@@ -365,12 +365,20 @@ while ($i < min($num, $limit)) {
     print '<td class="tdoverflowmax150">' . dol_escape_htmltag($obj->thirdparty_name) . '</td>';
     print '<td>' . dol_escape_htmltag(isset($object->fields['prestation']['arrayofkeyval'][$obj->prestation]) ? $langs->trans($object->fields['prestation']['arrayofkeyval'][$obj->prestation]) : $obj->prestation) . '</td>';
     print '<td class="right">' . (dol_strlen($obj->montant_ttc) ? price($obj->montant_ttc, 0, $langs, 1, -1, -1, $conf->currency) : '') . '</td>';
-    // Show the real next-generation date (kept as-is: it may shift from one year to the next).
-    $periodTs    = !empty($obj->period) ? $db->jdate($obj->period) : 0;
-    $isFaOverdue = ($periodTs && $periodTs < $todayMonthStart && empty($obj->facture_payee));
-    print '<td class="center nowraponall">' . ($periodTs ? dol_print_date($periodTs, 'day') : '');
+    // Date shown for the BROWSED year: real generation date if the invoice was billed that month
+    // (past), otherwise the next date projected onto the browsed year (same day/month every year).
+    $periodTs = !empty($obj->period) ? $db->jdate($obj->period) : 0;
+    if ($genTs) {
+        $displayTs = $genTs;
+    } elseif ($periodTs) {
+        $displayTs = dol_mktime(0, 0, 0, (int) $monthMonth, (int) dol_print_date($periodTs, '%d'), (int) $monthYear);
+    } else {
+        $displayTs = 0;
+    }
+    $isFaOverdue = (!$genTs && $displayTs && $displayTs < $todayMonthStart && empty($obj->facture_payee));
+    print '<td class="center nowraponall">' . ($displayTs ? dol_print_date($displayTs, 'day') : '');
     if ($isFaOverdue) {
-        print ' <span style="color:#cf4257;font-weight:bold" title="' . dol_escape_htmltag($langs->trans('FollowupLate')) . '"><i class="fas fa-exclamation-triangle"></i> ' . ((int) floor((dol_now() - $periodTs) / 86400)) . $langs->trans('FollowupDaysLateShort') . '</span>';
+        print ' <span style="color:#cf4257;font-weight:bold" title="' . dol_escape_htmltag($langs->trans('FollowupLate')) . '"><i class="fas fa-exclamation-triangle"></i> ' . ((int) floor((dol_now() - $displayTs) / 86400)) . $langs->trans('FollowupDaysLateShort') . '</span>';
     }
     print '</td>';
     print '<td class="center">' . yn($obj->facture_creee) . '</td>';

--- a/view/recurringinvoicefollowup_list.php
+++ b/view/recurringinvoicefollowup_list.php
@@ -74,7 +74,7 @@ $sortfield = GETPOST('sortfield', 'aZ09comma');
 $sortorder = GETPOST('sortorder', 'aZ09comma');
 $page      = GETPOSTISSET('pageplusone') ? (GETPOSTINT('pageplusone') - 1) : GETPOSTINT('page');
 if (empty($sortfield)) {
-    $sortfield = 't.period';
+    $sortfield = 'fr.date_when';
 }
 if (empty($sortorder)) {
     $sortorder = 'DESC';
@@ -122,21 +122,25 @@ if (GETPOST('button_removefilter_x', 'alpha') || GETPOST('button_removefilter.x'
  */
 $title = $langs->trans('RecurringInvoiceFollowupMenu');
 
-// Build the SQL request.
-$sql  = 'SELECT t.rowid, t.ref, t.status, t.fk_soc, t.fk_facture_rec, t.period, t.prestation, t.montant_ttc,';
-$sql .= ' t.facture_creee, t.facture_envoyee, t.facture_payee, t.paiement_ok, t.date_relance, t.date_maj_du, t.next_maj_du,';
-$sql .= ' t.besoin, s.nom as thirdparty_name, fr.titre as frec_titre';
-$sql .= ' FROM ' . MAIN_DB_PREFIX . 'reedcrm_facturerec_followup as t';
-$sql .= ' LEFT JOIN ' . MAIN_DB_PREFIX . 'societe as s ON s.rowid = t.fk_soc';
-$sql .= ' LEFT JOIN ' . MAIN_DB_PREFIX . 'facture_rec as fr ON fr.rowid = t.fk_facture_rec';
-$sql .= ' WHERE t.entity IN (' . getEntity('reedcrm_facturerec_followup') . ')';
-$sql .= " AND ((t.period >= '" . $db->idate($periodStart) . "' AND t.period <= '" . $db->idate($periodEnd) . "')";
-$sql .= " OR (t.period < '" . $db->idate($todayMonthStart) . "' AND t.facture_payee = 0 AND t.status = 1))";
+// Build the SQL request. Source = active recurring templates (factures modèles), read live so the
+// list is always up to date; the stored follow-up (t) only carries manual annotations + billing sync.
+if (!in_array($sortfield, ['fr.date_when', 'fr.titre', 'fr.fk_soc', 'fr.total_ttc', 't.prestation', 't.facture_creee', 't.facture_payee', 't.date_relance', 't.date_maj_du', 't.next_maj_du'], true)) {
+    $sortfield = 'fr.date_when';
+}
+$sql  = 'SELECT fr.rowid as frec_id, fr.titre as frec_titre, fr.total_ttc as montant_ttc, fr.date_when as period, fr.fk_soc,';
+$sql .= ' t.rowid as followup_id, t.prestation, t.facture_creee, t.facture_envoyee, t.facture_payee, t.paiement_ok, t.date_relance, t.date_maj_du, t.next_maj_du, t.besoin,';
+$sql .= ' s.nom as thirdparty_name';
+$sql .= ' FROM ' . MAIN_DB_PREFIX . 'facture_rec as fr';
+$sql .= ' LEFT JOIN ' . MAIN_DB_PREFIX . 'reedcrm_facturerec_followup as t ON t.fk_facture_rec = fr.rowid AND t.entity IN (' . getEntity('reedcrm_facturerec_followup') . ')';
+$sql .= ' LEFT JOIN ' . MAIN_DB_PREFIX . 'societe as s ON s.rowid = fr.fk_soc';
+$sql .= ' WHERE fr.entity IN (' . getEntity('facturerec') . ') AND fr.suspended = 0 AND fr.frequency > 0 AND fr.fk_soc > 0';
+$sql .= " AND ((fr.date_when >= '" . $db->idate($periodStart) . "' AND fr.date_when <= '" . $db->idate($periodEnd) . "')";
+$sql .= " OR (fr.date_when < '" . $db->idate($todayMonthStart) . "' AND (t.facture_payee IS NULL OR t.facture_payee = 0)))";
 if (dol_strlen($search_ref)) {
-    $sql .= natural_search('t.ref', $search_ref);
+    $sql .= natural_search('fr.titre', $search_ref);
 }
 if ($search_fk_soc > 0) {
-    $sql .= ' AND t.fk_soc = ' . ((int) $search_fk_soc);
+    $sql .= ' AND fr.fk_soc = ' . ((int) $search_fk_soc);
 }
 if (dol_strlen($search_prestation)) {
     $sql .= natural_search('t.prestation', $search_prestation);
@@ -219,8 +223,8 @@ print '</div>';
  */
 $chartYear = $monthYear;
 $faByMonth = array_fill(1, 12, 0.0);
-$sqlChartFa  = 'SELECT MONTH(period) as m, SUM(montant_ttc) as tot FROM ' . MAIN_DB_PREFIX . 'reedcrm_facturerec_followup';
-$sqlChartFa .= ' WHERE entity IN (' . getEntity('reedcrm_facturerec_followup') . ') AND status = 1 AND YEAR(period) = ' . $chartYear . ' GROUP BY m';
+$sqlChartFa  = 'SELECT MONTH(fr.date_when) as m, SUM(fr.total_ttc) as tot FROM ' . MAIN_DB_PREFIX . 'facture_rec as fr';
+$sqlChartFa .= ' WHERE fr.entity IN (' . getEntity('facturerec') . ') AND fr.suspended = 0 AND fr.frequency > 0 AND fr.fk_soc > 0 AND YEAR(fr.date_when) = ' . $chartYear . ' GROUP BY m';
 $resChartFa  = $db->query($sqlChartFa);
 if ($resChartFa) {
     while ($o = $db->fetch_object($resChartFa)) {
@@ -310,11 +314,11 @@ print '</tr>';
 
 // Title row.
 print '<tr class="liste_titre">';
-print getTitleFieldOfList($langs->trans('Ref'), 0, $_SERVER['PHP_SELF'], 't.ref', '', $param, '', $sortfield, $sortorder);
-print getTitleFieldOfList($langs->trans('ThirdParty'), 0, $_SERVER['PHP_SELF'], 't.fk_soc', '', $param, '', $sortfield, $sortorder);
+print getTitleFieldOfList($langs->trans('Ref'), 0, $_SERVER['PHP_SELF'], 'fr.titre', '', $param, '', $sortfield, $sortorder);
+print getTitleFieldOfList($langs->trans('ThirdParty'), 0, $_SERVER['PHP_SELF'], 'fr.fk_soc', '', $param, '', $sortfield, $sortorder);
 print getTitleFieldOfList($langs->trans('FollowupSubscription'), 0, $_SERVER['PHP_SELF'], 't.prestation', '', $param, '', $sortfield, $sortorder);
-print getTitleFieldOfList($langs->trans('FollowupAmountTTC'), 0, $_SERVER['PHP_SELF'], 't.montant_ttc', '', $param, 'class="right"', $sortfield, $sortorder);
-print getTitleFieldOfList($langs->trans('Period'), 0, $_SERVER['PHP_SELF'], 't.period', '', $param, 'class="center"', $sortfield, $sortorder);
+print getTitleFieldOfList($langs->trans('FollowupAmountTTC'), 0, $_SERVER['PHP_SELF'], 'fr.total_ttc', '', $param, 'class="right"', $sortfield, $sortorder);
+print getTitleFieldOfList($langs->trans('Period'), 0, $_SERVER['PHP_SELF'], 'fr.date_when', '', $param, 'class="center"', $sortfield, $sortorder);
 print getTitleFieldOfList($langs->trans('FollowupInvoiceCreated'), 0, $_SERVER['PHP_SELF'], 't.facture_creee', '', $param, 'class="center"', $sortfield, $sortorder);
 print getTitleFieldOfList($langs->trans('FollowupInvoicePaid'), 0, $_SERVER['PHP_SELF'], 't.facture_payee', '', $param, 'class="center"', $sortfield, $sortorder);
 print getTitleFieldOfList($langs->trans('FollowupRelanceDate'), 0, $_SERVER['PHP_SELF'], 't.date_relance', '', $param, 'class="center"', $sortfield, $sortorder);
@@ -333,17 +337,17 @@ while ($i < min($num, $limit)) {
     if (!$obj) {
         break;
     }
+    // Fill missing (unseeded) annotation defaults so the object helpers work on live rows.
+    if (empty($obj->prestation)) {
+        $obj->prestation = reedcrmFollowupGuessPrestation((string) $obj->frec_titre);
+    }
     $object->setVarsFromFetchObj($obj);
     $followupStatus = $object->getFollowupStatus();
     $totalTtc      += (float) $obj->montant_ttc;
-    $cardUrl        = $cardUrlBase . '?id=' . $obj->rowid;
+    $cardUrl        = $cardUrlBase . '?frec=' . ((int) $obj->frec_id);
 
     print '<tr class="oddeven">';
-    if (!empty($obj->fk_facture_rec) && dol_strlen($obj->frec_titre) > 0) {
-        print '<td class="tdoverflowmax200"><a href="' . DOL_URL_ROOT . '/compta/facture/card-rec.php?id=' . ((int) $obj->fk_facture_rec) . '" title="' . dol_escape_htmltag($obj->frec_titre) . '">' . img_object('', 'bill') . ' ' . dol_escape_htmltag($obj->frec_titre) . '</a></td>';
-    } else {
-        print '<td><a href="' . $cardUrl . '">' . dol_escape_htmltag($obj->ref) . '</a></td>';
-    }
+    print '<td class="tdoverflowmax200"><a href="' . DOL_URL_ROOT . '/compta/facture/card-rec.php?id=' . ((int) $obj->frec_id) . '" title="' . dol_escape_htmltag($obj->frec_titre) . '">' . img_object('', 'bill') . ' ' . dol_escape_htmltag($obj->frec_titre) . '</a></td>';
     print '<td class="tdoverflowmax150">' . dol_escape_htmltag($obj->thirdparty_name) . '</td>';
     print '<td>' . dol_escape_htmltag(isset($object->fields['prestation']['arrayofkeyval'][$obj->prestation]) ? $langs->trans($object->fields['prestation']['arrayofkeyval'][$obj->prestation]) : $obj->prestation) . '</td>';
     print '<td class="right">' . (dol_strlen($obj->montant_ttc) ? price($obj->montant_ttc, 0, $langs, 1, -1, -1, $conf->currency) : '') . '</td>';
@@ -361,9 +365,7 @@ while ($i < min($num, $limit)) {
     print '<td class="center">' . (!empty($obj->next_maj_du) ? dol_print_date($db->jdate($obj->next_maj_du), 'day') : '') . '</td>';
     print '<td class="center">' . dolGetStatus($followupStatus['label'], $followupStatus['label'], '', $followupStatus['badge'], 3) . '</td>';
     print '<td class="center nowraponall">';
-    if (!empty($obj->fk_facture_rec)) {
-        print '<a class="paddingright" href="' . DOL_URL_ROOT . '/compta/facture/card-rec.php?id=' . ((int) $obj->fk_facture_rec) . '" title="' . dol_escape_htmltag($langs->trans('FollowupGenerateInvoice')) . '"><i class="fas fa-file-invoice-dollar" style="color:#2f6f9f"></i></a>';
-    }
+    print '<a class="paddingright" href="' . DOL_URL_ROOT . '/compta/facture/card-rec.php?id=' . ((int) $obj->frec_id) . '" title="' . dol_escape_htmltag($langs->trans('FollowupGenerateInvoice')) . '"><i class="fas fa-file-invoice-dollar" style="color:#2f6f9f"></i></a>';
     print '<a class="editfielda" href="' . $cardUrl . '&action=edit&token=' . newToken() . '">' . img_edit() . '</a>';
     print '</td>';
     print '</tr>';


### PR DESCRIPTION
Le suivi des FA recurrentes lisait un objet stocke qui se desynchronisait de la realite (un modele desactive s'affichait quand meme, les nouveaux n'apparaissaient qu'apres le cron).

Desormais la liste, les tuiles et le graphe annuel sont pilotes **directement par les factures modeles actives** (facture_rec, suspended = 0), placees sur leur date de prochaine generation. L'objet suivi devient un simple **stockage d'annotations** (notes manuelles, suivi DU, synchro facturation) rattache au modele et joint en LEFT JOIN ; la fiche le trouve ou le cree a la volee (parametre frec).

Resultat : la vue est **toujours a jour** et evolue quand on ajoute/suspend/supprime un modele. Supersede la PR #834 (exclusion des desactives), incluse ici.

Generated with Claude Code