### PR TITLE
fix(fa): calendrier récurrent par année dans le tableau Suivi FA

### DIFF
--- a/lib/reedcrm_followup.lib.php
+++ b/lib/reedcrm_followup.lib.php
@@ -341,8 +341,8 @@ function reedcrmFollowupGetDashboardData(DoliDB $db, int $periodStart, int $peri
     $sql .= '   AND MONTH(f9.datef) = ' . $browsedMonth . ' AND YEAR(f9.datef) = ' . $browsedYear . ' ORDER BY f9.datef DESC' . $db->plimit(1) . ')';
     $sql .= ' LEFT JOIN ' . MAIN_DB_PREFIX . 'societe as s ON s.rowid = fr.fk_soc';
     $sql .= ' WHERE fr.entity IN (' . getEntity('facturerec') . ') AND fr.suspended = 0 AND fr.frequency > 0 AND fr.fk_soc > 0';
-    // Reality for the browsed month+year: billed that month (fa) OR next generation falls that month+year.
-    $sql .= ' AND (fa.rowid IS NOT NULL OR (MONTH(fr.date_when) = ' . $browsedMonth . ' AND YEAR(fr.date_when) = ' . $browsedYear . '))';
+    // Recurring calendar: match the billing month regardless of year (browsed year applies to display).
+    $sql .= ' AND MONTH(fr.date_when) = ' . $browsedMonth;
     $sql .= ' ORDER BY fr.total_ttc DESC';
 
     $resql = $db->query($sql);

--- a/view/recurringinvoicefollowup_list.php
+++ b/view/recurringinvoicefollowup_list.php
@@ -142,9 +142,10 @@ $sql .= '   WHERE f9.fk_fac_rec_source = fr.rowid AND f9.type <> 2 AND f9.entity
 $sql .= '   AND MONTH(f9.datef) = ' . ((int) $monthMonth) . ' AND YEAR(f9.datef) = ' . ((int) $monthYear) . ' ORDER BY f9.datef DESC' . $db->plimit(1) . ')';
 $sql .= ' LEFT JOIN ' . MAIN_DB_PREFIX . 'societe as s ON s.rowid = fr.fk_soc';
 $sql .= ' WHERE fr.entity IN (' . getEntity('facturerec') . ') AND fr.suspended = 0 AND fr.frequency > 0 AND fr.fk_soc > 0';
-// Reality for the browsed month+year: subscriptions actually billed that month (fa) OR whose next
-// generation falls that month+year (upcoming). Avoids showing a subscription in a year it did not bill.
-$sql .= ' AND (fa.rowid IS NOT NULL OR (MONTH(fr.date_when) = ' . ((int) $monthMonth) . ' AND YEAR(fr.date_when) = ' . ((int) $monthYear) . '))';
+// Recurring calendar: a subscription bills in the same month every year, so filter on the month of the
+// next generation date regardless of year. The browsed YEAR is applied to the displayed date, not here,
+// so July shows the same subscriptions whichever year is browsed — never an invoice from another year.
+$sql .= ' AND MONTH(fr.date_when) = ' . ((int) $monthMonth);
 if (dol_strlen($search_ref)) {
     $sql .= natural_search('fr.titre', $search_ref);
 }
@@ -367,8 +368,8 @@ while ($i < min($num, $limit)) {
     print '<td class="tdoverflowmax150">' . dol_escape_htmltag($obj->thirdparty_name) . '</td>';
     print '<td>' . dol_escape_htmltag(isset($object->fields['prestation']['arrayofkeyval'][$obj->prestation]) ? $langs->trans($object->fields['prestation']['arrayofkeyval'][$obj->prestation]) : $obj->prestation) . '</td>';
     print '<td class="right">' . (dol_strlen($obj->montant_ttc) ? price($obj->montant_ttc, 0, $langs, 1, -1, -1, $conf->currency) : '') . '</td>';
-    // Date shown for the BROWSED year: real generation date if the invoice was billed that month
-    // (past), otherwise the next date projected onto the browsed year (same day/month every year).
+    // Show the date in the BROWSED year: real generation date if billed that month+year, otherwise the
+    // recurring day/month projected onto the browsed year (never a date from another year).
     $periodTs = !empty($obj->period) ? $db->jdate($obj->period) : 0;
     if ($genTs) {
         $displayTs = $genTs;


### PR DESCRIPTION
Suite de #837 (déjà mergée). Corrige uniquement l'affichage du tableau **Suivi FA récurrentes** — 2 fichiers.

## Problème
Le tableau filtrait sur le mois **ET** l'année de `date_when`, ce qui : (a) vidait les années futures (un abonnement de juillet a sa prochaine génération cette année, donc juillet de l'an prochain était vide), et (b) pouvait afficher une date d'une autre année.

## Correctif
- Filtre sur le **mois de facturation uniquement** → chaque abonnement apparaît dans son mois, **quelle que soit l'année consultée**.
- **Date affichée projetée sur l'année consultée** → mai 2026 ne montre que des dates de mai 2026, mai 2027 que des dates de mai 2027. Jamais de date d'une autre année dans la vue.
- Le **graphique annuel** reste inchangé (calendrier des 12 mois).

Testé sur données Evarisk (lint OK). Aucune migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)