### PR TITLE
fix(fa): tableau Suivi FA identique au filtre natif Factures modeles

### DIFF
--- a/view/recurringinvoicefollowup_list.php
+++ b/view/recurringinvoicefollowup_list.php
@@ -316,8 +316,6 @@ print '<td class="liste_titre center"></td>';
 print '<td class="liste_titre center"></td>';
 print '<td class="liste_titre center"></td>';
 print '<td class="liste_titre center"></td>';
-print '<td class="liste_titre center"></td>';
-print '<td class="liste_titre center"></td>';
 print '<td class="liste_titre center maxwidthsearch">';
 print $form->showFilterButtons();
 print '</td>';
@@ -333,8 +331,6 @@ print getTitleFieldOfList($langs->trans('Period'), 0, $_SERVER['PHP_SELF'], 'fr.
 print getTitleFieldOfList($langs->trans('FollowupInvoiceCreated'), 0, $_SERVER['PHP_SELF'], 't.facture_creee', '', $param, 'class="center"', $sortfield, $sortorder);
 print getTitleFieldOfList($langs->trans('FollowupInvoicePaid'), 0, $_SERVER['PHP_SELF'], 't.facture_payee', '', $param, 'class="center"', $sortfield, $sortorder);
 print getTitleFieldOfList($langs->trans('FollowupRelanceDate'), 0, $_SERVER['PHP_SELF'], 't.date_relance', '', $param, 'class="center"', $sortfield, $sortorder);
-print getTitleFieldOfList($langs->trans('FollowupDuUpdateBilledDate'), 0, $_SERVER['PHP_SELF'], 't.date_maj_du', '', $param, 'class="center"', $sortfield, $sortorder);
-print getTitleFieldOfList($langs->trans('FollowupDuNextUpdate'), 0, $_SERVER['PHP_SELF'], 't.next_maj_du', '', $param, 'class="center"', $sortfield, $sortorder);
 print getTitleFieldOfList($langs->trans('Status'), 0, $_SERVER['PHP_SELF'], '', '', $param, 'class="center"', $sortfield, $sortorder);
 print getTitleFieldOfList('', 0, $_SERVER['PHP_SELF'], '', '', $param, 'class="center maxwidthsearch"', $sortfield, $sortorder);
 print '</tr>';
@@ -387,8 +383,6 @@ while ($i < min($num, $limit)) {
     print '<td class="center">' . yn($obj->facture_creee) . '</td>';
     print '<td class="center">' . yn($obj->facture_payee) . '</td>';
     print '<td class="center">' . (!empty($obj->date_relance) ? dol_print_date($db->jdate($obj->date_relance), 'day') : '') . '</td>';
-    print '<td class="center">' . (!empty($obj->date_maj_du) ? dol_print_date($db->jdate($obj->date_maj_du), 'day') : '') . '</td>';
-    print '<td class="center">' . (!empty($obj->next_maj_du) ? dol_print_date($db->jdate($obj->next_maj_du), 'day') : '') . '</td>';
     print '<td class="center">' . dolGetStatus($followupStatus['label'], $followupStatus['label'], '', $followupStatus['badge'], 3) . '</td>';
     print '<td class="center nowraponall">';
     print '<a class="paddingright" href="' . DOL_URL_ROOT . '/compta/facture/card-rec.php?id=' . ((int) $obj->frec_id) . '" title="' . dol_escape_htmltag($langs->trans('FollowupGenerateInvoice')) . '"><i class="fas fa-file-invoice-dollar" style="color:#2f6f9f"></i></a>';
@@ -403,7 +397,7 @@ if ($num > 0) {
     print '<td>' . $langs->trans('Total') . '</td>';
     print '<td></td><td></td>';
     print '<td class="right">' . price($totalTtc, 0, $langs, 1, -1, -1, $conf->currency) . '</td>';
-    print '<td colspan="8"></td>';
+    print '<td colspan="6"></td>';
     print '</tr>';
 }
 


### PR DESCRIPTION
Suite de #838 (déjà mergée). Corrige le tableau **Suivi FA récurrentes** pour qu'il colle **exactement** au filtre natif « Factures modèles ». 2 fichiers.

## Problèmes
1. Le tableau filtrait sur le **mois seul** et **projetait** la date sur l'année consultée. Résultat : un modèle déjà généré pour le mois (prochaine génération = année suivante) apparaissait quand même, avec une **fausse date** dans l'année consultée — alors que la carte du modèle montrait une autre année (ex. 2027). → juillet 2026 affichait 7-8 lignes au lieu des vraies (1 sur la prod).
2. Deux colonnes de dates (cycle DU) affichaient l'année suivante.

## Correctif
- Filtre strict sur la **vraie `date_when`** (mois **ET** année), **identique** au filtre « Date de prochaine génération » du natif → mêmes lignes que la liste native, sur n'importe quelle instance.
- **Date affichée = vraie `date_when`** (plus de projection) → correspond toujours à la carte du modèle.
- Colonnes de dates hors-année retirées ; tableau réaligné à 10 colonnes.

Aucune migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)