### PR TITLE
#829 [CallList] fix: size the widget logo with width/height attributes

### DIFF
--- a/class/actions_reedcrm.class.php
+++ b/class/actions_reedcrm.class.php
@@ -3485,7 +3485,7 @@ EOT;
         $html .= ' data-element-id="' . (int) $elementId . '"';
         $html .= ' data-ajax-url="' . dol_escape_htmltag($ajaxUrl) . '"';
         $html .= ' data-default-ajax-url="' . dol_escape_htmltag($defaultAjaxUrl) . '">';
-        $html .= '<img src="' . dol_escape_htmltag($logoPath) . '" class="reedcrm-add-to-call-list-logo" alt="ReedCRM" />';
+        $html .= '<img src="' . dol_escape_htmltag($logoPath) . '" class="reedcrm-add-to-call-list-logo" width="18" height="18" alt="ReedCRM" />';
         $html .= '<i class="fas fa-phone" style="color:#64748b;"></i>';
         $html .= '<i class="fas fa-star reedcrm-call-list-default-btn" title="' . dol_escape_htmltag($langs->trans('AddToMyCallList')) . '"></i>';
         $html .= '<select class="reedcrm-call-list-select">';


### PR DESCRIPTION
## Contexte

Sur la fiche proposition, le logo ReedCRM du widget « ajouter à une liste d'appels » s'affiche en 256x256 (sa taille native) au lieu de 18x18.

C'est le seul bloc ReedCRM du bandeau dont le logo est dimensionné **uniquement** par une classe CSS (`.reedcrm-add-to-call-list-logo`, dans `css/scss/pages/_call-list.scss`) : tous les autres (contact, sévérité, assignation, temps) le font en style inline. Dès que la feuille `reedcrm.min.css` réellement appliquée ne contient pas la règle — cache navigateur périmé, le `<link>` étant injecté sans paramètre de version contrairement au `<script>` — l'image retombe sur sa taille native et casse la mise en page du widget.

## Changements

- Ajout des attributs `width="18"` / `height="18"` sur l'`<img>` du widget : le logo garde sa taille même si la feuille de style est absente ou périmée. La classe CSS continue de gouverner le rendu final (mêmes valeurs, `object-fit`, bordure de séparation).

## Fichiers modifiés

- `class/actions_reedcrm.class.php`

## Vérifications

- `php -l` OK (PHP 7.4 et 8.2).
- Rendu headless du markup du widget avec **et** sans `reedcrm.min.css` : logo à 18px dans les deux cas.

Close #829
