### PR TITLE
fix(fa): tableau Suivi FA identique au filtre natif Factures modeles

### DIFF
--- a/lib/reedcrm_followup.lib.php
+++ b/lib/reedcrm_followup.lib.php
@@ -341,8 +341,8 @@ function reedcrmFollowupGetDashboardData(DoliDB $db, int $periodStart, int $peri
     $sql .= '   AND MONTH(f9.datef) = ' . $browsedMonth . ' AND YEAR(f9.datef) = ' . $browsedYear . ' ORDER BY f9.datef DESC' . $db->plimit(1) . ')';
     $sql .= ' LEFT JOIN ' . MAIN_DB_PREFIX . 'societe as s ON s.rowid = fr.fk_soc';
     $sql .= ' WHERE fr.entity IN (' . getEntity('facturerec') . ') AND fr.suspended = 0 AND fr.frequency > 0 AND fr.fk_soc > 0';
-    // Recurring calendar: match the billing month regardless of year (browsed year applies to display).
-    $sql .= ' AND MONTH(fr.date_when) = ' . $browsedMonth;
+    // Like the native "Factures modèles" next-generation filter: next generation in the browsed month AND year.
+    $sql .= ' AND MONTH(fr.date_when) = ' . $browsedMonth . ' AND YEAR(fr.date_when) = ' . $browsedYear;
     $sql .= ' ORDER BY fr.total_ttc DESC';
 
     $resql = $db->query($sql);

--- a/view/recurringinvoicefollowup_list.php
+++ b/view/recurringinvoicefollowup_list.php
@@ -142,10 +142,10 @@ $sql .= '   WHERE f9.fk_fac_rec_source = fr.rowid AND f9.type <> 2 AND f9.entity
 $sql .= '   AND MONTH(f9.datef) = ' . ((int) $monthMonth) . ' AND YEAR(f9.datef) = ' . ((int) $monthYear) . ' ORDER BY f9.datef DESC' . $db->plimit(1) . ')';
 $sql .= ' LEFT JOIN ' . MAIN_DB_PREFIX . 'societe as s ON s.rowid = fr.fk_soc';
 $sql .= ' WHERE fr.entity IN (' . getEntity('facturerec') . ') AND fr.suspended = 0 AND fr.frequency > 0 AND fr.fk_soc > 0';
-// Recurring calendar: a subscription bills in the same month every year, so filter on the month of the
-// next generation date regardless of year. The browsed YEAR is applied to the displayed date, not here,
-// so July shows the same subscriptions whichever year is browsed — never an invoice from another year.
-$sql .= ' AND MONTH(fr.date_when) = ' . ((int) $monthMonth);
+// Exactly like the native "Factures modèles" next-generation filter: the template's real next
+// generation date (date_when) must fall in the browsed month AND year. No projection, so the date
+// shown always matches the template card.
+$sql .= ' AND MONTH(fr.date_when) = ' . ((int) $monthMonth) . ' AND YEAR(fr.date_when) = ' . ((int) $monthYear);
 if (dol_strlen($search_ref)) {
     $sql .= natural_search('fr.titre', $search_ref);
 }
@@ -364,16 +364,10 @@ while ($i < min($num, $limit)) {
     print '<td class="tdoverflowmax150">' . dol_escape_htmltag($obj->thirdparty_name) . '</td>';
     print '<td>' . dol_escape_htmltag(isset($object->fields['prestation']['arrayofkeyval'][$obj->prestation]) ? $langs->trans($object->fields['prestation']['arrayofkeyval'][$obj->prestation]) : $obj->prestation) . '</td>';
     print '<td class="right">' . (dol_strlen($obj->montant_ttc) ? price($obj->montant_ttc, 0, $langs, 1, -1, -1, $conf->currency) : '') . '</td>';
-    // Show the date in the BROWSED year: real generation date if billed that month+year, otherwise the
-    // recurring day/month projected onto the browsed year (never a date from another year).
-    $periodTs = !empty($obj->period) ? $db->jdate($obj->period) : 0;
-    if ($genTs) {
-        $displayTs = $genTs;
-    } elseif ($periodTs) {
-        $displayTs = dol_mktime(0, 0, 0, (int) $monthMonth, (int) dol_print_date($periodTs, '%d'), (int) $monthYear);
-    } else {
-        $displayTs = 0;
-    }
+    // The real next generation date (date_when), which the filter already places in the browsed
+    // month+year — so it always matches the template card. Fall back to the generated invoice date if any.
+    $periodTs  = !empty($obj->period) ? $db->jdate($obj->period) : 0;
+    $displayTs = $genTs ? $genTs : $periodTs;
     $isFaOverdue = (!$genTs && $displayTs && $displayTs < $todayMonthStart && empty($obj->facture_payee));
     print '<td class="center nowraponall">' . ($displayTs ? dol_print_date($displayTs, 'day') : '');
     if ($isFaOverdue) {


### PR DESCRIPTION
Corrige le tableau **Suivi FA récurrentes** pour qu'il colle **exactement** au filtre natif « Factures modèles ». 2 fichiers, aucune migration.

## Problème
Le tableau filtrait sur le **mois seul** et **projetait** la date sur l'année consultée. Un modèle déjà généré pour le mois (prochaine génération = année suivante, ex. 21/07/2027) apparaissait quand même en juillet 2026, avec une **fausse date** « 21/07/2026 » — alors que la carte du modèle affiche 21/07/2027. Résultat : 7-8 lignes affichées au lieu du vrai décompte natif.

## Correctif
- Filtre strict sur la **vraie `date_when`** (mois **ET** année) = **identique** au filtre « Date de prochaine génération » du natif → exactement les mêmes lignes que la liste native, sur n'importe quelle instance.
- **Date affichée = vraie `date_when`** (fin de la projection) → correspond toujours à la carte du modèle quand on clique.
- Tuiles (compteurs) alignées sur le même filtre.

Vérifié : sur une même instance, mon filtre `MONTH(date_when)=M AND YEAR(date_when)=Y` renvoie le même nombre que le natif `date_when BETWEEN 01 et 31 du mois`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)