### PR TITLE
#821 [QuickCreation] fix: honor PROJECT_CREATE_NO_DRAFT on project status

### DIFF
--- a/core/tpl/reedcrm_quickcreation_actions.tpl.php
+++ b/core/tpl/reedcrm_quickcreation_actions.tpl.php
@@ -102,7 +102,7 @@ if ($action == 'add') {
 			$project->opp_amount        = price2num(GETPOST('opp_amount'));
 			$project->date_c            = dol_now();
 			$project->date_start        = $date_start;
-			$project->statut            = 1;
+			$project->status            = getDolGlobalString('PROJECT_CREATE_NO_DRAFT') ? Project::STATUS_VALIDATED : Project::STATUS_DRAFT;
 			$project->usage_opportunity = 1;
 			$project->usage_task        = 1;
 


### PR DESCRIPTION
## Problème

L'ajout rapide affectait `$project->statut = 1`, or `statut` est la propriété **dépréciée** de `Project` (`project.class.php:210`). `Project::create()` et `Project::update()` lisent tous les deux `$this->status`. L'affectation était donc sans effet : `$this->status` restait `null`, le projet était toujours créé en **brouillon**, et la constante `PROJECT_CREATE_NO_DRAFT` n'était jamais consultée.

## Changements

- `$project->status` (bonne propriété) au lieu de `$project->statut` (dépréciée, ignorée par `create()`)
- Statut aligné sur le natif `projet/card.php:216` : `STATUS_VALIDATED` si `PROJECT_CREATE_NO_DRAFT` est actif, `STATUS_DRAFT` sinon

Aucune régression : sans la constante, le projet reste en brouillon comme aujourd'hui.

## Tests

Rejeu du chemin de code complet (création + le `update()` qui suit pour stocker `commtask`, lui aussi susceptible de réécrire `fk_statut`), vérification directe en base :

```
OK PROJECT_CREATE_NO_DRAFT=0 -> fk_statut en base = 0 (attendu 0)
OK PROJECT_CREATE_NO_DRAFT=1 -> fk_statut en base = 1 (attendu 1)
```

## Fichiers modifiés

- `core/tpl/reedcrm_quickcreation_actions.tpl.php`

## Issue

Close #821
