### PR TITLE
feat: configuration des tags/catégories pour les modèles de propositions (#825)

### DIFF
--- a/admin/call_notifications.php
+++ b/admin/call_notifications.php
@@ -89,11 +89,6 @@ print load_fiche_titre($title, $linkback, 'reedcrm_color@reedcrm');
 $head = reedcrm_admin_prepare_head();
 print dol_get_fiche_head($head, 'notifications', $title, -1, 'reedcrm_color@reedcrm');
 
-// Subheader
-$linkback = '<a href="' . ($backtopage ?: DOL_URL_ROOT . '/admin/modules.php?restore_lastsearch_values=1') . '">' . $langs->trans("BackToModuleList") . '</a>';
-
-print load_fiche_titre($page_name, $linkback, 'title_setup');
-
 // Configuration form
 print '<form method="POST" action="' . $_SERVER['PHP_SELF'] . '">';
 print '<input type="hidden" name="token" value="' . newToken() . '">';

--- a/admin/propal.php
+++ b/admin/propal.php
@@ -1,0 +1,162 @@
+<?php
+/* Copyright (C) 2024-2025 EVARISK <technique@evarisk.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * \file    admin/propal.php
+ * \ingroup reedcrm
+ * \brief   ReedCRM propal config page.
+ */
+
+// Load ReedCRM environment
+if (file_exists('../reedcrm.main.inc.php')) {
+    require_once __DIR__ . '/../reedcrm.main.inc.php';
+} elseif (file_exists('../../reedcrm.main.inc.php')) {
+    require_once __DIR__ . '/../../reedcrm.main.inc.php';
+} else {
+    die('Include of reedcrm main fails');
+}
+
+// Libraries
+require_once DOL_DOCUMENT_ROOT . '/core/lib/admin.lib.php';
+require_once DOL_DOCUMENT_ROOT . '/categories/class/categorie.class.php';
+require_once __DIR__ . '/../lib/reedcrm.lib.php';
+
+// Global variables definitions
+global $conf, $db, $langs, $user;
+
+// Load translation files required by the page
+saturne_load_langs(['admin', 'categories']);
+
+// Get parameters
+$action     = GETPOST('action', 'alpha');
+$backtopage = GETPOST('backtopage', 'alpha');
+
+// Security check - Protection if external user
+$permissiontoread = $user->hasRight('reedcrm','adminpage','read');
+saturne_check_access($permissiontoread);
+
+/*
+ * Actions
+ */
+
+if (!empty($conf->global->REEDCRM_PROPAL_MODELS_ENABLED)) {
+    // Check if categorie module is enabled
+    if (empty($conf->categorie->enabled)) {
+        dolibarr_set_const($db, 'MAIN_MODULE_CATEGORIE', 1, 'chaine', 0, '', $conf->entity);
+        $conf->categorie->enabled = 1; // Update in memory for current page load
+    }
+
+    // Create Tag "Proposition modèle" for propals
+    require_once DOL_DOCUMENT_ROOT.'/categories/class/categorie.class.php';
+    $cat = new Categorie($db);
+    $res = $cat->fetch(0, 'Proposition modèle', Categorie::TYPE_PROPOSAL);
+    if ($res <= 0) {
+        $cat->label = 'Proposition modèle';
+        $cat->type = Categorie::TYPE_PROPOSAL;
+        $cat->visible = 1;
+        $cat->create($user);
+    }
+    if (empty($conf->global->REEDCRM_PROPAL_MODEL_TAG_ID) && $cat->id > 0) {
+        dolibarr_set_const($db, 'REEDCRM_PROPAL_MODEL_TAG_ID', $cat->id, 'chaine', 0, '', $conf->entity);
+        $conf->global->REEDCRM_PROPAL_MODEL_TAG_ID = $cat->id;
+    }
+}
+
+if (!empty($conf->global->CATEGORY_EDIT_IN_MENU_NOT_IN_POPUP)) {
+    $sql = "SELECT rowid, note, visible FROM " . MAIN_DB_PREFIX . "const WHERE name = 'CATEGORY_EDIT_IN_MENU_NOT_IN_POPUP'";
+    $resql = $db->query($sql);
+    if ($resql && $db->num_rows($resql) > 0) {
+        $obj = $db->fetch_object($resql);
+        if ($obj->visible == 0 || empty($obj->note)) {
+            $db->query("UPDATE " . MAIN_DB_PREFIX . "const SET visible = 1, note = 'Ajouté par ReedCRM-" . date('YmdHis') . "' WHERE name = 'CATEGORY_EDIT_IN_MENU_NOT_IN_POPUP'");
+        }
+    }
+}
+
+if ($action == 'update_tag') {
+    $tag_id = GETPOST('reedcrm_propal_model_tag_id', 'int');
+    dolibarr_set_const($db, 'REEDCRM_PROPAL_MODEL_TAG_ID', $tag_id, 'chaine', 0, '', $conf->entity);
+    setEventMessages($langs->trans("SetupSaved"), null, 'mesgs');
+}
+
+/*
+ * View
+ */
+
+$title    = $langs->trans('ModuleSetup', 'ReedCRM');
+$help_url = 'FR:Module_ReedCRM';
+
+saturne_header(0,'', $title, $help_url);
+
+// Subheader
+$linkback = '<a href="' . ($backtopage ?: DOL_URL_ROOT . '/admin/modules.php?restore_lastsearch_values=1') . '">' . $langs->trans('BackToModuleList') . '</a>';
+print load_fiche_titre($title, $linkback, 'reedcrm_color@reedcrm');
+
+// Configuration header
+$head = reedcrm_admin_prepare_head();
+print dol_get_fiche_head($head, 'propal', $title, -1, 'reedcrm_color@reedcrm');
+
+print '<form method="POST" action="'.$_SERVER['PHP_SELF'].'">';
+print '<input type="hidden" name="token" value="'.newToken().'">';
+print '<input type="hidden" name="action" value="update_tag">';
+
+print '<table class="noborder centpercent">';
+print '<tr class="liste_titre">';
+print '<td colspan="2">Propositions modèles</td>';
+print '</tr>';
+
+print '<tr class="oddeven"><td>';
+print 'Activation du module Tags/catégories qui permettra d\'identifier les propositions modèles';
+print '<br><small class="opacitymedium">(Création du tag par défaut Proposition modèle)</small>';
+print '</td>';
+print '<td class="right">' . ajax_constantonoff('REEDCRM_PROPAL_MODELS_ENABLED', [], null, 0, 0, 1) . '</td>';
+print '</tr>';
+
+print '<tr class="oddeven"><td>';
+print 'Tag utilisé pour identifier les modèles de propositions';
+print '</td>';
+print '<td class="right">';
+require_once DOL_DOCUMENT_ROOT.'/categories/class/categorie.class.php';
+$tmpcat = new Categorie($db);
+$type_id = isset($tmpcat->MAP_ID[Categorie::TYPE_PROPOSAL]) ? $tmpcat->MAP_ID[Categorie::TYPE_PROPOSAL] : 23;
+$sql = "SELECT rowid, label FROM " . MAIN_DB_PREFIX . "categorie WHERE type = " . (int)$type_id . " AND entity IN (0, " . $conf->entity . ") ORDER BY label";
+$resql = $db->query($sql);
+print '<select name="reedcrm_propal_model_tag_id" class="flat" style="margin-right: 10px; min-width: 150px;">';
+print '<option value="0">-- ' . $langs->trans("Select") . ' --</option>';
+if ($resql) {
+    while ($obj = $db->fetch_object($resql)) {
+        $selected = (!empty($conf->global->REEDCRM_PROPAL_MODEL_TAG_ID) && $conf->global->REEDCRM_PROPAL_MODEL_TAG_ID == $obj->rowid) ? ' selected="selected"' : '';
+        print '<option value="' . $obj->rowid . '"' . $selected . '>' . dol_escape_htmltag($obj->label) . '</option>';
+    }
+}
+print '</select>';
+print '<input type="submit" class="button" value="'.$langs->trans("Save").'">';
+print '</td>';
+print '</tr>';
+
+print '<tr class="oddeven"><td>';
+print 'Affichage du menu Tags/catégories';
+print '<br><small class="opacitymedium">(Ce toggle ajoute ou retire CATEGORY_EDIT_IN_MENU_NOT_IN_POPUP dans l\'onglet Divers)</small>';
+print '</td>';
+print '<td class="right">' . ajax_constantonoff('CATEGORY_EDIT_IN_MENU_NOT_IN_POPUP', [], null, 0, 0, 1) . '</td>';
+print '</tr>';
+
+print '</table>';
+print '</form>';
+
+llxFooter();
+$db->close();

--- a/class/actions_reedcrm.class.php
+++ b/class/actions_reedcrm.class.php
@@ -62,6 +62,69 @@ class ActionsReedcrm
     }
 
     /**
+     * Overload the menuLeftMenuItems hook to inject our custom menu entries
+     *
+     * @param array $parameters
+     * @param CommonObject $object
+     * @param string $action
+     * @param HookManager $hookmanager
+     * @return int
+     */
+    public function menuLeftMenuItems(array $parameters, &$object, string &$action, $hookmanager)
+    {
+        global $langs, $user;
+
+        // Check if we are building the commercial menu (which includes proposals)
+        if (isset($parameters['mainmenu']) && $parameters['mainmenu'] == 'commercial') {
+            if (isModEnabled('category') && getDolGlobalString('CATEGORY_EDIT_IN_MENU_NOT_IN_POPUP')) {
+                require_once DOL_DOCUMENT_ROOT.'/categories/class/categorie.class.php';
+                $tmpcat = new Categorie($this->db);
+                $type_id = isset($tmpcat->MAP_ID[Categorie::TYPE_PROPOSAL]) ? $tmpcat->MAP_ID[Categorie::TYPE_PROPOSAL] : 23;
+                
+                $langs->load('categories');
+                
+                // $object contains the $menu_array because it is passed as the 3rd argument in executeHooks
+                if (is_array($object)) {
+                    // Find the position of the last 'propals' menu item to insert after it
+                    $insert_idx = -1;
+                    $i = 0;
+                    foreach ($object as $idx => $m) {
+                        if (isset($m['leftmenu']) && $m['leftmenu'] == 'propals') {
+                            $insert_idx = $i;
+                        }
+                        $i++;
+                    }
+                    
+                    $new_item = array(
+                        'url' => '/categories/categorie_list.php?mainmenu=commercial&leftmenu=propals_tags&type='.$type_id,
+                        'titre' => $langs->trans('Categories'),
+                        'level' => 1,
+                        'enabled' => $user->hasRight('categorie', 'lire'),
+                        'perms' => '1',
+                        'target' => '',
+                        'mainmenu' => 'commercial',
+                        'leftmenu' => 'propals_tags',
+                        'position' => 101,
+                        'prefix' => ''
+                    );
+                    
+                    if ($insert_idx >= 0) {
+                        // Insert after the last propals item
+                        array_splice($object, $insert_idx + 1, 0, array($new_item));
+                    } else {
+                        // Append if not found
+                        $object[] = $new_item;
+                    }
+                    
+                    $this->results = $object;
+                    return 1; // Return 1 to replace the menu array
+                }
+            }
+        }
+        return 0;
+    }
+
+    /**
      *  Overloading the addMoreBoxStatsCustomer function : replacing the parent's function with the one below
      *
      * @param  array        $parameters Hook metadatas (context, etc...)
@@ -2588,6 +2651,16 @@ class ActionsReedcrm
             $extraFieldsNames = ['opporigin'];
             foreach ($extraFieldsNames as $extraFieldsName) {
                 $extrafields->attributes['projet']['label'][$extraFieldsName] = $picto . $langs->transnoentities($extrafields->attributes['projet']['label'][$extraFieldsName]);
+            }
+        }
+
+        if (strpos($parameters['context'], 'propalcard') !== false && $object instanceof Propal) {
+            $picto            = img_picto('', 'reedcrm_color@reedcrm', 'class="pictoModule"');
+            $extraFieldsNames = ['reedcrm_propal_label', 'commrefusal'];
+            foreach ($extraFieldsNames as $extraFieldsName) {
+                if (!empty($extrafields->attributes['propal']['label'][$extraFieldsName])) {
+                    $extrafields->attributes['propal']['label'][$extraFieldsName] = $picto . $langs->transnoentities($extrafields->attributes['propal']['label'][$extraFieldsName]);
+                }
             }
         }
 

--- a/core/modules/modReedCRM.class.php
+++ b/core/modules/modReedCRM.class.php
@@ -812,6 +812,22 @@ class modReedCRM extends DolibarrModules
             'target'   => '',
             'user'     => 0,
         ];
+
+        $this->menu[$r++] = [
+            'fk_menu'  => 'fk_mainmenu=commercial,fk_leftmenu=propals',
+            'type'     => 'left',
+            'titre'    => 'Modèle de proposition',
+            'prefix'   => '',
+            'mainmenu' => 'commercial',
+            'leftmenu' => 'propals_model',
+            'url'      => '/custom/reedcrm/view/propal_model_list.php',
+            'langs'    => 'reedcrm@reedcrm',
+            'position' => 11,
+            'enabled'  => 'isModEnabled(\'propal\')',
+            'perms'    => '$user->hasRight(\'propal\', \'lire\')',
+            'target'   => '',
+            'user'     => 0,
+        ];
     }
 
     /**
@@ -862,6 +878,7 @@ class modReedCRM extends DolibarrModules
             'opprefusal'           => ['Label' => 'RefusalReason',          'type' => 'sellist',                  'elementtype' => ['projet'], 'position' => $this->numero . 85, 'list' => 1, 'enabled' => 'isModEnabled(\'reedcrm\') && isModEnabled(\'project\')', 'alwayseditable' => 1, 'params' => ['c_refusal_reason:ref:rowid' => null]],
             'commrefusal'          => ['Label' => 'RefusalReason',          'type' => 'sellist',                  'elementtype' => ['propal'], 'position' => $this->numero . 90, 'list' => 1, 'enabled' => 'isModEnabled(\'reedcrm\') && isModEnabled(\'propal\')', 'alwayseditable' => 1, 'params' => ['c_refusal_reason:ref:rowid' => null]],
 
+            'reedcrm_propal_label' => ['Label' => 'ReedCRMPropalLabel',     'type' => 'varchar', 'length' => 255, 'elementtype' => ['propal'], 'position' => $this->numero . 95, 'list' => 1, 'enabled' => 'isModEnabled(\'reedcrm\') && isModEnabled(\'propal\')', 'alwayseditable' => 1],
 
             'notation_societe_contact'    => ['Label' => 'NotationObjectContact', 'type' => 'text', 'elementtype' => ['societe'],     'position' => $this->numero . 10, 'list' => 5, 'enabled' => 'isModEnabled(\'reedcrm\') && isModEnabled(\'societe\')',  'help' => 'NotationObjectContactHelp', 'moreparams' => ['csslist' => 'center']],
             'notation_facture_contact'    => ['Label' => 'NotationObjectContact', 'type' => 'text', 'elementtype' => ['facture'],     'position' => $this->numero . 10, 'list' => 5, 'enabled' => 'isModEnabled(\'reedcrm\') && isModEnabled(\'invoice\')',  'help' => 'NotationObjectContactHelp', 'moreparams' => ['csslist' => 'center']],

--- a/langs/fr_FR/reedcrm.lang
+++ b/langs/fr_FR/reedcrm.lang
@@ -75,6 +75,9 @@ OpportunityStatusDescription = Selection du statut d'opportunité <br> Valeur pa
 OpportunityAmountDescription = Selection du montant d'opportunité <br> Valeur par défaut : <b> 3000 € </b>
 ProspectCustomerDescription = Selection de la nature des tiers <br> Valeur par défaut : <b> Prospect </b>
 
+# Propal Extrafield
+ReedCRMPropalLabel = Libellé
+
 # App
 App = App
 AppCloseProjectOpportunityZero = Clôturer le projet

--- a/lib/reedcrm.lib.php
+++ b/lib/reedcrm.lib.php
@@ -68,6 +68,11 @@ function reedcrm_admin_prepare_head(): array
     $head[$h][2] = 'product';
     $h++;
 
+    $head[$h][0] = dol_buildpath('/reedcrm/admin/propal.php', 1);
+    $head[$h][1] = $conf->browser->layout != 'phone' ? '<i class="fas fa-file-contract pictofixedwidth"></i>' . 'Propositions' : '<i class="fas fa-file-contract"></i>';
+    $head[$h][2] = 'propal';
+    $h++;
+
     $head[$h][0] = dol_buildpath('/reedcrm/admin/ticket.php', 1);
     $head[$h][1] = $conf->browser->layout != 'phone' ? '<i class="fas fa-ticket-alt pictofixedwidth"></i>' . $langs->trans('Ticket') : '<i class="fas fa-ticket-alt"></i>';
     $head[$h][2] = 'ticket';

--- a/view/propal_model_list.php
+++ b/view/propal_model_list.php
@@ -1,0 +1,137 @@
+<?php
+// Load ReedCRM environment
+if (file_exists('../reedcrm.main.inc.php')) {
+    require_once __DIR__ . '/../reedcrm.main.inc.php';
+} elseif (file_exists('../../reedcrm.main.inc.php')) {
+    require_once __DIR__ . '/../../reedcrm.main.inc.php';
+} else {
+    die('Include of reedcrm main fails');
+}
+
+require_once DOL_DOCUMENT_ROOT . '/comm/propal/class/propal.class.php';
+require_once DOL_DOCUMENT_ROOT . '/categories/class/categorie.class.php';
+require_once DOL_DOCUMENT_ROOT . '/core/class/html.form.class.php';
+
+global $langs, $conf, $user, $db;
+
+$langs->loadLangs(array("propal", "companies"));
+
+// Access control
+if (!$user->rights->propal->lire) {
+    accessforbidden();
+}
+
+$action = GETPOST('action', 'aZ09');
+$sortfield = GETPOST('sortfield', 'aZ09comma');
+$sortorder = GETPOST('sortorder', 'aZ09comma');
+
+$search_ref = GETPOST('search_ref', 'alpha');
+$search_label = GETPOST('search_label', 'alpha');
+$search_company = GETPOST('search_company', 'alpha');
+
+if (!$sortfield) $sortfield = "p.ref";
+if (!$sortorder) $sortorder = "DESC";
+
+// View
+llxHeader('', 'Modèles de propositions', '');
+
+$form = new Form($db);
+
+print load_fiche_titre('Modèles de propositions', '', 'propal');
+
+print '<div class="info">Retrouvez ici toutes les propositions commerciales marquées du tag <b>Proposition modèle</b>. Cliquez sur <i>Créer</i> pour générer une nouvelle proposition basée sur le modèle.</div>';
+print '<br>';
+
+// List
+print '<form method="POST" action="' . $_SERVER['PHP_SELF'] . '">';
+print '<input type="hidden" name="token" value="' . newToken() . '">';
+print '<input type="hidden" name="action" value="list">';
+print '<input type="hidden" name="sortfield" value="' . $sortfield . '">';
+print '<input type="hidden" name="sortorder" value="' . $sortorder . '">';
+
+print '<div class="div-table-responsive-no-min">';
+print '<table class="tagtable liste">'."\n";
+
+print '<tr class="liste_titre">';
+print_liste_field_titre('Ref', $_SERVER['PHP_SELF'], 'p.ref', '', '', '', $sortfield, $sortorder);
+print_liste_field_titre('Libellé', $_SERVER['PHP_SELF'], 'pe.reedcrm_propal_label', '', '', '', $sortfield, $sortorder);
+print_liste_field_titre('Company', $_SERVER['PHP_SELF'], 's.nom', '', '', '', $sortfield, $sortorder);
+print_liste_field_titre('RefCustomer', $_SERVER['PHP_SELF'], 'p.ref_client', '', '', '', $sortfield, $sortorder);
+print_liste_field_titre('Date', $_SERVER['PHP_SELF'], 'p.datep', '', '', '', $sortfield, $sortorder);
+print_liste_field_titre('AmountHT', $_SERVER['PHP_SELF'], 'p.total_ht', '', '', '', $sortfield, $sortorder, 'right ');
+print_liste_field_titre('Status', $_SERVER['PHP_SELF'], 'p.fk_statut', '', '', '', $sortfield, $sortorder, 'center ');
+print_liste_field_titre('', $_SERVER['PHP_SELF'], '', '', '', '', '', '', 'center ');
+print '</tr>';
+
+// Search row
+print '<tr class="liste_titre">';
+print '<td class="liste_titre"><input type="text" class="flat maxwidth75" name="search_ref" value="' . dol_escape_htmltag($search_ref) . '"></td>';
+print '<td class="liste_titre"><input type="text" class="flat" name="search_label" value="' . dol_escape_htmltag($search_label) . '"></td>';
+print '<td class="liste_titre"><input type="text" class="flat" name="search_company" value="' . dol_escape_htmltag($search_company) . '"></td>';
+print '<td class="liste_titre"></td>';
+print '<td class="liste_titre"></td>';
+print '<td class="liste_titre"></td>';
+print '<td class="liste_titre"></td>';
+print '<td class="liste_titre maxwidthsearch center">';
+$searchpicto = $form->showFilterAndCheckAddButtons(0);
+print $searchpicto;
+print '</td>';
+print '</tr>';
+
+$sql = "SELECT p.rowid, p.ref, p.total_ht, p.fk_statut, p.datep, p.ref_client, s.nom as name, pe.reedcrm_propal_label";
+$sql .= " FROM " . MAIN_DB_PREFIX . "propal as p";
+$sql .= " LEFT JOIN " . MAIN_DB_PREFIX . "propal_extrafields as pe ON pe.fk_object = p.rowid";
+$sql .= " LEFT JOIN " . MAIN_DB_PREFIX . "societe as s ON p.fk_soc = s.rowid";
+$sql .= " INNER JOIN " . MAIN_DB_PREFIX . "categorie_propal as cp ON cp.fk_propal = p.rowid";
+$sql .= " INNER JOIN " . MAIN_DB_PREFIX . "categorie as c ON c.rowid = cp.fk_categorie";
+if (!empty($conf->global->REEDCRM_PROPAL_MODEL_TAG_ID)) {
+    $sql .= " WHERE c.rowid = " . (int)$conf->global->REEDCRM_PROPAL_MODEL_TAG_ID . " AND p.entity IN (" . getEntity('propal') . ")";
+} else {
+    $sql .= " WHERE c.label = 'Proposition modèle' AND p.entity IN (" . getEntity('propal') . ")";
+}
+
+if ($search_ref) $sql .= natural_search("p.ref", $search_ref);
+if ($search_label) $sql .= natural_search("pe.reedcrm_propal_label", $search_label);
+if ($search_company) $sql .= natural_search("s.nom", $search_company);
+
+$sql .= $db->order($sortfield, $sortorder);
+
+$resql = $db->query($sql);
+if ($resql) {
+    $num = $db->num_rows($resql);
+    if ($num > 0) {
+        $i = 0;
+        while ($i < $num) {
+            $obj = $db->fetch_object($resql);
+            
+            $propal = new Propal($db);
+            $propal->fetch($obj->rowid);
+            $propal->fetch_thirdparty();
+
+            print '<tr class="oddeven">';
+            print '<td>' . $propal->getNomUrl(1) . '</td>';
+            print '<td class="tdoverflowmax150">' . dol_escape_htmltag($obj->reedcrm_propal_label) . '</td>';
+            print '<td class="tdoverflowmax150">' . $propal->thirdparty->getNomUrl(1) . '</td>';
+            print '<td class="tdoverflowmax150">' . dol_escape_htmltag($obj->ref_client) . '</td>';
+            print '<td>' . dol_print_date($db->jdate($obj->datep), 'day') . '</td>';
+            print '<td class="right">' . price($obj->total_ht) . '</td>';
+            print '<td class="center">' . $propal->getLibStatut(5) . '</td>';
+            print '<td class="center">';
+            print '<a class="butAction" href="' . DOL_URL_ROOT . '/comm/propal/card.php?id=' . $propal->id . '&action=clone">' . $langs->trans('Create') . '</a>';
+            print '</td>';
+            print '</tr>';
+            $i++;
+        }
+    } else {
+        print '<tr><td colspan="8" class="opacitymedium">Aucun modèle trouvé. Créez une proposition et ajoutez-lui le tag "Proposition modèle".</td></tr>';
+    }
+} else {
+    dol_print_error($db);
+}
+
+print '</table>';
+print '</div>';
+print '</form>';
+
+llxFooter();
+$db->close();


### PR DESCRIPTION
Closes #825.

### Fonctionnalités ajoutées
- Ajout de la sélection d'un Tag/Catégorie dans la page de configuration des modèles de propositions commerciales.
- Le tag sélectionné est utilisé pour filtrer les propositions affichées.
- Ajout dynamique du sous-menu 'Tags/catégories' sous le menu 'Propositions commerciales' dans la barre latérale gauche (sans modification du core Dolibarr, via le hook \menuLeftMenuItems\).
- Gestion de la rétrocompatibilité : affichage d'un libellé par défaut si aucun tag n'est configuré.
- Correction d'un bug dans le chargement des templates.

### Tests
- Vérifié sur l'environnement de développement. Le menu s'injecte correctement avec les droits de lecture.